### PR TITLE
Refactor highway.js to factory function

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -2,7 +2,7 @@
  * Canvas-based Rocksmith highway renderer.
  * Receives note data via WebSocket, renders on requestAnimationFrame.
  */
-const highway = (() => {
+function createHighway() {
     let canvas, ctx, ws;
     let currentTime = 0;
     let animFrame = null;
@@ -1034,4 +1034,5 @@ const highway = (() => {
             document.getElementById('btn-play').textContent = '▶ Play';
         },
     };
-})();
+}
+const highway = createHighway();


### PR DESCRIPTION
## Summary

Converts `static/highway.js` from a singleton IIFE into a factory function (`createHighway()`) so multiple independent highway instances can coexist on one page. Each instance owns its own canvas, WebSocket, state, and render loop.

## Why

Unblocks plugins like Split Screen (2–4 highway panels showing different arrangements of the same song) and anything else that wants a second highway view without fighting the global singleton. Existing single-highway usage is unchanged — the default player creates one instance and uses it exactly as before.

## Scope

- `static/highway.js` only — 3 lines of diff wrapping the module in a factory.
- No server changes, no behavior change for existing users.

## Test plan

- [ ] Open any song, verify the single-highway player renders and plays normally
- [ ] With the Split Screen plugin installed, toggle split mode — multiple panels render independently with no state crosstalk