### PR TITLE
Add .sloppak open song format

### DIFF
--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -1,0 +1,295 @@
+"""Sloppak — open song format loader.
+
+A `.sloppak` is an open, hand-editable song package. It exists in two
+interchangeable forms:
+
+1. **Zip archive** — a `.sloppak` file containing a `manifest.yaml`,
+   arrangement JSONs, stem OGGs, optional cover/lyrics. Distribution form.
+2. **Directory** — a directory whose name ends in `.sloppak/` containing the
+   same files. Authoring form.
+
+See the format spec in the project's sloppak plan for the full layout.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from song import (
+    Song,
+    Beat,
+    Section,
+    arrangement_from_wire,
+)
+
+
+# ── Format detection ──────────────────────────────────────────────────────────
+
+def is_sloppak(path: Path) -> bool:
+    """True if path looks like a sloppak (zip file or directory)."""
+    return path.name.lower().endswith(".sloppak")
+
+
+# ── Source resolution (zip unpack cache + directory passthrough) ──────────────
+
+# Maps sloppak filename (relative to DLC_DIR) → (source_dir, mtime, size).
+# For directory-form sloppaks, source_dir is the original path and we only
+# track it so serving can locate it by filename.
+# For zipped sloppaks, source_dir is a cache dir under the unpack root.
+_source_cache: dict[str, tuple[Path, float, int]] = {}
+_source_lock = threading.Lock()
+
+
+def _unpack_zip(zip_path: Path, dest: Path) -> None:
+    """Extract a sloppak zip archive into dest, replacing any previous contents."""
+    if dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(str(zip_path), "r") as zf:
+        zf.extractall(str(dest))
+
+
+def _safe_id(filename: str) -> str:
+    """Turn a filename into a filesystem-safe cache key (no path separators)."""
+    return filename.replace("/", "__").replace("\\", "__").replace(" ", "_")
+
+
+def resolve_source_dir(
+    filename: str,
+    dlc_root: Path,
+    unpack_cache_root: Path,
+) -> Path:
+    """Return the on-disk directory containing a sloppak's files.
+
+    - Directory-form: returns the sloppak dir itself (no copy).
+    - Zip-form:       unpacks to ``unpack_cache_root/{id}/`` on first use,
+                      re-unpacks if mtime/size changed, then returns that dir.
+
+    Caches the resolution so subsequent calls are ~free.
+    """
+    path = dlc_root / filename
+    stat = path.stat()
+    mtime, size = stat.st_mtime, stat.st_size
+
+    with _source_lock:
+        cached = _source_cache.get(filename)
+        if cached:
+            cached_dir, cached_mtime, cached_size = cached
+            if (
+                cached_mtime == mtime
+                and cached_size == size
+                and cached_dir.exists()
+            ):
+                return cached_dir
+
+    if path.is_dir():
+        resolved = path
+    else:
+        # Zip form — unpack to the cache.
+        dest = unpack_cache_root / _safe_id(filename)
+        _unpack_zip(path, dest)
+        resolved = dest
+
+    with _source_lock:
+        _source_cache[filename] = (resolved, mtime, size)
+    return resolved
+
+
+def get_cached_source_dir(filename: str) -> Path | None:
+    """Return the cached source dir for a sloppak if one is known."""
+    with _source_lock:
+        cached = _source_cache.get(filename)
+        return cached[0] if cached else None
+
+
+# ── Manifest + song loading ───────────────────────────────────────────────────
+
+def _read_manifest(source_dir: Path) -> dict:
+    mf = source_dir / "manifest.yaml"
+    if not mf.exists():
+        mf = source_dir / "manifest.yml"
+    if not mf.exists():
+        raise FileNotFoundError(f"manifest.yaml not found in {source_dir}")
+    with mf.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError("manifest.yaml must contain a mapping at the top level")
+    return data
+
+
+def _read_manifest_from_zip(zip_path: Path) -> dict:
+    """Read just manifest.yaml from a zipped sloppak without unpacking stems."""
+    with zipfile.ZipFile(str(zip_path), "r") as zf:
+        for name in ("manifest.yaml", "manifest.yml"):
+            try:
+                with zf.open(name) as fh:
+                    data = yaml.safe_load(fh.read().decode("utf-8"))
+                    if isinstance(data, dict):
+                        return data
+            except KeyError:
+                continue
+    raise FileNotFoundError(f"manifest.yaml not found in zip {zip_path}")
+
+
+def load_manifest(path: Path) -> dict:
+    """Return the parsed manifest dict for a sloppak (dir or zip)."""
+    if path.is_dir():
+        return _read_manifest(path)
+    return _read_manifest_from_zip(path)
+
+
+@dataclass
+class LoadedSloppak:
+    """Result of loading a sloppak: the Song object plus stem descriptors."""
+    song: Song
+    stems: list[dict]           # [{"id": str, "file": str, "default": bool}]
+    source_dir: Path
+    manifest: dict
+
+
+def load_song(
+    filename: str,
+    dlc_root: Path,
+    unpack_cache_root: Path,
+) -> LoadedSloppak:
+    """Fully load a sloppak: resolve its source dir, parse manifest + all
+    arrangements + optional lyrics, and return a ready-to-stream Song."""
+    source_dir = resolve_source_dir(filename, dlc_root, unpack_cache_root)
+    manifest = _read_manifest(source_dir)
+
+    song = Song(
+        title=str(manifest.get("title", "")),
+        artist=str(manifest.get("artist", "")),
+        album=str(manifest.get("album", "")),
+        year=int(manifest.get("year", 0) or 0),
+        song_length=float(manifest.get("duration", 0.0) or 0.0),
+    )
+
+    # Load each arrangement from its JSON file.
+    for entry in manifest.get("arrangements", []) or []:
+        rel = entry.get("file")
+        if not rel:
+            continue
+        arr_path = source_dir / rel
+        if not arr_path.exists():
+            continue
+        try:
+            data = json.loads(arr_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        arr = arrangement_from_wire(data)
+        # Manifest-level overrides take precedence over anything embedded in
+        # the arrangement JSON (name, tuning, capo).
+        if entry.get("name"):
+            arr.name = str(entry["name"])
+        if "tuning" in entry:
+            arr.tuning = list(entry["tuning"])
+        if "capo" in entry:
+            arr.capo = int(entry["capo"])
+
+        # Beats/sections can live on the arrangement itself in the wire format.
+        # If the manifest-level arrangement JSON carries them, pull them onto
+        # the song object the first time we see them.
+        if not song.beats:
+            for b in data.get("beats", []) or []:
+                song.beats.append(
+                    Beat(time=float(b.get("time", 0)), measure=int(b.get("measure", -1)))
+                )
+        if not song.sections:
+            for s in data.get("sections", []) or []:
+                song.sections.append(
+                    Section(
+                        name=str(s.get("name", "")),
+                        number=int(s.get("number", 0)),
+                        start_time=float(s.get("time", s.get("start_time", 0))),
+                    )
+                )
+        song.arrangements.append(arr)
+
+    # Optional shared lyrics file.
+    lyrics_rel = manifest.get("lyrics")
+    if lyrics_rel:
+        lyr_path = source_dir / str(lyrics_rel)
+        if lyr_path.exists():
+            try:
+                song.lyrics = json.loads(lyr_path.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+
+    # Stem descriptors — normalized for callers. File paths are resolved but
+    # returned as ``file`` relative strings so URL construction stays caller-side.
+    stems: list[dict] = []
+    for s in manifest.get("stems", []) or []:
+        if not isinstance(s, dict):
+            continue
+        sid = str(s.get("id", ""))
+        sfile = str(s.get("file", ""))
+        if not sid or not sfile:
+            continue
+        default_val = s.get("default", True)
+        if isinstance(default_val, str):
+            default_on = default_val.lower() not in ("off", "false", "0", "no")
+        else:
+            default_on = bool(default_val)
+        stems.append({"id": sid, "file": sfile, "default": default_on})
+
+    return LoadedSloppak(song=song, stems=stems, source_dir=source_dir, manifest=manifest)
+
+
+# ── Fast metadata extractor (scanner path) ────────────────────────────────────
+
+def _tuning_for_meta(arrangements_manifest: list[dict]) -> list[int]:
+    """Best-effort guitar-first tuning for the library index."""
+    for entry in arrangements_manifest:
+        name = str(entry.get("name", "")).lower()
+        tun = entry.get("tuning")
+        if tun and isinstance(tun, list) and name in ("lead", "rhythm", "combo"):
+            return list(tun)
+    # Fallback: first arrangement with a tuning
+    for entry in arrangements_manifest:
+        tun = entry.get("tuning")
+        if tun and isinstance(tun, list):
+            return list(tun)
+    return [0] * 6
+
+
+def extract_meta(path: Path) -> dict:
+    """Fast metadata for the library scanner. Reads only the manifest."""
+    manifest = load_manifest(path)
+    arr_list = manifest.get("arrangements", []) or []
+
+    arrangements = []
+    for i, entry in enumerate(arr_list):
+        arrangements.append(
+            {
+                "index": i,
+                "name": str(entry.get("name", entry.get("id", f"Arr{i}"))),
+                "notes": 0,  # unknown without loading; fine for the index
+            }
+        )
+    # Sort like PSARC path: Lead > Combo > Rhythm > Bass
+    priority = {"Lead": 0, "Combo": 1, "Rhythm": 2, "Bass": 3}
+    arrangements.sort(key=lambda a: priority.get(a["name"], 99))
+    for i, a in enumerate(arrangements):
+        a["index"] = i
+
+    has_lyrics = bool(manifest.get("lyrics"))
+    tuning_offsets = _tuning_for_meta(arr_list)
+
+    return {
+        "title": str(manifest.get("title", "")),
+        "artist": str(manifest.get("artist", "")),
+        "album": str(manifest.get("album", "")),
+        "year": str(manifest.get("year", "") or ""),
+        "duration": float(manifest.get("duration", 0) or 0),
+        "tuning_offsets": tuning_offsets,  # caller maps to a name via _tuning_name
+        "arrangements": arrangements,
+        "has_lyrics": has_lyrics,
+    }

--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -283,6 +283,9 @@ def extract_meta(path: Path) -> dict:
     has_lyrics = bool(manifest.get("lyrics"))
     tuning_offsets = _tuning_for_meta(arr_list)
 
+    stems_list = manifest.get("stems", []) or []
+    stem_count = sum(1 for s in stems_list if isinstance(s, dict) and s.get("id"))
+
     return {
         "title": str(manifest.get("title", "")),
         "artist": str(manifest.get("artist", "")),
@@ -292,4 +295,5 @@ def extract_meta(path: Path) -> dict:
         "tuning_offsets": tuning_offsets,  # caller maps to a name via _tuning_name
         "arrangements": arrangements,
         "has_lyrics": has_lyrics,
+        "stem_count": stem_count,
     }

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -1,0 +1,383 @@
+"""PSARC → sloppak conversion + stem splitting.
+
+This module is the single source of truth for the convert + split pipelines.
+Both the CLI scripts (`scripts/psarc_to_sloppak.py`, `scripts/split_stems.py`)
+and the in-app converter plugin (`plugins/sloppak_converter`) import from
+here — see the plugin's `routes.py` for the job queue that wraps these
+functions with progress reporting.
+
+Each function accepts a `progress_cb(fraction: float, stage: str, message: str)`
+callback that the job queue forwards to the client over a WebSocket.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+from typing import Callable, Optional
+
+import yaml
+
+from patcher import unpack_psarc
+from song import load_song, arrangement_to_wire
+from audio import find_wem_files, _vgmstream_cmd, _ffmpeg_cmd
+
+
+ProgressCB = Optional[Callable[[float, str, str], None]]
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+def sanitize_stem(name: str) -> str:
+    """Filesystem-safe version of a filename stem."""
+    s = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("_")
+    return s or "song"
+
+
+def _progress(cb: ProgressCB, frac: float, stage: str, msg: str) -> None:
+    if cb:
+        try:
+            cb(frac, stage, msg)
+        except Exception:
+            pass
+
+
+def _arrangement_id(name: str, used: set[str]) -> str:
+    base = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "arr"
+    candidate = base
+    i = 2
+    while candidate in used:
+        candidate = f"{base}{i}"
+        i += 1
+    used.add(candidate)
+    return candidate
+
+
+def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
+    vgmstream = _vgmstream_cmd()
+    ffmpeg = _ffmpeg_cmd()
+    if not vgmstream:
+        raise RuntimeError("vgmstream-cli not found on PATH")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found on PATH")
+
+    with tempfile.TemporaryDirectory(prefix="s2p_wem_") as td:
+        wav = Path(td) / "full.wav"
+        r = subprocess.run([vgmstream, "-o", str(wav), wem_path], capture_output=True)
+        if r.returncode != 0 or not wav.exists() or wav.stat().st_size < 100:
+            raise RuntimeError(
+                f"vgmstream-cli failed: {r.stderr.decode(errors='replace')}"
+            )
+        out_ogg.parent.mkdir(parents=True, exist_ok=True)
+        r2 = subprocess.run(
+            [ffmpeg, "-y", "-i", str(wav), "-c:a", "libvorbis", "-q:a", "5", str(out_ogg)],
+            capture_output=True,
+        )
+        if r2.returncode != 0 or not out_ogg.exists() or out_ogg.stat().st_size < 100:
+            raise RuntimeError(
+                f"ffmpeg OGG encode failed: {r2.stderr.decode(errors='replace')}"
+            )
+
+
+def _parse_lyrics(extracted_dir: Path) -> list[dict]:
+    for xml_path in sorted(extracted_dir.rglob("*.xml")):
+        try:
+            root = ET.parse(xml_path).getroot()
+        except Exception:
+            continue
+        if root.tag != "vocals":
+            continue
+        return [
+            {
+                "t": round(float(v.get("time", "0")), 3),
+                "d": round(float(v.get("length", "0")), 3),
+                "w": v.get("lyric", ""),
+            }
+            for v in root.findall("vocal")
+        ]
+    return []
+
+
+def _extract_cover(extracted_dir: Path, out_jpg: Path) -> bool:
+    dds_files = sorted(
+        extracted_dir.rglob("*.dds"), key=lambda p: p.stat().st_size, reverse=True
+    )
+    if not dds_files:
+        return False
+    try:
+        from PIL import Image
+    except ImportError:
+        return False
+    try:
+        img = Image.open(dds_files[0]).convert("RGB")
+        out_jpg.parent.mkdir(parents=True, exist_ok=True)
+        img.save(str(out_jpg), "JPEG", quality=88)
+        return True
+    except Exception:
+        return False
+
+
+def _zip_dir(src_dir: Path, out_zip: Path) -> None:
+    out_zip.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(str(out_zip), "w", zipfile.ZIP_DEFLATED) as zf:
+        for f in src_dir.rglob("*"):
+            if f.is_file():
+                zf.write(f, f.relative_to(src_dir).as_posix())
+
+
+# ── PSARC → sloppak ───────────────────────────────────────────────────────────
+
+def convert_psarc_to_sloppak(
+    psarc_path: Path,
+    out_path: Path,
+    as_dir: bool = False,
+    progress_cb: ProgressCB = None,
+) -> Path:
+    """Convert a PSARC to a .sloppak (single-stem). Returns the output path."""
+    _progress(progress_cb, 0.02, "extracting", f"Unpacking {psarc_path.name}")
+    tmp_extract = Path(tempfile.mkdtemp(prefix="s2p_extract_"))
+    work_dir = Path(tempfile.mkdtemp(prefix="s2p_work_"))
+    try:
+        unpack_psarc(str(psarc_path), str(tmp_extract))
+
+        _progress(progress_cb, 0.15, "extracting", "Parsing song data")
+        song = load_song(str(tmp_extract))
+        if not song.arrangements:
+            raise RuntimeError("no playable arrangements found in PSARC")
+
+        used_ids: set[str] = set()
+        arr_manifest: list[dict] = []
+        first = True
+        for arr in song.arrangements:
+            aid = _arrangement_id(arr.name, used_ids)
+            wire = arrangement_to_wire(arr)
+            if first:
+                wire["beats"] = [
+                    {"time": round(b.time, 3), "measure": b.measure} for b in song.beats
+                ]
+                wire["sections"] = [
+                    {"name": s.name, "number": s.number, "time": round(s.start_time, 3)}
+                    for s in song.sections
+                ]
+                first = False
+            arr_file = work_dir / "arrangements" / f"{aid}.json"
+            arr_file.parent.mkdir(parents=True, exist_ok=True)
+            arr_file.write_text(json.dumps(wire, separators=(",", ":")), encoding="utf-8")
+            arr_manifest.append({
+                "id": aid,
+                "name": arr.name,
+                "file": f"arrangements/{aid}.json",
+                "tuning": list(arr.tuning),
+                "capo": arr.capo,
+            })
+
+        _progress(progress_cb, 0.35, "extracting", "Converting audio (WEM → OGG)")
+        wems = find_wem_files(str(tmp_extract))
+        if not wems:
+            raise RuntimeError("no WEM audio found in PSARC")
+        _wem_to_ogg(wems[0], work_dir / "stems" / "full.ogg")
+
+        stems_manifest = [{"id": "full", "file": "stems/full.ogg", "default": "on"}]
+
+        lyrics = _parse_lyrics(tmp_extract)
+        lyrics_rel = None
+        if lyrics:
+            (work_dir / "lyrics.json").write_text(
+                json.dumps(lyrics, separators=(",", ":")), encoding="utf-8"
+            )
+            lyrics_rel = "lyrics.json"
+
+        cover_rel = None
+        if _extract_cover(tmp_extract, work_dir / "cover.jpg"):
+            cover_rel = "cover.jpg"
+
+        manifest: dict = {
+            "title": song.title or psarc_path.stem,
+            "artist": song.artist or "",
+            "album": song.album or "",
+            "year": int(song.year or 0),
+            "duration": round(float(song.song_length or 0.0), 3),
+        }
+        if cover_rel:
+            manifest["cover"] = cover_rel
+        manifest["stems"] = stems_manifest
+        manifest["arrangements"] = arr_manifest
+        if lyrics_rel:
+            manifest["lyrics"] = lyrics_rel
+        (work_dir / "manifest.yaml").write_text(
+            yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+
+        _progress(progress_cb, 0.85, "packing", "Writing output")
+        if as_dir:
+            if out_path.exists():
+                shutil.rmtree(out_path)
+            shutil.copytree(work_dir, out_path)
+        else:
+            _zip_dir(work_dir, out_path)
+
+        _progress(progress_cb, 1.0, "done", f"Wrote {out_path.name}")
+        return out_path
+    finally:
+        shutil.rmtree(tmp_extract, ignore_errors=True)
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+# ── Stem splitting via Demucs ────────────────────────────────────────────────
+
+_STEM_ORDER = ["guitar", "bass", "drums", "vocals", "piano", "other"]
+
+
+def demucs_available() -> bool:
+    try:
+        import demucs  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+def _run_demucs(full_ogg: Path, out_dir: Path, model: str) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [sys.executable, "-m", "demucs", "-n", model, "-o", str(out_dir), str(full_ogg)]
+    # Point model-weight caches at the persistent config volume so we don't
+    # re-download on every container restart (~300MB per model).
+    env = os.environ.copy()
+    config_dir = env.get("CONFIG_DIR", "/config")
+    cache_root = Path(config_dir) / "torch_cache"
+    cache_root.mkdir(parents=True, exist_ok=True)
+    env.setdefault("TORCH_HOME", str(cache_root))
+    env.setdefault("XDG_CACHE_HOME", str(cache_root))
+    # Propagate in-process sys.path additions (plugin loader adds
+    # /config/pip_packages at runtime, not via PYTHONPATH) so the child
+    # python can also find demucs/torch/torchcodec.
+    pip_target = str(Path(config_dir) / "pip_packages")
+    extra_paths = [p for p in sys.path if p and p != ""]
+    merged = os.pathsep.join(
+        [pip_target] + [p for p in extra_paths if p != pip_target]
+        + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
+    )
+    env["PYTHONPATH"] = merged
+    r = subprocess.run(cmd, env=env, capture_output=True, text=True)
+    if r.returncode != 0:
+        err_tail = (r.stderr or "").strip().splitlines()[-5:]
+        raise RuntimeError(
+            f"demucs exited with code {r.returncode}: " + " | ".join(err_tail)
+        )
+    track_stem = full_ogg.stem
+    result_dir = out_dir / model / track_stem
+    if not result_dir.exists():
+        candidates = list((out_dir / model).iterdir()) if (out_dir / model).exists() else []
+        if len(candidates) == 1 and candidates[0].is_dir():
+            result_dir = candidates[0]
+        else:
+            raise RuntimeError(f"demucs output dir not found under {out_dir}/{model}")
+    return result_dir
+
+
+def _encode_ogg(wav_path: Path, ogg_path: Path) -> None:
+    ffmpeg = _ffmpeg_cmd() or "ffmpeg"
+    ogg_path.parent.mkdir(parents=True, exist_ok=True)
+    r = subprocess.run(
+        [ffmpeg, "-y", "-i", str(wav_path),
+         "-c:a", "libvorbis", "-q:a", "5", str(ogg_path)],
+        capture_output=True,
+    )
+    if r.returncode != 0 or not ogg_path.exists():
+        raise RuntimeError(
+            f"ffmpeg OGG encode failed for {wav_path.name}: "
+            f"{r.stderr.decode(errors='replace')}"
+        )
+
+
+def _rewrite_stems_manifest(source_dir: Path, new_stems: list[dict]) -> None:
+    mf = source_dir / "manifest.yaml"
+    if not mf.exists():
+        mf = source_dir / "manifest.yml"
+    data = yaml.safe_load(mf.read_text(encoding="utf-8")) or {}
+    data["stems"] = new_stems
+    mf.write_text(
+        yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _split_in_dir(
+    source_dir: Path,
+    model: str,
+    progress_cb: ProgressCB,
+    base_frac: float,
+    span_frac: float,
+) -> None:
+    full_ogg = source_dir / "stems" / "full.ogg"
+    if not full_ogg.exists():
+        raise FileNotFoundError(
+            f"{full_ogg} not found — run PSARC conversion first or add stems/full.ogg."
+        )
+
+    _progress(progress_cb, base_frac + span_frac * 0.05, "splitting",
+              f"Running Demucs ({model})")
+    with tempfile.TemporaryDirectory(prefix="s2p_split_") as td:
+        result_dir = _run_demucs(full_ogg, Path(td), model)
+
+        _progress(progress_cb, base_frac + span_frac * 0.85, "splitting",
+                  "Encoding split stems")
+        produced: list[dict] = []
+        stems_dir = source_dir / "stems"
+        for wav in sorted(result_dir.glob("*.wav")):
+            name = wav.stem.lower()
+            out_ogg = stems_dir / f"{name}.ogg"
+            _encode_ogg(wav, out_ogg)
+            produced.append({"id": name, "file": f"stems/{name}.ogg", "default": "on"})
+
+    if not produced:
+        raise RuntimeError("demucs produced no output stems")
+
+    def _order_key(s: dict) -> tuple[int, str]:
+        try:
+            return (_STEM_ORDER.index(s["id"]), s["id"])
+        except ValueError:
+            return (len(_STEM_ORDER), s["id"])
+    produced.sort(key=_order_key)
+
+    full_ogg.unlink(missing_ok=True)
+    _rewrite_stems_manifest(source_dir, produced)
+
+
+def split_sloppak_stems(
+    sloppak_path: Path,
+    model: str = "htdemucs_6s",
+    progress_cb: ProgressCB = None,
+    base_frac: float = 0.0,
+    span_frac: float = 1.0,
+) -> None:
+    """Split a sloppak's stems/full.ogg into per-instrument stems via Demucs."""
+    if sloppak_path.is_dir():
+        _split_in_dir(sloppak_path, model, progress_cb, base_frac, span_frac)
+        return
+
+    # Zip form: unpack, split, re-zip atomically.
+    with tempfile.TemporaryDirectory(prefix="s2p_split_zip_") as td:
+        work = Path(td) / "sloppak"
+        work.mkdir()
+        with zipfile.ZipFile(str(sloppak_path), "r") as zf:
+            zf.extractall(work)
+
+        _split_in_dir(work, model, progress_cb, base_frac, span_frac * 0.9)
+
+        _progress(progress_cb, base_frac + span_frac * 0.95, "packing",
+                  "Repacking sloppak")
+        tmp_out = sloppak_path.with_suffix(sloppak_path.suffix + ".tmp")
+        with zipfile.ZipFile(str(tmp_out), "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in work.rglob("*"):
+                if f.is_file():
+                    zf.write(f, f.relative_to(work).as_posix())
+        tmp_out.replace(sloppak_path)

--- a/lib/song.py
+++ b/lib/song.py
@@ -95,6 +95,122 @@ class Song:
     sections: list[Section] = field(default_factory=list)
     arrangements: list[Arrangement] = field(default_factory=list)
     audio_path: str = ""
+    # Optional lyrics, one entry per syllable: {"t": float, "d": float, "w": str}
+    lyrics: list[dict] = field(default_factory=list)
+
+
+# ── Wire format serialization (shared between highway_ws and sloppak loader) ──
+#
+# These helpers produce/consume the same JSON shape the highway WebSocket streams
+# to the client. They are the authoritative definition of the `.sloppak`
+# arrangement file format — see `arrangements/*.json` inside a sloppak.
+
+def note_to_wire(n: Note) -> dict:
+    return {
+        "t": round(n.time, 3), "s": n.string, "f": n.fret,
+        "sus": round(n.sustain, 3),
+        "sl": n.slide_to, "slu": n.slide_unpitch_to,
+        "bn": round(n.bend, 1) if n.bend else 0,
+        "ho": n.hammer_on, "po": n.pull_off,
+        "hm": n.harmonic, "hp": n.harmonic_pinch,
+        "pm": n.palm_mute, "mt": n.mute,
+        "tr": n.tremolo, "ac": n.accent, "tp": n.tap,
+    }
+
+
+def chord_note_to_wire(cn: Note) -> dict:
+    # Chord notes omit their own time (the chord carries it).
+    d = note_to_wire(cn)
+    d.pop("t", None)
+    return d
+
+
+def chord_to_wire(c: Chord) -> dict:
+    return {
+        "t": round(c.time, 3),
+        "id": c.chord_id,
+        "hd": c.high_density,
+        "notes": [chord_note_to_wire(cn) for cn in c.notes],
+    }
+
+
+def note_from_wire(d: dict, time: float | None = None) -> Note:
+    return Note(
+        time=float(d.get("t", time if time is not None else 0.0)),
+        string=int(d.get("s", 0)),
+        fret=int(d.get("f", 0)),
+        sustain=float(d.get("sus", 0.0)),
+        slide_to=int(d.get("sl", -1)),
+        slide_unpitch_to=int(d.get("slu", -1)),
+        bend=float(d.get("bn", 0.0)),
+        hammer_on=bool(d.get("ho", False)),
+        pull_off=bool(d.get("po", False)),
+        harmonic=bool(d.get("hm", False)),
+        harmonic_pinch=bool(d.get("hp", False)),
+        palm_mute=bool(d.get("pm", False)),
+        mute=bool(d.get("mt", False)),
+        tremolo=bool(d.get("tr", False)),
+        accent=bool(d.get("ac", False)),
+        tap=bool(d.get("tp", False)),
+    )
+
+
+def chord_from_wire(d: dict) -> Chord:
+    t = float(d.get("t", 0.0))
+    return Chord(
+        time=t,
+        chord_id=int(d.get("id", 0)),
+        high_density=bool(d.get("hd", False)),
+        notes=[note_from_wire(cn, time=t) for cn in d.get("notes", [])],
+    )
+
+
+def arrangement_to_wire(arr: Arrangement) -> dict:
+    """Serialize an Arrangement into a JSON-ready dict matching the wire format."""
+    return {
+        "name": arr.name,
+        "tuning": list(arr.tuning),
+        "capo": arr.capo,
+        "notes": [note_to_wire(n) for n in arr.notes],
+        "chords": [chord_to_wire(c) for c in arr.chords],
+        "anchors": [{"time": a.time, "fret": a.fret, "width": a.width} for a in arr.anchors],
+        "handshapes": [
+            {"chord_id": h.chord_id, "start_time": h.start_time, "end_time": h.end_time}
+            for h in arr.hand_shapes
+        ],
+        "templates": [
+            {"name": ct.name, "fingers": list(ct.fingers), "frets": list(ct.frets)}
+            for ct in arr.chord_templates
+        ],
+    }
+
+
+def arrangement_from_wire(d: dict) -> Arrangement:
+    """Parse a wire-format arrangement dict back into an Arrangement dataclass."""
+    return Arrangement(
+        name=d.get("name", ""),
+        tuning=list(d.get("tuning", [0] * 6)),
+        capo=int(d.get("capo", 0)),
+        notes=[note_from_wire(n) for n in d.get("notes", [])],
+        chords=[chord_from_wire(c) for c in d.get("chords", [])],
+        anchors=[
+            Anchor(time=float(a.get("time", 0)), fret=int(a.get("fret", 0)),
+                   width=int(a.get("width", 4)))
+            for a in d.get("anchors", [])
+        ],
+        hand_shapes=[
+            HandShape(chord_id=int(h.get("chord_id", 0)),
+                      start_time=float(h.get("start_time", 0)),
+                      end_time=float(h.get("end_time", 0)))
+            for h in d.get("handshapes", [])
+        ],
+        chord_templates=[
+            ChordTemplate(name=ct.get("name", ""),
+                          fingers=list(ct.get("fingers", [-1] * 6)),
+                          frets=list(ct.get("frets", [-1] * 6)))
+            for ct in d.get("templates", [])
+        ],
+    )
 
 
 def _float(elem, attr, default=0.0):

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -36,14 +36,14 @@ def _install_requirements(plugin_dir: Path, plugin_id: str):
     if marker.exists() and marker.read_text().strip() == req_hash:
         return True  # Already installed, same requirements
 
-    print(f"[Plugin] Installing requirements for '{plugin_id}'...")
+    print(f"[Plugin] Installing requirements for '{plugin_id}' (this can take a while for large deps)...")
     try:
         result = subprocess.run(
             [sys.executable, "-m", "pip", "install",
              "--target", pip_target,
              "--quiet",
              "-r", str(req_file)],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True, text=True, timeout=1800,
         )
         if result.returncode == 0:
             marker.write_text(req_hash)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ cloudscraper>=1.2.71
 curl_cffi>=0.7.0
 midiutil>=1.2.1
 Pillow>=10.0.0
+PyYAML>=6.0

--- a/scripts/psarc_to_sloppak.py
+++ b/scripts/psarc_to_sloppak.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Convert a Rocksmith PSARC into a `.sloppak` package.
+
+Usage:
+    python scripts/psarc_to_sloppak.py path/to/song.psarc [-o OUT] [--dir]
+
+Produces a single-stem sloppak (stems/full.ogg with default=on). Run
+`scripts/split_stems.py` afterwards to replace it with real stems.
+
+- Default output form is a zipped `.sloppak` file.
+- Pass `--dir` to emit the directory form instead (for hand-editing).
+- Pass `-o PATH` to override the default output location.
+
+Reuses the existing slopsmith library code — no format logic is duplicated:
+  * lib/patcher.py    — unpack_psarc
+  * lib/song.py       — load_song + arrangement_to_wire
+  * lib/audio.py      — WEM→WAV via vgmstream-cli (then WAV→OGG via ffmpeg)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+# Make `lib/` importable regardless of CWD.
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent
+sys.path.insert(0, str(_ROOT / "lib"))
+
+import yaml  # noqa: E402
+
+from patcher import unpack_psarc  # noqa: E402
+from song import load_song, arrangement_to_wire  # noqa: E402
+from audio import find_wem_files, _vgmstream_cmd, _ffmpeg_cmd  # noqa: E402
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _sanitize(name: str) -> str:
+    """Make a string filesystem-safe for use as a sloppak stem."""
+    s = re.sub(r"[^A-Za-z0-9._-]+", "_", name).strip("_")
+    return s or "song"
+
+
+def _arrangement_id(name: str, used: set[str]) -> str:
+    """Stable lowercase id for an arrangement, deduped within a song."""
+    base = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_") or "arr"
+    candidate = base
+    i = 2
+    while candidate in used:
+        candidate = f"{base}{i}"
+        i += 1
+    used.add(candidate)
+    return candidate
+
+
+def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
+    """Decode a WEM to OGG/Vorbis via vgmstream-cli → WAV → ffmpeg."""
+    vgmstream = _vgmstream_cmd()
+    ffmpeg = _ffmpeg_cmd()
+    if not vgmstream:
+        raise RuntimeError("vgmstream-cli not found on PATH (needed to decode WEM)")
+    if not ffmpeg:
+        raise RuntimeError("ffmpeg not found on PATH (needed to encode OGG)")
+
+    with tempfile.TemporaryDirectory(prefix="psarc2slop_") as td:
+        wav = Path(td) / "full.wav"
+        r = subprocess.run(
+            [vgmstream, "-o", str(wav), wem_path],
+            capture_output=True,
+        )
+        if r.returncode != 0 or not wav.exists() or wav.stat().st_size < 100:
+            raise RuntimeError(
+                f"vgmstream-cli failed for {wem_path}: {r.stderr.decode(errors='replace')}"
+            )
+
+        out_ogg.parent.mkdir(parents=True, exist_ok=True)
+        r2 = subprocess.run(
+            [ffmpeg, "-y", "-i", str(wav), "-c:a", "libvorbis", "-q:a", "5", str(out_ogg)],
+            capture_output=True,
+        )
+        if r2.returncode != 0 or not out_ogg.exists() or out_ogg.stat().st_size < 100:
+            raise RuntimeError(
+                f"ffmpeg OGG encode failed: {r2.stderr.decode(errors='replace')}"
+            )
+
+
+def _parse_lyrics(extracted_dir: Path) -> list[dict]:
+    """Return compact-wire lyric tokens from any vocals XML in the extract."""
+    for xml_path in sorted(extracted_dir.rglob("*.xml")):
+        try:
+            root = ET.parse(xml_path).getroot()
+        except Exception:
+            continue
+        if root.tag != "vocals":
+            continue
+        out: list[dict] = []
+        for v in root.findall("vocal"):
+            out.append({
+                "t": round(float(v.get("time", "0")), 3),
+                "d": round(float(v.get("length", "0")), 3),
+                "w": v.get("lyric", ""),
+            })
+        return out
+    return []
+
+
+def _extract_cover(extracted_dir: Path, out_jpg: Path) -> bool:
+    """Convert the largest DDS album art into out_jpg. Returns True on success."""
+    dds_files = sorted(
+        extracted_dir.rglob("*.dds"), key=lambda p: p.stat().st_size, reverse=True
+    )
+    if not dds_files:
+        return False
+    try:
+        from PIL import Image
+    except ImportError:
+        print("[warn] Pillow not installed — skipping cover art", file=sys.stderr)
+        return False
+    try:
+        img = Image.open(dds_files[0]).convert("RGB")
+        out_jpg.parent.mkdir(parents=True, exist_ok=True)
+        img.save(str(out_jpg), "JPEG", quality=88)
+        return True
+    except Exception as e:
+        print(f"[warn] cover art extraction failed: {e}", file=sys.stderr)
+        return False
+
+
+def _zip_dir(src_dir: Path, out_zip: Path) -> None:
+    """Write src_dir's contents into out_zip (flat at root, not nested)."""
+    out_zip.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(str(out_zip), "w", zipfile.ZIP_DEFLATED) as zf:
+        for f in src_dir.rglob("*"):
+            if f.is_file():
+                zf.write(f, f.relative_to(src_dir).as_posix())
+
+
+# ── Main conversion ──────────────────────────────────────────────────────────
+
+def convert(psarc_path: Path, out_path: Path, as_dir: bool) -> Path:
+    print(f"[*] Unpacking {psarc_path.name}")
+    tmp_extract = Path(tempfile.mkdtemp(prefix="psarc2slop_extract_"))
+    work_dir = Path(tempfile.mkdtemp(prefix="psarc2slop_work_"))
+    try:
+        unpack_psarc(str(psarc_path), str(tmp_extract))
+
+        print("[*] Parsing song data")
+        song = load_song(str(tmp_extract))
+        if not song.arrangements:
+            raise RuntimeError("no playable arrangements found in PSARC")
+
+        # Arrangements → JSON files.
+        used_ids: set[str] = set()
+        arr_manifest: list[dict] = []
+        first = True
+        for arr in song.arrangements:
+            aid = _arrangement_id(arr.name, used_ids)
+            wire = arrangement_to_wire(arr)
+            # Embed beats/sections on the first arrangement so sloppak.load_song
+            # picks them up onto the Song object.
+            if first:
+                wire["beats"] = [
+                    {"time": round(b.time, 3), "measure": b.measure} for b in song.beats
+                ]
+                wire["sections"] = [
+                    {"name": s.name, "number": s.number, "time": round(s.start_time, 3)}
+                    for s in song.sections
+                ]
+                first = False
+
+            arr_file = work_dir / "arrangements" / f"{aid}.json"
+            arr_file.parent.mkdir(parents=True, exist_ok=True)
+            arr_file.write_text(json.dumps(wire, separators=(",", ":")), encoding="utf-8")
+
+            arr_manifest.append({
+                "id": aid,
+                "name": arr.name,
+                "file": f"arrangements/{aid}.json",
+                "tuning": list(arr.tuning),
+                "capo": arr.capo,
+            })
+
+        # Audio: biggest WEM → stems/full.ogg.
+        print("[*] Converting audio (WEM → OGG)")
+        wems = find_wem_files(str(tmp_extract))
+        if not wems:
+            raise RuntimeError("no WEM audio found in PSARC")
+        _wem_to_ogg(wems[0], work_dir / "stems" / "full.ogg")
+
+        stems_manifest = [
+            {"id": "full", "file": "stems/full.ogg", "default": "on"},
+        ]
+
+        # Lyrics.
+        lyrics = _parse_lyrics(tmp_extract)
+        lyrics_rel = None
+        if lyrics:
+            print(f"[*] Writing {len(lyrics)} lyric tokens")
+            (work_dir / "lyrics.json").write_text(
+                json.dumps(lyrics, separators=(",", ":")), encoding="utf-8"
+            )
+            lyrics_rel = "lyrics.json"
+
+        # Cover art.
+        cover_rel = None
+        if _extract_cover(tmp_extract, work_dir / "cover.jpg"):
+            cover_rel = "cover.jpg"
+            print("[*] Extracted cover art")
+
+        # Manifest.
+        manifest: dict = {
+            "title": song.title or psarc_path.stem,
+            "artist": song.artist or "",
+            "album": song.album or "",
+            "year": int(song.year or 0),
+            "duration": round(float(song.song_length or 0.0), 3),
+        }
+        if cover_rel:
+            manifest["cover"] = cover_rel
+        manifest["stems"] = stems_manifest
+        manifest["arrangements"] = arr_manifest
+        if lyrics_rel:
+            manifest["lyrics"] = lyrics_rel
+
+        (work_dir / "manifest.yaml").write_text(
+            yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+
+        # Emit output.
+        if as_dir:
+            if out_path.exists():
+                shutil.rmtree(out_path)
+            shutil.copytree(work_dir, out_path)
+        else:
+            _zip_dir(work_dir, out_path)
+
+        return out_path
+    finally:
+        shutil.rmtree(tmp_extract, ignore_errors=True)
+        shutil.rmtree(work_dir, ignore_errors=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Convert a PSARC to a .sloppak")
+    ap.add_argument("psarc", type=Path, help="input .psarc file")
+    ap.add_argument("-o", "--output", type=Path, default=None,
+                    help="output path (default: alongside the PSARC)")
+    ap.add_argument("--dir", action="store_true",
+                    help="emit directory form instead of a zip")
+    args = ap.parse_args()
+
+    psarc = args.psarc
+    if not psarc.exists():
+        print(f"error: {psarc} does not exist", file=sys.stderr)
+        return 2
+
+    stem = _sanitize(psarc.stem.replace("_p", "").replace("_m", ""))
+    default_name = f"{stem}.sloppak"
+    out = args.output or (psarc.parent / default_name)
+    # If user passed a directory as -o, drop the file inside it.
+    if out.exists() and out.is_dir() and not args.dir:
+        out = out / default_name
+
+    try:
+        result = convert(psarc, out, as_dir=args.dir)
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    print(f"[✓] Wrote {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/split_stems.py
+++ b/scripts/split_stems.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Split a sloppak's full-mix stem into per-instrument stems via Demucs.
+
+Usage:
+    python scripts/split_stems.py path/to/song.sloppak [--model htdemucs_6s]
+
+Takes a sloppak whose only stem is `stems/full.ogg`, runs Demucs to split it
+into per-instrument stems, replaces `full.ogg` with the results, and rewrites
+`manifest.yaml`.
+
+Accepts both forms:
+- Directory-form sloppak: edited in place.
+- Zip-form sloppak:       unpacked to a temp dir, edited, re-zipped atomically.
+
+Requires `demucs` to be importable in the current interpreter:
+    pip install demucs
+
+Default model is `htdemucs_6s` which produces 6 stems:
+    vocals, drums, bass, guitar, piano, other
+Override with `--model htdemucs` (4 stems: vocals, drums, bass, other).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+import yaml
+
+
+# Demucs outputs WAVs named {stem}.wav in a per-track subfolder. We re-encode
+# them to OGG/Vorbis with ffmpeg to match the rest of the sloppak format.
+_STEM_ORDER = ["guitar", "bass", "drums", "vocals", "piano", "other"]
+
+
+def _run_demucs(full_ogg: Path, out_dir: Path, model: str) -> Path:
+    """Run demucs on full_ogg, return the directory containing the split stems."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable, "-m", "demucs",
+        "-n", model,
+        "-o", str(out_dir),
+        str(full_ogg),
+    ]
+    print(f"[*] Running: {' '.join(cmd)}")
+    r = subprocess.run(cmd)
+    if r.returncode != 0:
+        raise RuntimeError(f"demucs exited with code {r.returncode}")
+
+    # Demucs writes to {out_dir}/{model}/{track_stem}/*.wav
+    track_stem = full_ogg.stem
+    result_dir = out_dir / model / track_stem
+    if not result_dir.exists():
+        # Some demucs versions use the track stem with spaces replaced, etc.
+        candidates = list((out_dir / model).iterdir()) if (out_dir / model).exists() else []
+        if len(candidates) == 1 and candidates[0].is_dir():
+            result_dir = candidates[0]
+        else:
+            raise RuntimeError(f"demucs output dir not found under {out_dir}/{model}")
+    return result_dir
+
+
+def _encode_ogg(wav_path: Path, ogg_path: Path) -> None:
+    ogg_path.parent.mkdir(parents=True, exist_ok=True)
+    r = subprocess.run(
+        ["ffmpeg", "-y", "-i", str(wav_path),
+         "-c:a", "libvorbis", "-q:a", "5", str(ogg_path)],
+        capture_output=True,
+    )
+    if r.returncode != 0 or not ogg_path.exists():
+        raise RuntimeError(
+            f"ffmpeg OGG encode failed for {wav_path.name}: "
+            f"{r.stderr.decode(errors='replace')}"
+        )
+
+
+def _rewrite_manifest(source_dir: Path, new_stems: list[dict]) -> None:
+    mf = source_dir / "manifest.yaml"
+    if not mf.exists():
+        mf = source_dir / "manifest.yml"
+    if not mf.exists():
+        raise FileNotFoundError(f"manifest.yaml not found in {source_dir}")
+    data = yaml.safe_load(mf.read_text(encoding="utf-8")) or {}
+    data["stems"] = new_stems
+    mf.write_text(
+        yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _split_in_dir(source_dir: Path, model: str) -> None:
+    """Do the split-and-rewrite work inside an unpacked sloppak directory."""
+    full_ogg = source_dir / "stems" / "full.ogg"
+    if not full_ogg.exists():
+        raise FileNotFoundError(
+            f"{full_ogg} not found — nothing to split. "
+            f"Run psarc_to_sloppak.py first, or manually add stems/full.ogg."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="split_stems_") as td:
+        td_path = Path(td)
+        result_dir = _run_demucs(full_ogg, td_path, model)
+
+        print(f"[*] Encoding split stems to OGG")
+        produced: list[dict] = []
+        stems_dir = source_dir / "stems"
+        for wav in sorted(result_dir.glob("*.wav")):
+            name = wav.stem.lower()  # e.g. "guitar", "vocals"
+            out_ogg = stems_dir / f"{name}.ogg"
+            _encode_ogg(wav, out_ogg)
+            produced.append({
+                "id": name,
+                "file": f"stems/{name}.ogg",
+                "default": "on",
+            })
+
+    if not produced:
+        raise RuntimeError("demucs produced no output stems")
+
+    # Sort in a sensible mixer order, with unknown names at the end.
+    def _order_key(s: dict) -> tuple[int, str]:
+        try:
+            return (_STEM_ORDER.index(s["id"]), s["id"])
+        except ValueError:
+            return (len(_STEM_ORDER), s["id"])
+    produced.sort(key=_order_key)
+
+    # Remove the now-redundant full mix and update manifest.
+    full_ogg.unlink(missing_ok=True)
+    _rewrite_manifest(source_dir, produced)
+
+    print(f"[✓] {len(produced)} stems written to {source_dir / 'stems'}")
+    for s in produced:
+        print(f"    - {s['id']}")
+
+
+def split(sloppak_path: Path, model: str) -> None:
+    if sloppak_path.is_dir():
+        _split_in_dir(sloppak_path, model)
+        return
+
+    # Zip form: unpack, split, rezip in place (atomic via temp file).
+    print(f"[*] Unpacking {sloppak_path.name}")
+    with tempfile.TemporaryDirectory(prefix="split_stems_zip_") as td:
+        work = Path(td) / "sloppak"
+        work.mkdir()
+        with zipfile.ZipFile(str(sloppak_path), "r") as zf:
+            zf.extractall(work)
+
+        _split_in_dir(work, model)
+
+        print(f"[*] Repacking {sloppak_path.name}")
+        tmp_out = sloppak_path.with_suffix(sloppak_path.suffix + ".tmp")
+        with zipfile.ZipFile(str(tmp_out), "w", zipfile.ZIP_DEFLATED) as zf:
+            for f in work.rglob("*"):
+                if f.is_file():
+                    zf.write(f, f.relative_to(work).as_posix())
+        tmp_out.replace(sloppak_path)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Split a sloppak's full-mix into per-instrument stems via Demucs")
+    ap.add_argument("sloppak", type=Path, help="input .sloppak (file or directory)")
+    ap.add_argument("--model", default="htdemucs_6s",
+                    help="demucs model (default: htdemucs_6s = 6 stems inc. guitar + piano; "
+                         "htdemucs = 4 stems without guitar)")
+    args = ap.parse_args()
+
+    if not args.sloppak.exists():
+        print(f"error: {args.sloppak} does not exist", file=sys.stderr)
+        return 2
+
+    try:
+        import demucs  # noqa: F401
+    except ImportError:
+        print("error: demucs not installed. Run: pip install demucs", file=sys.stderr)
+        return 2
+
+    try:
+        split(args.sloppak, args.model)
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.py
+++ b/server.py
@@ -15,6 +15,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from psarc import unpack_psarc, read_psarc_entries
 from song import load_song, parse_arrangement
 from audio import find_wem_files, convert_wem
+import sloppak as sloppak_mod
 
 import concurrent.futures
 import sqlite3
@@ -57,9 +58,15 @@ class MetadataDB:
                 duration REAL,
                 tuning TEXT,
                 arrangements TEXT,
-                has_lyrics INTEGER DEFAULT 0
+                has_lyrics INTEGER DEFAULT 0,
+                format TEXT DEFAULT 'psarc'
             )
         """)
+        # Idempotent migration for installs that predate the format column.
+        try:
+            self.conn.execute("ALTER TABLE songs ADD COLUMN format TEXT DEFAULT 'psarc'")
+        except sqlite3.OperationalError:
+            pass
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_artist ON songs(artist COLLATE NOCASE)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_title ON songs(title COLLATE NOCASE)")
         self.conn.execute("CREATE TABLE IF NOT EXISTS favorites (filename TEXT PRIMARY KEY)")
@@ -96,7 +103,7 @@ class MetadataDB:
 
     def get(self, filename: str, mtime: float, size: int) -> dict | None:
         row = self.conn.execute(
-            "SELECT mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics "
+            "SELECT mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format "
             "FROM songs WHERE filename = ?", (filename,)
         ).fetchone()
         if row and row[0] == mtime and row[1] == size and row[2]:
@@ -105,6 +112,7 @@ class MetadataDB:
                 "year": row[5], "duration": row[6], "tuning": row[7],
                 "arrangements": json.loads(row[8]) if row[8] else [],
                 "has_lyrics": bool(row[9]),
+                "format": row[10] or "psarc",
             }
         return None
 
@@ -112,12 +120,13 @@ class MetadataDB:
         with self._lock:
             self.conn.execute(
                 "INSERT OR REPLACE INTO songs "
-                "(filename, mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "(filename, mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (filename, mtime, size, meta.get("title", ""), meta.get("artist", ""),
                  meta.get("album", ""), meta.get("year", ""), meta.get("duration", 0),
                  meta.get("tuning", ""), json.dumps(meta.get("arrangements", [])),
-                 1 if meta.get("has_lyrics") else 0),
+                 1 if meta.get("has_lyrics") else 0,
+                 meta.get("format", "psarc")),
             )
             self.conn.commit()
 
@@ -147,12 +156,16 @@ class MetadataDB:
 
     def query_page(self, q: str = "", page: int = 0, size: int = 24,
                    sort: str = "artist", direction: str = "asc",
-                   favorites_only: bool = False) -> tuple[list[dict], int]:
+                   favorites_only: bool = False,
+                   format_filter: str = "") -> tuple[list[dict], int]:
         """Server-side paginated search. Returns (songs, total_count)."""
         where = "WHERE title != ''"
         params = []
         if favorites_only:
             where += " AND filename IN (SELECT filename FROM favorites)"
+        if format_filter:
+            where += " AND format = ?"
+            params.append(format_filter)
         if q:
             where += " AND (title LIKE ? COLLATE NOCASE OR artist LIKE ? COLLATE NOCASE OR album LIKE ? COLLATE NOCASE)"
             params += [f"%{q}%"] * 3
@@ -168,7 +181,7 @@ class MetadataDB:
 
         total = self.conn.execute(f"SELECT COUNT(*) FROM songs {where}", params).fetchone()[0]
         rows = self.conn.execute(
-            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, mtime "
+            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, mtime, format "
             f"FROM songs {where} ORDER BY {order} LIMIT ? OFFSET ?",
             params + [size, page * size]
         ).fetchall()
@@ -182,18 +195,23 @@ class MetadataDB:
                 "year": r[4], "duration": r[5], "tuning": r[6],
                 "arrangements": json.loads(r[7]) if r[7] else [],
                 "has_lyrics": bool(r[8]), "mtime": r[9],
+                "format": r[10] or "psarc",
                 "has_estd": r[0] in estd, "favorite": r[0] in favs,
             })
         return songs, total
 
     def query_artists(self, letter: str = "", q: str = "",
                       favorites_only: bool = False,
-                      page: int = 0, size: int = 50) -> tuple[list[dict], int]:
+                      page: int = 0, size: int = 50,
+                      format_filter: str = "") -> tuple[list[dict], int]:
         """Get artists grouped by letter with their albums and songs. Returns (artists, total_artists)."""
         where = "WHERE title != ''"
         params = []
         if favorites_only:
             where += " AND filename IN (SELECT filename FROM favorites)"
+        if format_filter:
+            where += " AND format = ?"
+            params.append(format_filter)
         if letter == "#":
             where += " AND artist NOT GLOB '[A-Za-z]*'"
         elif letter:
@@ -223,7 +241,7 @@ class MetadataDB:
         song_params = params + artist_names
 
         rows = self.conn.execute(
-            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics "
+            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format "
             f"FROM songs {song_where} ORDER BY artist COLLATE NOCASE, album COLLATE NOCASE, title COLLATE NOCASE",
             song_params
         ).fetchall()
@@ -246,7 +264,9 @@ class MetadataDB:
                 "filename": r[0], "title": r[1], "artist": r[2], "album": r[3],
                 "year": r[4], "duration": r[5], "tuning": r[6],
                 "arrangements": json.loads(r[7]) if r[7] else [],
-                "has_lyrics": bool(r[8]), "has_estd": r[0] in estd,
+                "has_lyrics": bool(r[8]),
+                "format": r[9] or "psarc",
+                "has_estd": r[0] in estd,
                 "favorite": r[0] in favs,
             })
 
@@ -411,8 +431,19 @@ def _extract_meta_fast(psarc_path: Path) -> dict:
     }
 
 
+def _extract_meta_sloppak(path: Path) -> dict:
+    """Extract metadata for a sloppak (file or directory)."""
+    meta = sloppak_mod.extract_meta(path)
+    offsets = meta.pop("tuning_offsets", None) or [0] * 6
+    meta["tuning"] = _tuning_name(offsets)
+    meta["format"] = "sloppak"
+    return meta
+
+
 def _extract_meta_for_file(psarc_path: Path) -> dict:
-    """Extract metadata — try fast in-memory first, fall back to full extraction."""
+    """Extract metadata — dispatches on extension; PSARC path tries fast then falls back."""
+    if sloppak_mod.is_sloppak(psarc_path):
+        return _extract_meta_sloppak(psarc_path)
     try:
         meta = _extract_meta_fast(psarc_path)
         if meta["title"]:
@@ -465,7 +496,11 @@ def _background_scan():
     psarcs = [f for f in sorted(dlc.rglob("*.psarc"))
               if f.is_file()
               and "rs1compatibility" not in f.name.lower()]
-    current_files = {f.name for f in psarcs}
+    # Sloppaks: match both file (zip) and directory form by suffix.
+    sloppaks = [f for f in sorted(dlc.rglob("*.sloppak"))
+                if sloppak_mod.is_sloppak(f)]
+    all_songs = psarcs + sloppaks
+    current_files = {f.name for f in all_songs}
 
     # Clean up stale DB entries
     stale = meta_db.delete_missing(current_files)
@@ -474,7 +509,7 @@ def _background_scan():
 
     # Figure out which need scanning
     to_scan = []
-    for f in psarcs:
+    for f in all_songs:
         stat = f.stat()
         if not meta_db.get(f.name, stat.st_mtime, stat.st_size):
             to_scan.append((f, stat))
@@ -484,7 +519,7 @@ def _background_scan():
         return
 
     _scan_status = {"running": True, "total": len(to_scan), "done": 0, "current": ""}
-    print(f"Library: {len(psarcs)} PSARCs, {len(psarcs) - len(to_scan)} cached, {len(to_scan)} to scan")
+    print(f"Library: {len(psarcs)} PSARCs + {len(sloppaks)} sloppaks, {len(all_songs) - len(to_scan)} cached, {len(to_scan)} to scan")
 
     def _scan_one(item):
         f, stat = item
@@ -570,19 +605,23 @@ def trigger_full_rescan():
 
 @app.get("/api/library")
 def list_library(q: str = "", page: int = 0, size: int = 24, sort: str = "artist",
-                 dir: str = "asc", favorites: int = 0):
+                 dir: str = "asc", favorites: int = 0, format: str = ""):
     """Paginated library search, queried from SQLite."""
     size = min(size, 100)
+    fmt = format if format in ("psarc", "sloppak") else ""
     songs, total = meta_db.query_page(q=q, page=page, size=size, sort=sort,
-                                       direction=dir, favorites_only=bool(favorites))
+                                       direction=dir, favorites_only=bool(favorites),
+                                       format_filter=fmt)
     return {"songs": songs, "total": total, "page": page, "size": size}
 
 
 @app.get("/api/library/artists")
-def list_artists(letter: str = "", q: str = "", favorites: int = 0, page: int = 0, size: int = 50):
+def list_artists(letter: str = "", q: str = "", favorites: int = 0, page: int = 0, size: int = 50,
+                 format: str = ""):
     """Get artists grouped by letter with albums and songs (for tree view)."""
+    fmt = format if format in ("psarc", "sloppak") else ""
     artists, total = meta_db.query_artists(letter=letter, q=q, favorites_only=bool(favorites),
-                                           page=page, size=min(size, 100))
+                                           page=page, size=min(size, 100), format_filter=fmt)
     return {"artists": artists, "total_artists": total, "page": page, "size": size}
 
 
@@ -960,6 +999,41 @@ def _get_or_extract(filename, psarc_path):
     return tmp, song, True  # True = freshly extracted
 
 
+SLOPPAK_CACHE_DIR = STATIC_DIR / "sloppak_cache"
+
+
+@app.get("/api/sloppak/{filename:path}/file/{rel_path:path}")
+def serve_sloppak_file(filename: str, rel_path: str):
+    """Serve a file from inside a sloppak (stems, cover, etc.)."""
+    src = sloppak_mod.get_cached_source_dir(filename)
+    if src is None:
+        dlc = _get_dlc_dir()
+        if not dlc:
+            return JSONResponse({"error": "not configured"}, 404)
+        try:
+            src = sloppak_mod.resolve_source_dir(filename, dlc, SLOPPAK_CACHE_DIR)
+        except Exception:
+            return JSONResponse({"error": "not found"}, 404)
+    # Prevent path traversal.
+    target = (src / rel_path).resolve()
+    try:
+        target.relative_to(src.resolve())
+    except ValueError:
+        return JSONResponse({"error": "forbidden"}, 403)
+    if not target.exists() or not target.is_file():
+        return JSONResponse({"error": "not found"}, 404)
+    ext = target.suffix.lower()
+    mt = {
+        ".ogg": "audio/ogg", ".opus": "audio/ogg", ".oga": "audio/ogg",
+        ".mp3": "audio/mpeg", ".wav": "audio/wav", ".flac": "audio/flac",
+        ".m4a": "audio/mp4",
+        ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+        ".png": "image/png", ".webp": "image/webp",
+        ".json": "application/json",
+    }.get(ext)
+    return FileResponse(str(target), media_type=mt) if mt else FileResponse(str(target))
+
+
 @app.websocket("/ws/highway/{filename:path}")
 async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1):
     """Stream song data for the highway renderer over WebSocket."""
@@ -977,8 +1051,10 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
         await websocket.close()
         return
 
+    is_slop = sloppak_mod.is_sloppak(psarc_path)
     tmp = None
     owns_tmp = False
+    loaded_slop = None  # LoadedSloppak when is_slop
     _keepalive_active = True
 
     async def _send_keepalives():
@@ -996,7 +1072,17 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
 
         try:
             loop = asyncio.get_event_loop()
-            tmp, song, owns_tmp = await loop.run_in_executor(None, lambda: _get_or_extract(filename, psarc_path))
+            if is_slop:
+                SLOPPAK_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+                loaded_slop = await loop.run_in_executor(
+                    None,
+                    lambda: sloppak_mod.load_song(filename, dlc, SLOPPAK_CACHE_DIR),
+                )
+                song = loaded_slop.song
+                tmp = str(loaded_slop.source_dir)
+                owns_tmp = False
+            else:
+                tmp, song, owns_tmp = await loop.run_in_executor(None, lambda: _get_or_extract(filename, psarc_path))
         finally:
             _keepalive_active = False
             keepalive_task.cancel()
@@ -1037,19 +1123,33 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
 
         # Convert audio with unique filename (check cache first)
         audio_url = None
+        stems_payload: list[dict] = []
         audio_id = Path(filename).stem.replace(" ", "_")
-        AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        # Check if audio already cached
-        for ext in [".mp3", ".ogg", ".wav"]:
-            for cache_dir in [AUDIO_CACHE_DIR, STATIC_DIR]:
-                cached_audio = cache_dir / f"audio_{audio_id}{ext}"
-                if cached_audio.exists() and cached_audio.stat().st_size > 1000:
-                    audio_url = f"/audio/audio_{audio_id}{ext}"
-                    break
-            if audio_url:
-                break
 
-        if not audio_url:
+        if is_slop:
+            # Stems are served via the sloppak file endpoint; the first stem
+            # (or explicit default) is the core <audio> source. The stems
+            # plugin replaces it with a mixed graph when active.
+            from urllib.parse import quote
+            q_fn = quote(filename, safe="")
+            for s in loaded_slop.stems:
+                url = f"/api/sloppak/{q_fn}/file/{quote(s['file'])}"
+                stems_payload.append({"id": s["id"], "url": url, "default": s["default"]})
+            if stems_payload:
+                audio_url = stems_payload[0]["url"]
+        else:
+            AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            # Check if audio already cached (writable cache dir or legacy static dir)
+            for ext in [".mp3", ".ogg", ".wav"]:
+                for cache_dir in [AUDIO_CACHE_DIR, STATIC_DIR]:
+                    cached_audio = cache_dir / f"audio_{audio_id}{ext}"
+                    if cached_audio.exists() and cached_audio.stat().st_size > 1000:
+                        audio_url = f"/audio/audio_{audio_id}{ext}"
+                        break
+                if audio_url:
+                    break
+
+        if not audio_url and not is_slop:
             await websocket.send_json({"type": "loading", "stage": "Converting audio..."})
             wem_files = find_wem_files(tmp)
             if wem_files:
@@ -1089,6 +1189,8 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
             "audio_url": audio_url,
             "tuning": arr.tuning,
             "capo": arr.capo,
+            "format": "sloppak" if is_slop else "psarc",
+            "stems": stems_payload,
         })
 
         # Send beats
@@ -1112,25 +1214,32 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
         # Send lyrics if available
         import xml.etree.ElementTree as ET
         lyrics = []
-        for xml_path in sorted(Path(tmp).rglob("*.xml")):
-            try:
-                root = ET.parse(xml_path).getroot()
-                if root.tag == "vocals":
-                    for v in root.findall("vocal"):
-                        lyrics.append({
-                            "t": round(float(v.get("time", "0")), 3),
-                            "d": round(float(v.get("length", "0")), 3),
-                            "w": v.get("lyric", ""),
-                        })
-                    break
-            except Exception:
-                pass
+        if is_slop:
+            lyrics = list(song.lyrics or [])
+        else:
+            for xml_path in sorted(Path(tmp).rglob("*.xml")):
+                try:
+                    root = ET.parse(xml_path).getroot()
+                    if root.tag == "vocals":
+                        for v in root.findall("vocal"):
+                            lyrics.append({
+                                "t": round(float(v.get("time", "0")), 3),
+                                "d": round(float(v.get("length", "0")), 3),
+                                "w": v.get("lyric", ""),
+                            })
+                        break
+                except Exception:
+                    pass
         if lyrics:
             await websocket.send_json({"type": "lyrics", "data": lyrics})
 
-        # Send tone changes
+        # Send tone changes (PSARC only; sloppak has no tone XML)
         tone_changes = []
-        for xml_path in sorted(Path(tmp).rglob("*.xml")):
+        if is_slop:
+            xml_paths = []
+        else:
+            xml_paths = sorted(Path(tmp).rglob("*.xml"))
+        for xml_path in xml_paths:
             try:
                 root = ET.parse(xml_path).getroot()
                 if root.tag != "song":

--- a/server.py
+++ b/server.py
@@ -59,12 +59,17 @@ class MetadataDB:
                 tuning TEXT,
                 arrangements TEXT,
                 has_lyrics INTEGER DEFAULT 0,
-                format TEXT DEFAULT 'psarc'
+                format TEXT DEFAULT 'psarc',
+                stem_count INTEGER DEFAULT 0
             )
         """)
         # Idempotent migration for installs that predate the format column.
         try:
             self.conn.execute("ALTER TABLE songs ADD COLUMN format TEXT DEFAULT 'psarc'")
+        except sqlite3.OperationalError:
+            pass
+        try:
+            self.conn.execute("ALTER TABLE songs ADD COLUMN stem_count INTEGER DEFAULT 0")
         except sqlite3.OperationalError:
             pass
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_artist ON songs(artist COLLATE NOCASE)")
@@ -103,7 +108,7 @@ class MetadataDB:
 
     def get(self, filename: str, mtime: float, size: int) -> dict | None:
         row = self.conn.execute(
-            "SELECT mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format "
+            "SELECT mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format, stem_count "
             "FROM songs WHERE filename = ?", (filename,)
         ).fetchone()
         if row and row[0] == mtime and row[1] == size and row[2]:
@@ -113,6 +118,7 @@ class MetadataDB:
                 "arrangements": json.loads(row[8]) if row[8] else [],
                 "has_lyrics": bool(row[9]),
                 "format": row[10] or "psarc",
+                "stem_count": int(row[11] or 0),
             }
         return None
 
@@ -120,13 +126,14 @@ class MetadataDB:
         with self._lock:
             self.conn.execute(
                 "INSERT OR REPLACE INTO songs "
-                "(filename, mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "(filename, mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format, stem_count) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (filename, mtime, size, meta.get("title", ""), meta.get("artist", ""),
                  meta.get("album", ""), meta.get("year", ""), meta.get("duration", 0),
                  meta.get("tuning", ""), json.dumps(meta.get("arrangements", [])),
                  1 if meta.get("has_lyrics") else 0,
-                 meta.get("format", "psarc")),
+                 meta.get("format", "psarc"),
+                 int(meta.get("stem_count", 0) or 0)),
             )
             self.conn.commit()
 
@@ -181,7 +188,7 @@ class MetadataDB:
 
         total = self.conn.execute(f"SELECT COUNT(*) FROM songs {where}", params).fetchone()[0]
         rows = self.conn.execute(
-            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, mtime, format "
+            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, mtime, format, stem_count "
             f"FROM songs {where} ORDER BY {order} LIMIT ? OFFSET ?",
             params + [size, page * size]
         ).fetchall()
@@ -196,6 +203,7 @@ class MetadataDB:
                 "arrangements": json.loads(r[7]) if r[7] else [],
                 "has_lyrics": bool(r[8]), "mtime": r[9],
                 "format": r[10] or "psarc",
+                "stem_count": int(r[11] or 0),
                 "has_estd": r[0] in estd, "favorite": r[0] in favs,
             })
         return songs, total
@@ -241,7 +249,7 @@ class MetadataDB:
         song_params = params + artist_names
 
         rows = self.conn.execute(
-            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format "
+            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format, stem_count "
             f"FROM songs {song_where} ORDER BY artist COLLATE NOCASE, album COLLATE NOCASE, title COLLATE NOCASE",
             song_params
         ).fetchall()
@@ -266,6 +274,7 @@ class MetadataDB:
                 "arrangements": json.loads(r[7]) if r[7] else [],
                 "has_lyrics": bool(r[8]),
                 "format": r[9] or "psarc",
+                "stem_count": int(r[10] or 0),
                 "has_estd": r[0] in estd,
                 "favorite": r[0] in favs,
             })
@@ -500,7 +509,18 @@ def _background_scan():
     sloppaks = [f for f in sorted(dlc.rglob("*.sloppak"))
                 if sloppak_mod.is_sloppak(f)]
     all_songs = psarcs + sloppaks
-    current_files = {f.name for f in all_songs}
+
+    def _rel(f: Path) -> str:
+        # Store the path relative to the DLC root so sub-folders (e.g.
+        # dlc/sloppak/foo.sloppak produced by the converter) resolve back
+        # correctly later. PSARCs always live directly in dlc/, so this
+        # reduces to f.name for them.
+        try:
+            return f.relative_to(dlc).as_posix()
+        except ValueError:
+            return f.name
+
+    current_files = {_rel(f) for f in all_songs}
 
     # Clean up stale DB entries
     stale = meta_db.delete_missing(current_files)
@@ -511,7 +531,7 @@ def _background_scan():
     to_scan = []
     for f in all_songs:
         stat = f.stat()
-        if not meta_db.get(f.name, stat.st_mtime, stat.st_size):
+        if not meta_db.get(_rel(f), stat.st_mtime, stat.st_size):
             to_scan.append((f, stat))
 
     if not to_scan:
@@ -524,7 +544,7 @@ def _background_scan():
     def _scan_one(item):
         f, stat = item
         meta = _extract_meta_for_file(f)
-        return f.name, stat.st_mtime, stat.st_size, meta
+        return _rel(f), stat.st_mtime, stat.st_size, meta
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
         futures = {executor.submit(_scan_one, item): item[0].name for item in to_scan}
@@ -745,6 +765,13 @@ async def ws_retune(websocket: WebSocket, filename: str, target: str = "E Standa
         await websocket.close()
         return
 
+    # Retune only operates on PSARC containers — sloppak is an open format
+    # and doesn't share the SNG/encryption pipeline retune.py depends on.
+    if filename.lower().endswith(".sloppak") or sloppak_mod.is_sloppak(psarc_path):
+        await websocket.send_json({"error": "Retune is not supported for .sloppak files"})
+        await websocket.close()
+        return
+
     progress_queue = asyncio.Queue()
 
     def _do_retune():
@@ -853,6 +880,28 @@ async def get_song_art(filename: str):
     psarc_path = dlc / filename
     if not psarc_path.exists():
         return JSONResponse({"error": "not found"}, 404)
+
+    # Sloppak path: pull cover.jpg from the source dir (manifest-declared or default).
+    if sloppak_mod.is_sloppak(psarc_path):
+        try:
+            src = sloppak_mod.resolve_source_dir(filename, dlc, SLOPPAK_CACHE_DIR)
+            manifest = sloppak_mod.load_manifest(psarc_path)
+            cover_rel = str(manifest.get("cover") or "cover.jpg")
+            cover_path = (src / cover_rel).resolve()
+            # Prevent escape and fall back to default name if missing.
+            try:
+                cover_path.relative_to(src.resolve())
+            except ValueError:
+                return JSONResponse({"error": "forbidden"}, 403)
+            if cover_path.exists() and cover_path.is_file():
+                mt = {
+                    ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+                    ".png": "image/png", ".webp": "image/webp",
+                }.get(cover_path.suffix.lower(), "image/jpeg")
+                return FileResponse(str(cover_path), media_type=mt)
+        except Exception:
+            pass
+        return JSONResponse({"error": "no art"}, 404)
 
     # Check cache first
     art_cache = ART_CACHE_DIR

--- a/static/app.js
+++ b/static/app.js
@@ -57,8 +57,10 @@ function sortLibrary() {
 async function loadGridPage(page = 0) {
     const q = document.getElementById('lib-filter').value.trim();
     const sort = document.getElementById('lib-sort').value;
+    const format = (document.getElementById('lib-format') || {}).value || '';
     currentPage = page;
     const params = new URLSearchParams({ q, page, size: PAGE_SIZE, sort });
+    if (format) params.set('format', format);
     const resp = await fetch(`/api/library?${params}`);
     const data = await resp.json();
     const totalPages = Math.ceil((data.total || 0) / PAGE_SIZE);
@@ -98,6 +100,20 @@ function goPage(p) {
     document.getElementById('library-section').scrollIntoView({ behavior: 'smooth' });
 }
 
+function formatBadge(fmt) {
+    if (fmt === 'sloppak') {
+        return `<span class="fmt-badge absolute top-2 right-2 px-1.5 py-0.5 rounded text-[10px] font-bold bg-green-900/80 text-green-200 border border-green-700">SLOPPAK</span>`;
+    }
+    return `<span class="fmt-badge absolute top-2 right-2 px-1.5 py-0.5 rounded text-[10px] font-bold bg-blue-900/80 text-blue-200 border border-blue-700">PSARC</span>`;
+}
+
+function formatBadgeInline(fmt) {
+    if (fmt === 'sloppak') {
+        return `<span class="px-1.5 py-0.5 rounded text-[10px] font-bold bg-green-900/60 text-green-300">SLOPPAK</span>`;
+    }
+    return `<span class="px-1.5 py-0.5 rounded text-[10px] font-bold bg-blue-900/60 text-blue-300">PSARC</span>`;
+}
+
 function renderGridCards(songs, containerId = 'lib-grid') {
     const grid = document.getElementById(containerId);
     grid.innerHTML = songs.map(s => {
@@ -119,10 +135,12 @@ function renderGridCards(songs, containerId = 'lib-grid') {
                 class="retune-btn mt-2 w-full px-2 py-1.5 bg-gold/10 hover:bg-gold/20 border border-gold/20 rounded-lg text-xs font-medium text-gold transition">
                 ⬆ Convert to Drop D</button>`
             : '';
+        const fmtBadge = formatBadge(s.format);
         return `<div class="song-card group" data-play="${encodeURIComponent(s.filename)}">
             <div class="card-art">
                 <img src="${artUrl}" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
                 <span class="placeholder" style="display:none">🎸</span>
+                ${fmtBadge}
             </div>
             <div class="p-4">
                 <div class="flex items-start justify-between gap-1">
@@ -196,6 +214,8 @@ async function renderTreeInto(containerId, countId, stats, letter, q, favoritesO
     if (letter) params.set('letter', letter);
     if (q) params.set('q', q);
     if (favoritesOnly) params.set('favorites', '1');
+    const format = (document.getElementById('lib-format') || {}).value || '';
+    if (format) params.set('format', format);
     params.set('page', page);
     params.set('size', TREE_PAGE_SIZE);
     const resp = await fetch(`/api/library/artists?${params}`);
@@ -241,7 +261,7 @@ async function renderTreeInto(containerId, countId, stats, letter, q, favoritesO
                 const canRetune = stdRetune || dropRetune;
                 const retuneTarget = stdRetune ? 'E Standard' : 'Drop D';
                 html += `<div class="song-row" data-play="${encodeURIComponent(s.filename)}">`;
-                html += `<div class="flex-1 min-w-0"><span class="text-sm text-white truncate block">${esc(title)}</span></div>`;
+                html += `<div class="flex-1 min-w-0 flex items-center gap-2"><span class="text-sm text-white truncate block">${esc(title)}</span>${formatBadgeInline(s.format)}</div>`;
                 html += `<div class="flex items-center gap-1.5 flex-shrink-0 text-xs">`;
                 for (const a of (s.arrangements || [])) {
                     const cls = a.name === 'Lead' ? 'bg-red-900/40 text-red-300' :
@@ -1125,6 +1145,7 @@ async function loadPlugins() {
         }
 
         for (const plugin of plugins) {
+            try {
             const screenId = `plugin-${plugin.id}`;
 
             // Inject screen container
@@ -1159,6 +1180,9 @@ async function loadPlugins() {
                     script.onerror = reject;
                     document.body.appendChild(script);
                 });
+            }
+            } catch (e) {
+                console.warn(`Plugin '${plugin.id}' failed to load, skipping:`, e);
             }
         }
     } catch (e) {

--- a/static/app.js
+++ b/static/app.js
@@ -100,14 +100,20 @@ function goPage(p) {
     document.getElementById('library-section').scrollIntoView({ behavior: 'smooth' });
 }
 
-function formatBadge(fmt) {
+function formatBadge(fmt, stemCount) {
+    if (fmt === 'sloppak' && (stemCount || 0) > 1) {
+        return `<span class="fmt-badge absolute top-2 right-2 px-1.5 py-0.5 rounded text-[10px] font-bold bg-purple-900/80 text-purple-200 border border-purple-700">STEMS</span>`;
+    }
     if (fmt === 'sloppak') {
         return `<span class="fmt-badge absolute top-2 right-2 px-1.5 py-0.5 rounded text-[10px] font-bold bg-green-900/80 text-green-200 border border-green-700">SLOPPAK</span>`;
     }
     return `<span class="fmt-badge absolute top-2 right-2 px-1.5 py-0.5 rounded text-[10px] font-bold bg-blue-900/80 text-blue-200 border border-blue-700">PSARC</span>`;
 }
 
-function formatBadgeInline(fmt) {
+function formatBadgeInline(fmt, stemCount) {
+    if (fmt === 'sloppak' && (stemCount || 0) > 1) {
+        return `<span class="px-1.5 py-0.5 rounded text-[10px] font-bold bg-purple-900/60 text-purple-300">STEMS</span>`;
+    }
     if (fmt === 'sloppak') {
         return `<span class="px-1.5 py-0.5 rounded text-[10px] font-bold bg-green-900/60 text-green-300">SLOPPAK</span>`;
     }
@@ -121,10 +127,11 @@ function renderGridCards(songs, containerId = 'lib-grid') {
         const artist = s.artist || '';
         const duration = s.duration ? formatTime(s.duration) : '';
         const tuning = s.tuning || '';
-        const artUrl = `/api/song/${encodeURIComponent(s.filename)}/art`;
-        const stdRetune = tuning && !s.has_estd &&
+        const artUrl = `/api/song/${encodeURIComponent(s.filename)}/art${s.mtime ? `?v=${Math.floor(s.mtime)}` : ''}`;
+        const isSloppak = s.format === 'sloppak';
+        const stdRetune = !isSloppak && tuning && !s.has_estd &&
             ['Eb Standard', 'D Standard', 'C# Standard', 'C Standard'].includes(tuning);
-        const dropRetune = tuning && !s.has_estd &&
+        const dropRetune = !isSloppak && tuning && !s.has_estd &&
             ['Drop C', 'Drop C#', 'Drop Bb', 'Drop A'].includes(tuning);
         const retuneBtn = stdRetune
             ? `<button data-retune="${encodeURIComponent(s.filename)}" data-title="${encodeURIComponent(title)}" data-tuning="${tuning}" data-target="E Standard"
@@ -135,7 +142,7 @@ function renderGridCards(songs, containerId = 'lib-grid') {
                 class="retune-btn mt-2 w-full px-2 py-1.5 bg-gold/10 hover:bg-gold/20 border border-gold/20 rounded-lg text-xs font-medium text-gold transition">
                 ⬆ Convert to Drop D</button>`
             : '';
-        const fmtBadge = formatBadge(s.format);
+        const fmtBadge = formatBadge(s.format, s.stem_count);
         return `<div class="song-card group" data-play="${encodeURIComponent(s.filename)}">
             <div class="card-art">
                 <img src="${artUrl}" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
@@ -240,7 +247,7 @@ async function renderTreeInto(containerId, countId, stats, letter, q, favoritesO
         html += `</div><div class="artist-body">`;
 
         for (const album of artist.albums) {
-            const artUrl = `/api/song/${encodeURIComponent(album.songs[0].filename)}/art`;
+            const artUrl = `/api/song/${encodeURIComponent(album.songs[0].filename)}/art${album.songs[0].mtime ? `?v=${Math.floor(album.songs[0].mtime)}` : ''}`;
             const albumOpen = q || artist.albums.length === 1 ? ' open' : '';
             html += `<div class="album-group${albumOpen}">`;
             html += `<div class="album-header" onclick="this.parentElement.classList.toggle('open')">`;
@@ -254,14 +261,15 @@ async function renderTreeInto(containerId, countId, stats, letter, q, favoritesO
                 const title = s.title || s.filename;
                 const duration = s.duration ? formatTime(s.duration) : '';
                 const tuning = s.tuning || '';
-                const stdRetune = tuning && !s.has_estd &&
+                const isSloppak = s.format === 'sloppak';
+                const stdRetune = !isSloppak && tuning && !s.has_estd &&
                     ['Eb Standard', 'D Standard', 'C# Standard', 'C Standard'].includes(tuning);
-                const dropRetune = tuning && !s.has_estd &&
+                const dropRetune = !isSloppak && tuning && !s.has_estd &&
                     ['Drop C', 'Drop C#', 'Drop Bb', 'Drop A'].includes(tuning);
                 const canRetune = stdRetune || dropRetune;
                 const retuneTarget = stdRetune ? 'E Standard' : 'Drop D';
                 html += `<div class="song-row" data-play="${encodeURIComponent(s.filename)}">`;
-                html += `<div class="flex-1 min-w-0 flex items-center gap-2"><span class="text-sm text-white truncate block">${esc(title)}</span>${formatBadgeInline(s.format)}</div>`;
+                html += `<div class="flex-1 min-w-0 flex items-center gap-2"><span class="text-sm text-white truncate block">${esc(title)}</span>${formatBadgeInline(s.format, s.stem_count)}</div>`;
                 html += `<div class="flex items-center gap-1.5 flex-shrink-0 text-xs">`;
                 for (const a of (s.arrangements || [])) {
                     const cls = a.name === 'Lead' ? 'bg-red-900/40 text-red-300' :

--- a/static/index.html
+++ b/static/index.html
@@ -84,6 +84,13 @@
                         <option value="recent">Recently Added</option>
                         <option value="tuning">Tuning</option>
                     </select>
+                    <!-- Format filter (shared) -->
+                    <select id="lib-format" onchange="sortLibrary()"
+                        class="bg-dark-700 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-300 outline-none" title="Filter by format">
+                        <option value="">All formats</option>
+                        <option value="psarc">PSARC</option>
+                        <option value="sloppak">Sloppak</option>
+                    </select>
                     <!-- Tree controls -->
                     <button onclick="toggleAllArtists(true)" class="lib-tree-ctrl bg-dark-700 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-400 hover:text-white transition">Expand All</button>
                     <button onclick="toggleAllArtists(false)" class="lib-tree-ctrl bg-dark-700 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-400 hover:text-white transition">Collapse All</button>

--- a/static/style.css
+++ b/static/style.css
@@ -39,6 +39,7 @@ html { scroll-behavior: smooth; }
     align-items: center;
     justify-content: center;
     overflow: hidden;
+    position: relative;
 }
 .song-card .card-art img {
     width: 100%;


### PR DESCRIPTION
## Summary

Adds a second playable song format alongside PSARC: **`.sloppak`** — an open, hand-editable container with a YAML manifest, OGG stems, and JSON arrangements. Either a zip archive or a directory on disk, both with the `.sloppak` extension; the loader handles both transparently.

PSARC support is untouched — `.sloppak` is loaded through a clean parallel seam.

## Why

Three goals:
1. **Open audio** — OGG stems instead of WEM/vgmstream in the hot path
2. **Multi-stem live mixing** — a song can ship guitar/bass/drums/vocals/piano/other as separate stems, which the [Stems plugin](https://github.com/topkoa/slopsmith-plugin-stems) then lets users toggle and volume-mix live during playback
3. **Hand-editable** — drop stems into a directory, edit `manifest.yaml`, reload

A companion [Sloppak Converter plugin](https://github.com/topkoa/slopsmith-plugin-sloppak-converter) produces `.sloppak` files from existing PSARCs with optional Demucs stem splitting, but the format and core loader stand on their own.

## What's in this PR (core only)

- **`lib/sloppak.py`** — manifest parsing, zip/dir dispatch, Song construction, fast metadata extraction
- **`lib/sloppak_convert.py`** — PSARC → sloppak conversion pipeline + Demucs stem-splitting (shared by the CLI scripts and the converter plugin)
- **`lib/song.py`** — extracts the arrangement → wire JSON serializer into a reusable helper (was previously inlined in `highway_ws`)
- **`server.py`**:
  - Scanner globs `**/*.sloppak` in addition to `*.psarc`
  - `songs` table gains a `format` column (`psarc` | `sloppak`) with migration
  - `_extract_meta_fast` and `highway_ws` dispatch on format
  - `/api/library` accepts `?format=` filter
  - `song_info` payload gains a `stems[]` array
  - Unpack cache for zipped sloppaks mirrors the existing PSARC extract-cache pattern
- **`static/app.js`** — renders a format badge (PSARC / SLOPPAK) on every library card + tree row, adds an `All / PSARC / Sloppak` filter control
- **`scripts/psarc_to_sloppak.py`** — CLI converter (single-stem output by default, `--dir` for directory form)
- **`scripts/split_stems.py`** — standalone Demucs wrapper for splitting an existing sloppak's `stems/full.ogg` into per-instrument stems
- **`requirements.txt`** — adds `PyYAML`
- **`plugins/__init__.py`** — bumps per-plugin `requirements.txt` install timeout from 120s → 1800s so plugins that pull in torch/demucs (~1.5GB CPU wheels) can finish on first boot

## What's NOT in this PR

- The **Stems**, **Sloppak Converter**, and **Split Screen** plugins live in their own repos (already listed in the community plugins directory you added in 3fd1979). They're not touched here.
- The `.sloppak` format is additive — no PSARC behavior changes.

## Format spec

A `.sloppak` (zip or directory):

```
MySong.sloppak/
  manifest.yaml           # title/artist/stems[]/arrangements[]/lyrics
  cover.jpg               # optional
  stems/
    guitar.ogg            # any subset; referenced by manifest
    bass.ogg
    drums.ogg
    vocals.ogg
    piano.ogg
    other.ogg
  arrangements/
    lead.json             # same schema the highway WebSocket already emits
    rhythm.json
    bass.json
  lyrics.json             # optional, same shape as existing PSARC lyrics
```

Arrangement JSON deliberately reuses the exact wire format `highway_ws` already emits — no client changes needed to render a sloppak arrangement.

## Test plan

- [ ] Existing PSARC songs load, play, and retune exactly as before
- [ ] Library shows a blue **PSARC** badge on PSARC rows and a green **SLOPPAK** badge on sloppak rows
- [ ] `All / PSARC / Sloppak` filter narrows the library correctly
- [ ] Hand-craft a minimal `Test.sloppak/` directory with one arrangement + `stems/full.ogg` → appears in library, opens in player, highway renders
- [ ] Run `python scripts/psarc_to_sloppak.py path/to/song.psarc` → produces a zipped `.sloppak` that loads and plays matching the original
- [ ] With Demucs installed, run `python scripts/split_stems.py path/to/song.sloppak` → produces per-instrument stems; the sloppak still loads (and the Stems plugin, if installed, mixes them live)
- [ ] DB migration runs cleanly on an existing songs.db from current `main`