### PR TITLE
Expose getLyricsVisible/setLyricsVisible on highway instance

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -1049,6 +1049,9 @@ function createHighway() {
             }
         },
 
+        getLyricsVisible() { return showLyrics; },
+        setLyricsVisible(v) { showLyrics = !!v; },
+
         reconnect(filename, arrangement) {
             // Close old WS but keep audio + animation running
             if (ws) { ws.close(); ws = null; }


### PR DESCRIPTION
## Summary

The existing \`toggleLyrics()\` is DOM-coupled — it flips \`showLyrics\` and also mutates the global \`#btn-lyrics\` button. That's the right behavior for the core toolbar but breaks for plugins that want per-instance lyrics control without scrambling shared DOM.

Concrete case: the splitscreen plugin instantiates multiple highways via \`createHighway()\`, each with its own panel control bar. To give each panel its own Lyrics toggle, it needs to flip lyrics state on a single instance without touching the global button.

This PR adds DOM-free getters/setters mirroring the existing \`getInverted/setInverted\` pattern. Three lines, no behavior change for existing callers.

\`\`\`js
getLyricsVisible() { return showLyrics; },
setLyricsVisible(v) { showLyrics = !!v; },
\`\`\`

## Test plan

- [x] Core \`toggleLyrics()\` button still works (unchanged path)
- [ ] Splitscreen consumes the new API in a follow-up PR for its per-panel Lyrics toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)