### PR TITLE
Expose sloppak cache dir to plugin context

### DIFF
--- a/server.py
+++ b/server.py
@@ -572,6 +572,7 @@ load_plugins(app, {
     "get_dlc_dir": _get_dlc_dir,
     "extract_meta": _extract_meta_for_file,
     "meta_db": meta_db,
+    "get_sloppak_cache_dir": lambda: SLOPPAK_CACHE_DIR,
 })
 
 


### PR DESCRIPTION
## Summary
- Adds `get_sloppak_cache_dir` to the plugin context dict passed into `load_plugins()`
- Plugins can now call `sloppak_mod.load_song(filename, dlc, cache_dir)` for sloppak-format songs
- Getter is a lambda because `SLOPPAK_CACHE_DIR` is defined later in server.py; resolution happens at request time

## Motivation
I'm extending the Tab View plugin to serve GP5 tablature for sloppak songs (it currently only handles PSARC). To resolve a sloppak's on-disk source dir — including unpacking zipped sloppaks on demand — the plugin needs access to the same cache directory the core uses.

## Test plan
- [x] Restart server, verify existing PSARC/sloppak playback unchanged
- [x] Verify plugins without a `routes.py` unaffected (context is only consumed by plugins that opt in)
- [x] Exercised downstream from the tabview plugin on a sloppak song — GP5 generated and loaded in the Tab View

🤖 Generated with [Claude Code](https://claude.com/claude-code)