### PR TITLE
Fix sloppak converter missing lyrics for official DLC (SNG-only)

### DIFF
--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -88,6 +88,7 @@ def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
 
 
 def _parse_lyrics(extracted_dir: Path) -> list[dict]:
+    # Try vocals XML first (CDLC and some official DLC)
     for xml_path in sorted(extracted_dir.rglob("*.xml")):
         try:
             root = ET.parse(xml_path).getroot()
@@ -103,6 +104,16 @@ def _parse_lyrics(extracted_dir: Path) -> list[dict]:
             }
             for v in root.findall("vocal")
         ]
+    # Fall back to vocals SNG (official DLC ships SNG-only)
+    try:
+        from sng_vocals import parse_vocals_sng
+        for sng_path in sorted(extracted_dir.rglob("*vocals*.sng")):
+            plat = "mac" if "/macos/" in str(sng_path).replace("\\", "/").lower() else "pc"
+            lyrics = parse_vocals_sng(str(sng_path), plat)
+            if lyrics:
+                return lyrics
+    except ImportError:
+        pass
     return []
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ curl_cffi>=0.7.0
 midiutil>=1.2.1
 Pillow>=10.0.0
 PyYAML>=6.0
+python-multipart>=0.0.9


### PR DESCRIPTION
_parse_lyrics in sloppak_convert.py only looked for vocals XML, so PSARCs that ship SNG-only vocals (official Rocksmith DLC) produced sloppaks with no lyrics.json. Add the same SNG fallback that the highway WebSocket handler uses: after XML search fails, scan for *vocals*.sng, detect pc/mac platform from the path, and decode via sng_vocals.parse_vocals_sng.

Also adds python-multipart to requirements.txt, needed by the editor plugin's file upload routes.