### PR TITLE
Remove broken plugin symlinks pointing to dev-local paths

### DIFF
--- a/plugins/3dhighway
+++ b/plugins/3dhighway
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-3dhighway/

--- a/plugins/audio_engine
+++ b/plugins/audio_engine
@@ -1,1 +1,0 @@
-/home/byron/.config/slopsmith-desktop/plugins/audio_engine

--- a/plugins/backingtrack
+++ b/plugins/backingtrack
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-backingtrack/

--- a/plugins/cf
+++ b/plugins/cf
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-cf/

--- a/plugins/discextract
+++ b/plugins/discextract
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-discextract/

--- a/plugins/fretboard
+++ b/plugins/fretboard
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-fretboard/

--- a/plugins/metronome
+++ b/plugins/metronome
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-metronome/

--- a/plugins/midi
+++ b/plugins/midi
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-midi/

--- a/plugins/plugin_manager
+++ b/plugins/plugin_manager
@@ -1,1 +1,0 @@
-/home/byron/.config/slopsmith-desktop/plugins/plugin_manager

--- a/plugins/practice
+++ b/plugins/practice
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-practice/

--- a/plugins/profileimport
+++ b/plugins/profileimport
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-profileimport/

--- a/plugins/rs1extract
+++ b/plugins/rs1extract
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-rs1extract/

--- a/plugins/sectionmap
+++ b/plugins/sectionmap
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-sectionmap/

--- a/plugins/setlist
+++ b/plugins/setlist
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-setlist/

--- a/plugins/tabimport
+++ b/plugins/tabimport
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-tabimport/

--- a/plugins/tabview
+++ b/plugins/tabview
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-tabview/

--- a/plugins/tones
+++ b/plugins/tones
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-tones/

--- a/plugins/ug
+++ b/plugins/ug
@@ -1,1 +1,0 @@
-/home/byron/Repositories/slopsmith-plugin-ug/


### PR DESCRIPTION
## Summary

All 18 plugin directories tracked under `plugins/` in the repo are symbolic links into `/home/byron/Repositories/` and `/home/byron/.config/slopsmith-desktop/plugins/` — paths that don't resolve on anyone else's machine. A fresh clone gets a `plugins/` directory full of dangling symlinks.

`.gitignore` already has `plugins/*/` with `!plugins/__init__.py`, so newly-cloned plugins won't be tracked — but these symlinks predate that rule and remained in the index.

Per the README's "Installing a Plugin" section, users are expected to clone plugin repos into `plugins/` themselves. The tree should ship empty (apart from `__init__.py`).

## Changes

- `git rm` the 18 symlinks: `3dhighway`, `audio_engine`, `backingtrack`, `cf`, `discextract`, `fretboard`, `metronome`, `midi`, `plugin_manager`, `practice`, `profileimport`, `rs1extract`, `sectionmap`, `setlist`, `tabimport`, `tabview`, `tones`, `ug`
- `plugins/__init__.py` left in place so `plugins/` remains a valid Python package

## Test plan

- [ ] `git clone` a fresh copy on a machine without `/home/byron/...` — `plugins/` should contain only `__init__.py` with no dangling entries
- [ ] `docker compose up -d` still starts cleanly with the empty plugin dir
- [ ] Dropping any plugin (e.g. `git clone slopsmith-plugin-metronome metronome`) into `plugins/` still works as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)