### PR TITLE
Plugin context API: window.slopsmith EventTarget + cross-plugin navigation

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -7,6 +7,7 @@ function showScreen(id) {
     if (id === 'settings') loadSettings();
     if (id !== 'player') { highway.stop(); }
     window.scrollTo(0, 0);
+    if (window.slopsmith) window.slopsmith.emit('screen:changed', { id });
 }
 
 // ── Library ──────────────────────────────────────────────────────────────
@@ -647,7 +648,26 @@ function retuneSong(filename, title, tuning, target) {
 const audio = document.getElementById('audio');
 let isPlaying = false;
 let currentFilename = '';
-window.slopsmithPlayer = { currentSong: null, isPlaying: false };
+// Plugin context API — lightweight event bus for plugin integration
+window.slopsmith = Object.assign(new EventTarget(), {
+    currentSong: null,
+    isPlaying: false,
+    _navParams: {},
+    navigate(screenId, params) {
+        this._navParams = params || {};
+        showScreen(screenId);
+    },
+    getNavParams() {
+        const p = this._navParams;
+        this._navParams = {};
+        return p;
+    },
+    emit(event, detail) {
+        this.dispatchEvent(new CustomEvent(event, { detail }));
+    },
+    on(event, fn) { this.addEventListener(event, fn); },
+    off(event, fn) { this.removeEventListener(event, fn); }
+});
 
 // Debug audio issues
 audio.addEventListener('pause', () => { if (isPlaying) console.log('Audio paused unexpectedly at', audio.currentTime.toFixed(1)); });
@@ -658,7 +678,21 @@ audio.addEventListener('error', (e) => {
 });
 audio.addEventListener('stalled', () => console.log('Audio stalled at', audio.currentTime.toFixed(1)));
 audio.addEventListener('waiting', () => console.log('Audio waiting/buffering at', audio.currentTime.toFixed(1)));
-audio.addEventListener('ended', () => { console.log('Audio ended'); isPlaying = false; document.getElementById('btn-play').textContent = '▶ Play'; window.slopsmithPlayer.isPlaying = false; window.dispatchEvent(new CustomEvent('slopsmith:playbackchanged', { detail: { isPlaying: false } })); });
+audio.addEventListener('ended', () => {
+    console.log('Audio ended'); isPlaying = false;
+    document.getElementById('btn-play').textContent = '▶ Play';
+    window.slopsmith.isPlaying = false;
+    window.slopsmith.emit('song:ended', { time: audio.currentTime });
+});
+audio.addEventListener('play', () => {
+    window.slopsmith.isPlaying = true;
+    window.slopsmith.emit('song:play', { time: audio.currentTime });
+});
+audio.addEventListener('pause', () => {
+    if (!isPlaying) return;
+    window.slopsmith.isPlaying = false;
+    window.slopsmith.emit('song:pause', { time: audio.currentTime });
+});
 
 // Abort controller for cancelling pending requests when entering player
 let artAbortController = null;
@@ -724,6 +758,7 @@ function changeArrangement(index) {
         };
 
         highway.reconnect(currentFilename, index);
+        window.slopsmith.emit('arrangement:changed', { index, filename: currentFilename });
     }
 }
 
@@ -735,8 +770,6 @@ function togglePlay() {
         audio.play(); isPlaying = true;
         document.getElementById('btn-play').textContent = '⏸ Pause';
     }
-    window.slopsmithPlayer.isPlaying = isPlaying;
-    window.dispatchEvent(new CustomEvent('slopsmith:playbackchanged', { detail: { isPlaying } }));
 }
 
 function seekBy(s) { audio.currentTime = Math.max(0, audio.currentTime + s); }

--- a/static/app.js
+++ b/static/app.js
@@ -647,6 +647,7 @@ function retuneSong(filename, title, tuning, target) {
 const audio = document.getElementById('audio');
 let isPlaying = false;
 let currentFilename = '';
+window.slopsmithPlayer = { currentSong: null, isPlaying: false };
 
 // Debug audio issues
 audio.addEventListener('pause', () => { if (isPlaying) console.log('Audio paused unexpectedly at', audio.currentTime.toFixed(1)); });
@@ -657,7 +658,7 @@ audio.addEventListener('error', (e) => {
 });
 audio.addEventListener('stalled', () => console.log('Audio stalled at', audio.currentTime.toFixed(1)));
 audio.addEventListener('waiting', () => console.log('Audio waiting/buffering at', audio.currentTime.toFixed(1)));
-audio.addEventListener('ended', () => { console.log('Audio ended'); isPlaying = false; document.getElementById('btn-play').textContent = '▶ Play'; });
+audio.addEventListener('ended', () => { console.log('Audio ended'); isPlaying = false; document.getElementById('btn-play').textContent = '▶ Play'; window.slopsmithPlayer.isPlaying = false; window.dispatchEvent(new CustomEvent('slopsmith:playbackchanged', { detail: { isPlaying: false } })); });
 
 // Abort controller for cancelling pending requests when entering player
 let artAbortController = null;
@@ -734,6 +735,8 @@ function togglePlay() {
         audio.play(); isPlaying = true;
         document.getElementById('btn-play').textContent = '⏸ Pause';
     }
+    window.slopsmithPlayer.isPlaying = isPlaying;
+    window.dispatchEvent(new CustomEvent('slopsmith:playbackchanged', { detail: { isPlaying } }));
 }
 
 function seekBy(s) { audio.currentTime = Math.max(0, audio.currentTime + s); }

--- a/static/highway.js
+++ b/static/highway.js
@@ -979,6 +979,27 @@ function createHighway() {
                                 `<option value="${a.index}" ${a.index === msg.arrangement_index ? 'selected' : ''}>${a.name} (${a.notes})</option>`
                             ).join('');
                         }
+                        // Plugin context API — broadcast current song state
+                        {
+                            const wsPath = ws.url.split('/ws/highway/')[1] || '';
+                            const filename = decodeURIComponent(wsPath.split('?')[0]);
+                            if (!window.slopsmithPlayer) window.slopsmithPlayer = { currentSong: null, isPlaying: false };
+                            window.slopsmithPlayer.currentSong = {
+                                filename,
+                                title: msg.title,
+                                artist: msg.artist,
+                                duration: msg.duration,
+                                arrangement: msg.arrangement,
+                                arrangementIndex: msg.arrangement_index,
+                                arrangements: msg.arrangements || [],
+                                tuning: msg.tuning,
+                                capo: msg.capo,
+                                format: msg.format,
+                            };
+                            window.dispatchEvent(new CustomEvent('slopsmith:songloaded', {
+                                detail: window.slopsmithPlayer.currentSong
+                            }));
+                        }
                         break;
                     case 'beats': beats = msg.data; break;
                     case 'sections': sections = msg.data; break;

--- a/static/highway.js
+++ b/static/highway.js
@@ -980,11 +980,10 @@ function createHighway() {
                             ).join('');
                         }
                         // Plugin context API — broadcast current song state
-                        {
+                        if (window.slopsmith) {
                             const wsPath = ws.url.split('/ws/highway/')[1] || '';
                             const filename = decodeURIComponent(wsPath.split('?')[0]);
-                            if (!window.slopsmithPlayer) window.slopsmithPlayer = { currentSong: null, isPlaying: false };
-                            window.slopsmithPlayer.currentSong = {
+                            window.slopsmith.currentSong = {
                                 filename,
                                 title: msg.title,
                                 artist: msg.artist,
@@ -996,9 +995,7 @@ function createHighway() {
                                 capo: msg.capo,
                                 format: msg.format,
                             };
-                            window.dispatchEvent(new CustomEvent('slopsmith:songloaded', {
-                                detail: window.slopsmithPlayer.currentSong
-                            }));
+                            window.slopsmith.emit('song:loaded', window.slopsmith.currentSong);
                         }
                         break;
                     case 'beats': beats = msg.data; break;


### PR DESCRIPTION
## Summary

Implements the plugin context API as proposed by @byrongamatos in #19. Replaces the initial `window.slopsmithPlayer` + `CustomEvent` approach with Byron's recommended `EventTarget`-based design.

## Changes

### `static/app.js`
- **`window.slopsmith`**: `EventTarget` instance with `on()`/`off()`/`emit()` helpers, `currentSong` property, `isPlaying` state
- **`navigate(screenId, params)`** + **`getNavParams()`**: cross-plugin navigation with parameter passing
- **`song:play`** / **`song:pause`** / **`song:ended`**: emitted from `<audio>` element event listeners
- **`arrangement:changed`**: emitted from `changeArrangement()`
- **`screen:changed`**: emitted from `showScreen()`

### `static/highway.js`
- **`song:loaded`**: emitted from the `song_info` WebSocket handler when song data arrives
- Updates `window.slopsmith.currentSong` with song metadata (title, artist, tuning, arrangement, etc.)

## Plugin usage

```js
// Listen for song loads
window.slopsmith.on('song:loaded', (e) => {
    const { title, artist, tuning, arrangement } = e.detail;
    // Auto-match tuning, highlight key, etc.
});

// Listen for arrangement changes
window.slopsmith.on('arrangement:changed', (e) => {
    const { index, filename } = e.detail;
});

// Listen for playback
window.slopsmith.on('song:play', (e) => { /* playing */ });
window.slopsmith.on('song:pause', (e) => { /* paused */ });

// Cross-plugin navigation with params
window.slopsmith.navigate('plugin-guitar_theory', { root: 'E', scale: 'pentatonicMinor' });

// In the target plugin:
const params = window.slopsmith.getNavParams();
if (params.root) { /* apply */ }

// Read current state anytime
const song = window.slopsmith.currentSong; // null if no song loaded
```

## Events

| Event | Source | Detail |
|-------|--------|--------|
| `song:loaded` | `highway.js` song_info WS handler | `{ filename, title, artist, duration, arrangement, arrangementIndex, arrangements, tuning, capo, format }` |
| `song:play` | `<audio>` play event | `{ time }` |
| `song:pause` | `<audio>` pause event | `{ time }` |
| `song:ended` | `<audio>` ended event | `{ time }` |
| `arrangement:changed` | `changeArrangement()` | `{ index, filename }` |
| `screen:changed` | `showScreen()` | `{ id }` |

## Non-breaking

All existing plugins are unaffected — `window.slopsmith` is additive. Plugins opt in by calling `slopsmith.on()`. The existing `window.highway` API is preserved.

Resolves #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)