### PR TITLE
Verbose scan: per-file logging, stage tracking, permission error capture

### DIFF
--- a/server.py
+++ b/server.py
@@ -493,25 +493,46 @@ def _extract_meta_for_file(psarc_path: Path) -> dict:
         shutil.rmtree(tmp, ignore_errors=True)
 
 
-_scan_status = {"running": False, "total": 0, "done": 0, "current": ""}
+_SCAN_STATUS_INIT = {"running": False, "stage": "idle", "total": 0, "done": 0, "current": "", "error": None}
+_scan_status = dict(_SCAN_STATUS_INIT)
 
 
 def _background_scan():
     """Scan all PSARCs and cache metadata on startup. Uses thread pool for parallelism."""
     global _scan_status
+    _scan_status = {**_SCAN_STATUS_INIT, "running": True, "stage": "listing"}
+
     dlc = _get_dlc_dir()
     if not dlc:
-        _scan_status = {"running": False, "total": 0, "done": 0, "current": ""}
+        _scan_status = {**_SCAN_STATUS_INIT, "stage": "idle", "error": "DLC folder not configured"}
+        print("Scan: no DLC folder configured", flush=True)
         return
 
-    # Skip RS1 compatibility mega-PSARCs (multi-song, not individually playable)
-    psarcs = [f for f in sorted(dlc.rglob("*.psarc"))
-              if f.is_file()
-              and "rs1compatibility" not in f.name.lower()]
-    # Sloppaks: match both file (zip) and directory form by suffix.
-    sloppaks = [f for f in sorted(dlc.rglob("*.sloppak"))
-                if sloppak_mod.is_sloppak(f)]
+    # Listing can fail on macOS without Full Disk Access, or on Docker if the
+    # path isn't shared. Report the failure explicitly rather than silently
+    # appearing to scan nothing.
+    try:
+        # Skip RS1 compatibility mega-PSARCs (multi-song, not individually playable)
+        psarcs = [f for f in sorted(dlc.rglob("*.psarc"))
+                  if f.is_file()
+                  and "rs1compatibility" not in f.name.lower()]
+        # Sloppaks: match both file (zip) and directory form by suffix.
+        sloppaks = [f for f in sorted(dlc.rglob("*.sloppak"))
+                    if sloppak_mod.is_sloppak(f)]
+    except PermissionError as e:
+        msg = (f"Permission denied reading {dlc}. "
+               "On macOS: grant Full Disk Access to the app in System Settings → Privacy & Security. "
+               "With Docker: share this path in Docker Desktop → Settings → Resources → File Sharing.")
+        print(f"Scan failed: {msg} ({e})", flush=True)
+        _scan_status = {**_SCAN_STATUS_INIT, "stage": "error", "error": msg}
+        return
+    except OSError as e:
+        print(f"Scan failed listing {dlc}: {e}", flush=True)
+        _scan_status = {**_SCAN_STATUS_INIT, "stage": "error", "error": f"Unable to list {dlc}: {e}"}
+        return
+
     all_songs = psarcs + sloppaks
+    print(f"Scan: listed {len(psarcs)} PSARCs and {len(sloppaks)} sloppaks in {dlc}", flush=True)
 
     def _rel(f: Path) -> str:
         # Store the path relative to the DLC root so sub-folders (e.g.
@@ -528,7 +549,7 @@ def _background_scan():
     # Clean up stale DB entries
     stale = meta_db.delete_missing(current_files)
     if stale:
-        print(f"Removed {stale} stale DB entries")
+        print(f"Removed {stale} stale DB entries", flush=True)
 
     # Figure out which need scanning
     to_scan = []
@@ -538,14 +559,18 @@ def _background_scan():
             to_scan.append((f, stat))
 
     if not to_scan:
-        _scan_status = {"running": False, "total": 0, "done": 0, "current": ""}
+        _scan_status = {**_SCAN_STATUS_INIT, "stage": "complete"}
+        print(f"Scan: nothing new to scan ({len(all_songs)} songs, all cached)", flush=True)
         return
 
-    _scan_status = {"running": True, "total": len(to_scan), "done": 0, "current": ""}
-    print(f"Library: {len(psarcs)} PSARCs + {len(sloppaks)} sloppaks, {len(all_songs) - len(to_scan)} cached, {len(to_scan)} to scan")
+    _scan_status = {**_SCAN_STATUS_INIT, "running": True, "stage": "scanning", "total": len(to_scan)}
+    print(f"Library: {len(psarcs)} PSARCs + {len(sloppaks)} sloppaks, {len(all_songs) - len(to_scan)} cached, {len(to_scan)} to scan", flush=True)
 
     def _scan_one(item):
         f, stat = item
+        # Per-file log so users running the server / desktop can see live
+        # activity and distinguish a stuck scan from a slow one.
+        print(f"  scanning {f.name}", flush=True)
         meta = _extract_meta_for_file(f)
         return _rel(f), stat.st_mtime, stat.st_size, meta
 
@@ -557,12 +582,12 @@ def _background_scan():
                 name, mtime, size, meta = future.result()
                 meta_db.put(name, mtime, size, meta)
             except Exception as e:
-                print(f"  Failed: {fname}: {e}")
+                print(f"  Failed: {fname}: {e}", flush=True)
             _scan_status["done"] += 1
             _scan_status["current"] = fname
 
-    print(f"Scan complete: {len(to_scan)} songs cached")
-    _scan_status = {"running": False, "total": 0, "done": 0, "current": ""}
+    print(f"Scan complete: {len(to_scan)} songs cached", flush=True)
+    _scan_status = {**_SCAN_STATUS_INIT, "stage": "complete"}
 
 
 # ── Load plugins at import time (before app starts) ─────────────────────────

--- a/static/app.js
+++ b/static/app.js
@@ -514,12 +514,13 @@ async function rescanLibrary() {
         const sr = await fetch('/api/scan-status');
         const sd = await sr.json();
         if (sd.running) {
-            status.textContent = `${sd.done} / ${sd.total} scanned...`;
+            const cur = sd.current ? ` · ${sd.current}` : '';
+            status.textContent = `${sd.done} / ${sd.total} scanned${cur}...`;
         } else {
             clearInterval(poll);
             btn.disabled = false;
             btn.textContent = 'Rescan Library';
-            status.textContent = 'Done!';
+            status.textContent = sd.error ? `Error: ${sd.error}` : 'Done!';
             _treeStats = null;
             loadLibrary();
         }
@@ -540,12 +541,13 @@ async function fullRescanLibrary() {
         const sr = await fetch('/api/scan-status');
         const sd = await sr.json();
         if (sd.running) {
-            status.textContent = `${sd.done} / ${sd.total} scanned...`;
+            const cur = sd.current ? ` · ${sd.current}` : '';
+            status.textContent = `${sd.done} / ${sd.total} scanned${cur}...`;
         } else {
             clearInterval(poll);
             btn.disabled = false;
             btn.textContent = 'Full Rescan';
-            status.textContent = 'Done!';
+            status.textContent = sd.error ? `Error: ${sd.error}` : 'Done!';
             _treeStats = null;
             loadLibrary();
         }
@@ -1185,6 +1187,17 @@ async function pollScanStatus() {
     try {
         const resp = await fetch('/api/scan-status');
         const data = await resp.json();
+        if (data.stage === 'error' && data.error) {
+            // Surface the error in the banner and stop polling.
+            showScanBanner();
+            const file = document.getElementById('scan-file');
+            const prog = document.getElementById('scan-progress');
+            if (file) { file.textContent = 'Scan failed: ' + data.error; file.classList.add('text-red-400'); }
+            if (prog) prog.textContent = 'Error';
+            clearInterval(_scanPollId);
+            _scanPollId = null;
+            return;
+        }
         if (data.running) {
             showScanBanner();
             const pct = data.total > 0 ? Math.round(data.done / data.total * 100) : 0;
@@ -1194,8 +1207,8 @@ async function pollScanStatus() {
             if (bar) bar.style.width = pct + '%';
             if (prog) prog.textContent = `${data.done} / ${data.total} (${pct}%)`;
             if (file) {
-                const name = data.current.replace(/_p\.psarc$/i, '').replace(/_/g, ' ');
-                file.textContent = name || 'Processing...';
+                const name = (data.current || '').replace(/_p\.psarc$/i, '').replace(/_/g, ' ');
+                file.textContent = name || (data.stage === 'listing' ? 'Listing DLC folder...' : 'Processing...');
             }
         } else {
             if (document.getElementById('scan-banner')) {


### PR DESCRIPTION
## Summary
The DLC scan appeared silently stuck when it couldn't list the DLC folder — most commonly on macOS without Full Disk Access, or Docker without the path shared in Docker Desktop. Status sat at "scanning" with 0 files, and nothing distinguished "permission wall" from "slow disk." Surfaces the failure mode, and adds per-file logging so users can see live activity.

Triggered by a Discord bug report ("MacOS - can't see DLC in Default Rocksmith Steam folder") and feature-request bundle `byrongamatos/slopsmith-desktop#7`.

## Backend (`server.py`)
- `_scan_status` gains `stage` (`idle|listing|scanning|complete|error`) and `error` fields. Existing `running/total/done/current` preserved.
- `try/except` around the `rglob` listing. `PermissionError` → platform-specific hint (Full Disk Access on macOS / Docker file sharing). `OSError` → raw message.
- Each worker `print`s `  scanning <filename>` at the start of its task. `flush=True` throughout so Electron's pipe doesn't buffer.
- Summary lines at listing, completion, and the "nothing new to scan" case.

## Frontend (`static/app.js`)
- `rescanLibrary` / `fullRescanLibrary` poll now append `· <current>` during scan and show `sd.error` on completion.
- Scan banner (`pollScanStatus`) detects `stage === 'error'`, surfaces the error message in red, stops polling, and keeps the banner up so the user can read it.
- "Listing DLC folder..." shows during the listing stage before any file has been scanned — prevents large libraries from looking stuck during the initial enumeration.

## No breaking changes
- `_scan_status` is a dict; new fields are additive. Any consumer only reading `running/total/done/current` continues to work.
- API surface of `/api/scan-status` unchanged (same endpoint, richer JSON).

## Verification
- Run with a valid DLC folder → banner shows listing stage briefly → per-file activity → completes.
- macOS without Full Disk Access → banner shows "Scan failed: Permission denied reading /path... On macOS: grant Full Disk Access…" in red, stays visible.
- Docker without file sharing → same behavior with Docker-specific hint.
- Terminal / desktop log pane → visible `  scanning <filename>` per file.
