### PR TITLE
Lyrics toggle: decouple from singleton DOM element

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -1068,6 +1068,7 @@ function createHighway() {
         getSections() { return sections; },
         getSongInfo() { return songInfo; },
         addDrawHook(fn) { _drawHooks.push(fn); },
+        removeDrawHook(fn) { _drawHooks = _drawHooks.filter(h => h !== fn); },
         project(tOffset) { return project(tOffset); },
         fretX(fret, scale, w) { return fretX(fret, scale, w); },
 

--- a/static/highway.js
+++ b/static/highway.js
@@ -9,6 +9,7 @@ function createHighway() {
     let _connectOpts = {};
     let _resizeContainer = null;
     let _resizeHandler = null;
+    let _onLyricsChange = null;
 
     // Song data (populated via WebSocket)
     let songInfo = {};
@@ -1076,17 +1077,15 @@ function createHighway() {
         toggleLyrics() {
             showLyrics = !showLyrics;
             localStorage.setItem('showLyrics', String(showLyrics));
-            const btn = document.getElementById('btn-lyrics');
-            if (btn) {
-                btn.textContent = showLyrics ? 'Lyrics ✓' : 'Lyrics ✗';
-                btn.className = showLyrics
-                    ? 'px-3 py-1.5 bg-purple-900/40 hover:bg-purple-900/60 rounded-lg text-xs text-purple-300 transition'
-                    : 'px-3 py-1.5 bg-dark-600 hover:bg-dark-500 rounded-lg text-xs text-gray-500 transition';
-            }
+            if (_onLyricsChange) _onLyricsChange(showLyrics);
         },
 
         getLyricsVisible() { return showLyrics; },
-        setLyricsVisible(v) { showLyrics = !!v; },
+        setLyricsVisible(v) {
+            showLyrics = !!v;
+            if (_onLyricsChange) _onLyricsChange(showLyrics);
+        },
+        setOnLyricsChange(fn) { _onLyricsChange = fn; },
 
         reconnect(filename, arrangement) {
             // Close old WS but keep audio + animation running
@@ -1115,3 +1114,12 @@ function createHighway() {
 }
 const highway = createHighway();
 window.highway = highway; // expose for plugins
+highway.setOnLyricsChange(function(visible) {
+    const btn = document.getElementById('btn-lyrics');
+    if (btn) {
+        btn.textContent = visible ? 'Lyrics \u2713' : 'Lyrics \u2717';
+        btn.className = visible
+            ? 'px-3 py-1.5 bg-purple-900/40 hover:bg-purple-900/60 rounded-lg text-xs text-purple-300 transition'
+            : 'px-3 py-1.5 bg-dark-600 hover:bg-dark-500 rounded-lg text-xs text-gray-500 transition';
+    }
+});


### PR DESCRIPTION
## Summary

- `toggleLyrics()` inside `createHighway()` directly queried and mutated the shared `#btn-lyrics` button by ID — this breaks multi-instance usage (e.g. splitscreen per-panel lyrics)
- Moved DOM update into a `setOnLyricsChange(fn)` callback. The global singleton registers it to sync `#btn-lyrics`; factory instances stay DOM-free
- `setLyricsVisible(v)` now fires the callback too, so plugins get notified of programmatic changes
- Zero visible change for single-panel usage — identical behavior, cleaner architecture

## API additions

```js
// Register a callback for lyrics visibility changes
highway.setOnLyricsChange(fn)  // fn(visible: boolean)
```

This lets splitscreen (or any plugin) register per-panel lyrics UI callbacks instead of sharing the singleton button.

## Refs

Partial fix for #20 — factory pattern for core UI components

## Test plan

- [ ] Load a song, toggle lyrics button — should toggle on/off with button text updating as before
- [ ] Reload page — lyrics preference should persist via localStorage
- [ ] No console errors on any screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)