### PR TITLE
Surface audio conversion failures in song_info (desktop#9)

### DIFF
--- a/server.py
+++ b/server.py
@@ -1174,6 +1174,7 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
 
         # Convert audio with unique filename (check cache first)
         audio_url = None
+        audio_error: str | None = None  # Surfaced in song_info when audio_url is None
         stems_payload: list[dict] = []
         audio_id = Path(filename).stem.replace(" ", "_")
 
@@ -1188,6 +1189,8 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
                 stems_payload.append({"id": s["id"], "url": url, "default": s["default"]})
             if stems_payload:
                 audio_url = stems_payload[0]["url"]
+            else:
+                audio_error = "This sloppak has no playable stems."
         else:
             AUDIO_CACHE_DIR.mkdir(parents=True, exist_ok=True)
             # Check if audio already cached (writable cache dir or legacy static dir)
@@ -1203,7 +1206,9 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
         if not audio_url and not is_slop:
             await websocket.send_json({"type": "loading", "stage": "Converting audio..."})
             wem_files = find_wem_files(tmp)
-            if wem_files:
+            if not wem_files:
+                audio_error = "No WEM audio files were found inside this PSARC."
+            else:
                 try:
                     audio_path = convert_wem(wem_files[0], os.path.join(tmp, "audio"))
                     ext = Path(audio_path).suffix
@@ -1214,6 +1219,7 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
                     print(f"Audio conversion failed: {e}")
                     import traceback
                     traceback.print_exc()
+                    audio_error = f"Audio conversion failed: {e}"
 
             # Clean up old audio cache files (keep max 100)
             try:
@@ -1238,6 +1244,7 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
             "arrangement_index": best,
             "arrangements": arr_list,
             "audio_url": audio_url,
+            "audio_error": audio_error,
             "tuning": arr.tuning,
             "capo": arr.capo,
             "format": "sloppak" if is_slop else "psarc",

--- a/static/highway.js
+++ b/static/highway.js
@@ -985,6 +985,32 @@ function createHighway() {
                             document.getElementById('hud-artist').textContent = msg.artist;
                             document.getElementById('hud-title').textContent = msg.title;
                             document.getElementById('hud-arrangement').textContent = msg.arrangement;
+
+                            // Clear any lingering audio-error banner from a prior song.
+                            const existingAudioErr = document.getElementById('audio-error-banner');
+                            if (existingAudioErr) existingAudioErr.remove();
+
+                            // Server reported a concrete audio-pipeline failure and has
+                            // no URL to give us — surface it instead of leaving the
+                            // user with a cryptic "Empty src attribute" from audio.play().
+                            if (!msg.audio_url && msg.audio_error) {
+                                const banner = document.createElement('div');
+                                banner.id = 'audio-error-banner';
+                                banner.className = 'fixed top-4 left-1/2 -translate-x-1/2 z-[300] bg-red-900/95 border border-red-700 text-red-100 rounded-lg px-4 py-3 max-w-2xl shadow-xl';
+                                banner.innerHTML = `
+                                    <div class="flex items-start gap-3">
+                                        <span class="text-xl leading-none">⚠</span>
+                                        <div class="flex-1">
+                                            <div class="font-semibold text-sm">Audio unavailable</div>
+                                            <div class="text-xs text-red-200 mt-1"></div>
+                                        </div>
+                                        <button class="text-red-300 hover:text-white text-lg leading-none" aria-label="Dismiss">✕</button>
+                                    </div>`;
+                                banner.querySelector('.text-xs').textContent = msg.audio_error;
+                                banner.querySelector('button').addEventListener('click', () => banner.remove());
+                                document.body.appendChild(banner);
+                            }
+
                             if (msg.audio_url) {
                                 const audio = document.getElementById('audio');
                                 if (!audio.src || !audio.src.includes(msg.audio_url.split('/').pop())) {


### PR DESCRIPTION
Partially addresses `byrongamatos/slopsmith-desktop#9` (TheBurnoutTV's "MEDIA_ELEMENT_ERROR: Empty src attribute" on v0.2.2 Windows). This PR doesn't fix *his* specific root cause (still waiting on his logs) but it does turn the entire "empty audio src with no explanation" failure mode into something with an actual error message — both for him and any future user who hits the same pipeline.

## The problem
When the server's WEM→MP3 pipeline fails (vgmstream-cli not on PATH, ffmpeg missing, PSARC has no WEM files, sloppak has no stems), the exception is caught, logged once to stderr, and the server sends `song_info` with `audio_url: null`. The frontend's `if (msg.audio_url)` guard silently skips setting `audio.src`. When the user clicks play, the browser throws `MEDIA_ELEMENT_ERROR: Empty src attribute` / `NotSupportedError: The element has no supported sources` — neither of which tells them anything about what actually went wrong.

## The change

**`server.py`**: track an `audio_error: str | None` alongside `audio_url` in the song_info WebSocket handler. Set it in three places:
- Sloppak with no stems: `"This sloppak has no playable stems."`
- PSARC with no WEM files: `"No WEM audio files were found inside this PSARC."`
- `convert_wem` raised: `f"Audio conversion failed: {e}"` — includes the underlying reason (e.g. the `"No WEM audio decoder found..."` message from `lib/audio.py` when vgmstream + ffmpeg are both absent from PATH)

Include `audio_error` in the song_info payload.

**`static/highway.js`**: in the song_info handler, when `!msg.audio_url && msg.audio_error`, inject a red banner at top-center with the message and a dismiss button. Clear any existing banner on any subsequent song_info (so a successful song after a failure cleans up).

## Not breaking
`audio_error` is additive. Clients that ignore it behave exactly as before; the frontend only renders the banner when `audio_error` is populated. No WS schema versioning needed.

## Tests
- `pytest` green (53/53), 0.13s — unchanged
- Manual smoke plan (pending a local setup with an environment that reproduces): uninstall / shadow vgmstream-cli → click any song → expect red banner with "Audio conversion failed: No WEM audio decoder found..." instead of silent failure + cryptic console errors

## Followups
- Desktop release note when v0.2.3 ships: "Audio failures now show a visible error instead of silently leaving the player blank."
- If TheBurnoutTV's logs point at a specific root cause (bundling vs. AV-quarantined binaries), a separate follow-up addresses that.
