### PR TITLE
docs: CLAUDE.md polish — song_info shape + manifest field note (#74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ The highway WebSocket at `/ws/highway/{filename}?arrangement={index}` streams th
 | Message | Shape | Description |
 |---------|-------|-------------|
 | `loading` | `{ type: 'loading', stage }` | Status/progress message during extraction or conversion |
-| `song_info` | `{ type, title, artist, arrangement, arrangement_index, arrangements, duration, tuning, capo, format, audio_url, audio_error?, stems? }` | Song metadata. `arrangements` is the full list for the switcher; `audio_error` only appears when audio conversion failed; `stems` only on sloppak songs with split stems. `tuning` is an array (6 for guitar, 4 for bass). |
+| `song_info` | `{ type, title, artist, arrangement, arrangement_index, arrangements, duration, tuning, capo, format, audio_url, audio_error, stems }` | Song metadata. `arrangements` is the full list for the switcher. `audio_url` is `null` when audio is unavailable, in which case `audio_error` is non-null; otherwise `audio_error` is `null`. `stems` is always present — an empty array for non-sloppak songs or sloppak songs with no split stems. `tuning` is an array (6 for guitar, 4 for bass). |
 | `beats` | `{ type, data: [{ time, measure }] }` | Beat timestamps with measure numbers |
 | `sections` | `{ type, data: [{ time, name }] }` | Named sections (Intro, Verse, Chorus, etc.) |
 | `anchors` | `{ type, data: [{ time, fret, width }] }` | Fret zoom anchors |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Plugins are the primary extension point. Each plugin lives in `plugins/<name>/` 
 
 All fields except `id` and `name` are optional. Plugins can have any combination of frontend (screen/script), backend (routes), and settings.
 
+`version` and `private` are advisory metadata — the plugin loader does not currently consume them, but plugins commonly include them for publishing/tooling purposes.
+
 **Backend routes** — `routes.py` must export a `setup(app, context)` function. The `context` dict provides:
 - `config_dir` — persistent config path
 - `get_dlc_dir()` — returns the DLC folder Path
@@ -184,7 +186,7 @@ The highway WebSocket at `/ws/highway/{filename}?arrangement={index}` streams th
 | Message | Shape | Description |
 |---------|-------|-------------|
 | `loading` | `{ type: 'loading', stage }` | Status/progress message during extraction or conversion |
-| `song_info` | `{ type, title, artist, arrangement, duration, tuning, capo }` | Song metadata. `tuning` is an array (6 for guitar, 4 for bass). |
+| `song_info` | `{ type, title, artist, arrangement, arrangement_index, arrangements, duration, tuning, capo, format, audio_url, audio_error?, stems? }` | Song metadata. `arrangements` is the full list for the switcher; `audio_error` only appears when audio conversion failed; `stems` only on sloppak songs with split stems. `tuning` is an array (6 for guitar, 4 for bass). |
 | `beats` | `{ type, data: [{ time, measure }] }` | Beat timestamps with measure numbers |
 | `sections` | `{ type, data: [{ time, name }] }` | Named sections (Intro, Verse, Chorus, etc.) |
 | `anchors` | `{ type, data: [{ time, fret, width }] }` | Fret zoom anchors |


### PR DESCRIPTION
## Summary

Two factual tightenings in the AI-agent guide, carried over from the [#73](https://github.com/byrongamatos/slopsmith/pull/73) review's non-blocking follow-up issue ([#74](https://github.com/byrongamatos/slopsmith/issues/74)).

1. **`song_info` shape is now complete.** The WebSocket Protocol Reference row for `song_info` documented 7 of the 13 fields the server actually sends at \`server.py:1236\`. Plugin authors reading the doc would miss `arrangement_index`, `arrangements` (the full switcher list), `audio_url`, `audio_error`, `format`, and `stems` entirely. The row now reflects the full payload with `?` on the fields that only appear conditionally, plus one-line notes on when they do.
2. **Manifest example + prose note.** The example shows `version` and `private`, fields the plugin loader does not currently read. Real plugins on disk (notedetect, 3dhighway, etc.) DO include them — so dropping them from the example would make it drift from actual manifests. Added a prose note clarifying they're advisory metadata for publishing/tooling rather than something the loader consumes.

## Test plan

- [x] Verified against current `server.py:1236-1250` that the expanded `song_info` row is accurate
- [x] Verified against `plugins/__init__.py` that the loader really only reads `id`, `name`, `routes`, `nav`, `screen`, `script`, `settings`
- [ ] Render check on GitHub that the `song_info` table row still parses as a 3-column row

Closes #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)