### PR TITLE
feat: expose getChordTemplates() for overlay plugins (slopsmith#91)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,7 @@ Plugins that add a layer on top of whichever visualization is active — HUDs, f
 
 - `highway.getTime()` / `highway.getBeats()` — current playback position
 - `highway.getNotes()` / `highway.getChords()` — difficulty-filter-aware arrays
+- `highway.getChordTemplates()` — chord shape lookup table; index by `chord.id` from `getChords()` to get `{ name, fingers, frets }`. Not filter-aware: templates are static metadata, every `chord_id` referenced by `getChords()` is guaranteed valid
 - `highway.getSongInfo()` — tuning, arrangement, capo
 - `highway.getLefty()` / `highway.getInverted()` — mirror + invert state
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,7 @@ Plugins that add a layer on top of whichever visualization is active — HUDs, f
 
 - `highway.getTime()` / `highway.getBeats()` — current playback position
 - `highway.getNotes()` / `highway.getChords()` — difficulty-filter-aware arrays
-- `highway.getChordTemplates()` — chord shape lookup table; index by `chord.id` from `getChords()` to get `{ name, fingers, frets }`. Not filter-aware: templates are static metadata, every `chord_id` referenced by `getChords()` is guaranteed valid
+- `highway.getChordTemplates()` — chord shape lookup table; index by `chord.id` from `getChords()` to get `{ name, fingers, frets }`. `fingers` and `frets` are per-string arrays (length matches the tuning's string count); within `fingers`, `-1` = unused, `0` = open string, `n > 0` = finger number. RS XML sources populate real fingerings; GP imports currently emit all `-1` since pre-import sources don't carry finger data. Not filter-aware: templates are static metadata, every `chord_id` referenced by `getChords()` is guaranteed valid
 - `highway.getSongInfo()` — tuning, arrangement, capo
 - `highway.getLefty()` / `highway.getInverted()` — mirror + invert state
 

--- a/server.py
+++ b/server.py
@@ -1339,10 +1339,20 @@ async def highway_ws(websocket: WebSocket, filename: str, arrangement: int = -1)
         anchors = [{"time": a.time, "fret": a.fret, "width": a.width} for a in arr.anchors]
         await websocket.send_json({"type": "anchors", "data": anchors})
 
-        # Send chord templates
+        # Send chord templates. Include `fingers` alongside `name` /
+        # `frets` so plugin overlays consuming highway.getChordTemplates()
+        # can render full chord boxes (Rocksmith-style fingering
+        # diagrams), not just chord names. Each fingering entry is
+        # per-string: -1 = unused, 0 = open string, n > 0 = finger
+        # number. RS XML sources populate real values; GP imports
+        # currently emit all -1 (no finger data available pre-import).
         templates = []
         for ct in arr.chord_templates:
-            templates.append({"name": ct.name, "frets": ct.frets})
+            templates.append({
+                "name": ct.name,
+                "fingers": ct.fingers,
+                "frets": ct.frets,
+            })
         await websocket.send_json({"type": "chord_templates", "data": templates})
 
         # Send lyrics if available

--- a/static/highway.js
+++ b/static/highway.js
@@ -1339,7 +1339,7 @@ function createHighway() {
             _resizeHandler = () => this.resize();
             window.addEventListener('resize', _resizeHandler);
             ready = false;
-            notes = []; chords = []; beats = []; sections = []; anchors = []; lyrics = []; toneChanges = []; toneBase = "";
+            notes = []; chords = []; beats = []; sections = []; anchors = []; chordTemplates = []; lyrics = []; toneChanges = []; toneBase = "";
             // Reset phrase ladder + filter (slopsmith#48). _mastery
             // persists across arrangement switches — the slider's
             // position stays put. Filter rebuilds on the next `ready`
@@ -1626,6 +1626,14 @@ function createHighway() {
         getTime() { return currentTime; },
         getNotes() { return notes; },
         getChords() { return chords; },
+        // Live reference to the chord-template lookup table —
+        // `getChords()[i].id` is an index into this array. Each
+        // template carries `{ name, fingers, frets }`. Read-only:
+        // overlay plugins should NOT mutate the array or its
+        // entries. Not difficulty-filter-aware (templates are static
+        // metadata; every chord_id referenced by `getChords()` is
+        // guaranteed valid).
+        getChordTemplates() { return chordTemplates; },
         getToneChanges() { return toneChanges; },
         getToneBase() { return toneBase; },
         getSections() { return sections; },
@@ -1655,7 +1663,7 @@ function createHighway() {
             // Close old WS but keep audio + animation running
             if (ws) { ws.close(); ws = null; }
             ready = false;
-            notes = []; chords = []; beats = []; sections = []; anchors = []; lyrics = []; toneChanges = []; toneBase = "";
+            notes = []; chords = []; beats = []; sections = []; anchors = []; chordTemplates = []; lyrics = []; toneChanges = []; toneBase = "";
             // Reset phrase ladder + filter (slopsmith#48). _mastery
             // persists across arrangement switches — the slider's
             // position stays put. Filter rebuilds on the next `ready`

--- a/static/highway.js
+++ b/static/highway.js
@@ -1628,11 +1628,18 @@ function createHighway() {
         getChords() { return chords; },
         // Live reference to the chord-template lookup table —
         // `getChords()[i].id` is an index into this array. Each
-        // template carries `{ name, fingers, frets }`. Read-only:
-        // overlay plugins should NOT mutate the array or its
-        // entries. Not difficulty-filter-aware (templates are static
-        // metadata; every chord_id referenced by `getChords()` is
-        // guaranteed valid).
+        // template carries `{ name, fingers, frets }`:
+        //   - name:    chord name string ("Em", "Cmaj7", …)
+        //   - fingers: per-string finger numbers (length matches
+        //              the tuning's string count; -1 = unused, 0 =
+        //              open string, n > 0 = finger number). RS XML
+        //              sources populate real values; GP imports
+        //              currently emit all -1.
+        //   - frets:   per-string fret numbers, same indexing.
+        // Read-only: overlay plugins should NOT mutate the array or
+        // its entries. Not difficulty-filter-aware (templates are
+        // static metadata; every chord_id referenced by `getChords()`
+        // is guaranteed valid).
         getChordTemplates() { return chordTemplates; },
         getToneChanges() { return toneChanges; },
         getToneBase() { return toneBase; },


### PR DESCRIPTION
## Summary

Closes #91.

Overlay plugins (per CLAUDE.md's "Overlay contract") read public highway state via the getter API. Chord-name display has been blocked for them because chord events from `getChords()` carry only an `.id` referencing the templates array — and the array itself wasn't exposed.

## Changes

1. **`highway.getChordTemplates()`** — new public getter returning the live `chordTemplates` array. Same convention as the existing getters (`getNotes` / `getChords` / etc. — read-only live ref).

2. **`fingers` added to the `chord_templates` WS payload** — server.py was sending `{ name, frets }` only; the Python `ChordTemplate` dataclass carried `fingers` but the wire serializer dropped it. Codex caught this in pre-push review (the originally-shipped commit documented `{ name, fingers, frets }` but the server only sent name + frets, so overlay plugins drawing fingering would have hit `undefined`). Now real RS XML fingerings flow through; GP imports emit `[-1] * 6` placeholders (`gp2rs.py` doesn't parse finger data from GP files).

3. **`chordTemplates` reset in `api.init()` + `reconnect()`** — pre-existing latent inconsistency. The other arrays (`notes`, `chords`, `beats`, `sections`, `anchors`, `lyrics`, `toneChanges`, `toneBase`) already reset on song change; `chordTemplates` was the lone holdout. Without this, an overlay plugin reading `getChordTemplates()` during the brief WS-reconnect window would see the previous song's data until the new `chord_templates` message arrives.

4. **CLAUDE.md** — add the new getter to the overlay-contract list, with `{ name, fingers, frets }` shape documented (per-string finger semantics: `-1` = unused, `0` = open string, `n > 0` = finger number) and a "not filter-aware" qualifier matching the convention of the sibling bullet.

## Plugin usage

```js
const chord = highway.getChords()[i];
const tmpl  = highway.getChordTemplates()[chord.id];
const name  = tmpl?.name;     // "Em", "Cmaj7", etc.
// Optional fingering — RS XML sources only:
tmpl?.fingers.forEach((f, str) => {
    if (f > 0) drawFingerNumber(str, tmpl.frets[str], f);
});
```

## Test plan

- [ ] Browser DevTools: open a song with chord shapes, confirm `highway.getChordTemplates()` returns a populated array.
- [ ] `highway.getChordTemplates()[highway.getChords()[0].id]` returns `{ name, fingers, frets }`.
- [ ] Same call returns the same reference twice (live ref, not copy).
- [ ] Switch song → `getChordTemplates()` is `[]` during the loading window, then repopulates.
- [ ] RS XML source: `fingers` carries real finger numbers (open chords like Em should have a recognizable pattern).
- [ ] GP import source: `fingers` is `[-1] * 6` placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)