### PR TITLE
fix: keep player controls above viz-plugin overlays

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -17,6 +17,12 @@ html { scroll-behavior: smooth; }
     background: #050508;
 }
 #highway { flex: 1; width: 100%; min-height: 0; }
+/* Establish a stacking context so absolutely-positioned overlays from viz
+   plugins (e.g. 3dhighway's WebGL wrap) can't paint over the controls.
+   Was previously set at runtime by the splitscreen plugin's injectBtn
+   hook; doing it in core means the picker stays visible before / without
+   splitscreen too. */
+#player-controls { position: relative; z-index: 10; }
 
 /* Song cards */
 .song-card {


### PR DESCRIPTION
## Summary
\`#player-controls\` had no positioning context, so any \`z-index\` was a no-op. Viz plugins that paint absolutely-positioned overlays (e.g. 3dhighway's WebGL wrap at \`z-index:2\`) covered the bottom controls bar — picker, buttons, sliders all invisible (but click-throughable, since the wrap uses \`pointer-events:none\`).

The splitscreen plugin had been masking this by setting \`position:relative; z-index:10\` at runtime in its \`injectBtn\` hook on first \`playSong\`. That fixed the symptom *only* after a song had played at least once and *only* when splitscreen was loaded. Without splitscreen (or before the first play), the controls were hidden behind the 3D wrap.

This PR sets \`position:relative; z-index:10\` on \`#player-controls\` in core CSS so the stack is correct from the start.

## Repro (before)
1. Pull a build that includes the 3dhighway plugin but not splitscreen (or has splitscreen but you haven't pressed Play yet).
2. Open a song. The visualization picker, mixer button, lyrics toggle, etc. all sit underneath the WebGL canvas — \`document.elementFromPoint\` on their bounding rect returns the highway canvas, not the control.

## After
- \`#player-controls\` establishes its own stacking context, paints above any \`z-index < 10\` overlay.
- Splitscreen's runtime patch is now redundant; left in place because removing it is a separate refactor and it's a no-op when the CSS already covers the same ground.

## Test plan
- [ ] In a build with 3dhighway as the active viz, the bottom controls bar is visible immediately on entering the player (before pressing Play).
- [ ] Splitscreen still works the same way (the runtime z-index assignment is idempotent with the CSS).