### PR TITLE
fix: execute <script> tags in plugin settings.html

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1658,6 +1658,25 @@ async function loadPlugins() {
 
                 const settingsResp = await fetch(`/api/plugins/${plugin.id}/settings.html`);
                 settingsDiv.innerHTML = await settingsResp.text();
+                // <script> tags inserted via innerHTML are intentionally
+                // inert per the HTML5 spec — the browser parses them as
+                // DOM nodes but never runs the body. That silently breaks
+                // any plugin settings.html that wires event handlers via
+                // addEventListener (e.g. file pickers, anything that
+                // can't be expressed as an inline onclick=… attribute),
+                // and any inline IIFE that hydrates form values from
+                // localStorage. Re-create each script node — script
+                // elements created via document.createElement DO execute
+                // when appended — so plugins get the script behavior
+                // they'd expect from a normal HTML document.
+                settingsDiv.querySelectorAll('script').forEach(oldScript => {
+                    const newScript = document.createElement('script');
+                    for (const attr of oldScript.attributes) {
+                        newScript.setAttribute(attr.name, attr.value);
+                    }
+                    newScript.textContent = oldScript.textContent;
+                    oldScript.parentNode.replaceChild(newScript, oldScript);
+                });
             }
 
             // Load plugin JS


### PR DESCRIPTION
## Summary
Plugin settings panels are loaded via \`settingsDiv.innerHTML = await settingsResp.text();\` (\`static/app.js:1660\`). Per the HTML5 spec, \`<script>\` tags inserted via \`innerHTML\` are parsed as DOM nodes but **never execute**. This silently breaks any plugin \`settings.html\` that wires event handlers via \`addEventListener\` from an inline IIFE — and any hydration logic that reads localStorage on panel open.

## Symptom
Discovered via the 3dhighway custom-image upload (\`slopsmith-plugin-3dhighway#30\`):
- File picker accepts an image, but the \"Custom image\" option in the style dropdown stays grayed out.
- Ctrl+R refresh loses the upload (the setter that writes to localStorage lives inside the IIFE that never ran).
- Hydration of persisted form state never runs either.

The same bug will hit the in-flight video picker (\`slopsmith-plugin-3dhighway#31\`) and any future plugin that needs more than inline attribute handlers.

## Fix
Five-line patch: after \`innerHTML\` injects the panel, walk the new DOM, find each \`<script>\` node, and re-create it via \`document.createElement('script')\`. Script elements created that way DO execute when appended.

## Test plan
- [ ] Reload UI, open the 3D Highway settings panel, upload a JPG/PNG/WebP. Style dropdown's \"Custom image\" option becomes selectable. Refresh — option stays selectable, asset persists.
- [ ] Confirm palette dropdown and intensity slider still work (they used inline attribute handlers and shouldn't be affected).
- [ ] No regressions in other plugin settings panels (notedetect, splitscreen, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)