### PR TITLE
Insulate plugins from cross-plugin module-name collisions (#33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ All fields except `id` and `name` are optional. Plugins can have any combination
 
 **Sibling imports — use `load_sibling`, not bare imports** (slopsmith#33). The plugin loader inserts each plugin's directory onto `sys.path` so `from extractor import X` works, but Python caches imports by **module name** in `sys.modules`. Two plugins that each ship a top-level `extractor.py` (or any other generic name — `util.py`, `client.py`, `parser.py`, `config.py`, …) collide: whichever loads first wins, and the other plugin's `from extractor import X` either gets the wrong module or fails with `cannot import name 'X' from 'extractor'`.
 
-The fix is `context["load_sibling"](name)`, which loads the sibling under a namespaced module name (`plugin_<id>.<name>`, with `.` in plugin_id escaped to `_x2e_` so reverse-DNS-style ids like `com.example.foo` work) so each plugin gets its own copy:
+The fix is `context["load_sibling"](name)`, which loads the sibling under a namespaced module name (`plugin_<id>.<name>`, where plugin_id is bijectively encoded so reverse-DNS-style ids like `com.example.foo` work without colliding: `_` -> `_5f_`, `.` -> `_2e_`) so each plugin gets its own copy:
 
 ```python
 def setup(app, context):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,24 @@ All fields except `id` and `name` are optional. Plugins can have any combination
 - `extract_meta()` — metadata extraction callable
 - `meta_db` — shared MetadataDB instance
 - `get_sloppak_cache_dir()` — sloppak cache path
+- `load_sibling(name)` — loads a sibling `.py` file from this plugin's directory under a unique, namespaced module name. See "Sibling imports" below.
+
+**Sibling imports — use `load_sibling`, not bare imports** (slopsmith#33). The plugin loader inserts each plugin's directory onto `sys.path` so `from extractor import X` works, but Python caches imports by **module name** in `sys.modules`. Two plugins that each ship a top-level `extractor.py` (or any other generic name — `util.py`, `client.py`, `parser.py`, `config.py`, …) collide: whichever loads first wins, and the other plugin's `from extractor import X` either gets the wrong module or fails with `cannot import name 'X' from 'extractor'`.
+
+The fix is `context["load_sibling"](name)`, which loads the sibling under a namespaced module name (`plugin_<id>_<name>`) so each plugin gets its own copy:
+
+```python
+def setup(app, context):
+    extractor = context["load_sibling"]("extractor")
+    PsarcReader = extractor.PsarcReader
+    # …
+```
+
+Notes:
+- `name` is a bare module name — no `.py` suffix, no slashes. The helper raises `ValueError` for path traversal attempts and `ImportError` for missing files.
+- Repeat calls return the cached module (same `sys.modules` entry).
+- The transitive case (a sibling that itself wants its own siblings) is not yet automatic — pass `load_sibling` down as a parameter, or rely on bare imports if the helper module names are already plugin-specific.
+- Bare `import sibling` from `routes.py` still works during the transition period, but the loader prints a startup warning when it detects two plugins shipping a same-named top-level `.py` file. Migrate to `load_sibling` to silence the warning and immunize your plugin from future ecosystem collisions.
 
 **Frontend scripts** — `screen.js` runs in the global scope via a `<script>` tag. It can access `window.playSong`, `window.showScreen`, `window.createHighway`, the `<audio>` element, and the `window.slopsmith` event emitter.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,11 +60,11 @@ All fields except `id` and `name` are optional. Plugins can have any combination
 - `extract_meta()` — metadata extraction callable
 - `meta_db` — shared MetadataDB instance
 - `get_sloppak_cache_dir()` — sloppak cache path
-- `load_sibling(name)` — loads a sibling `.py` file from this plugin's directory under a unique, namespaced module name. See "Sibling imports" below.
+- `load_sibling(name)` — loads a sibling module from this plugin's directory under a unique, namespaced module name. See "Sibling imports" below.
 
 **Sibling imports — use `load_sibling`, not bare imports** (slopsmith#33). The plugin loader inserts each plugin's directory onto `sys.path` so `from extractor import X` works, but Python caches imports by **module name** in `sys.modules`. Two plugins that each ship a top-level `extractor.py` (or any other generic name — `util.py`, `client.py`, `parser.py`, `config.py`, …) collide: whichever loads first wins, and the other plugin's `from extractor import X` either gets the wrong module or fails with `cannot import name 'X' from 'extractor'`.
 
-The fix is `context["load_sibling"](name)`, which loads the sibling under a namespaced module name (`plugin_<id>_<name>`) so each plugin gets its own copy:
+The fix is `context["load_sibling"](name)`, which loads the sibling under a namespaced module name (`plugin_<id>.<name>`, with `.` in plugin_id escaped to `_x2e_` so reverse-DNS-style ids like `com.example.foo` work) so each plugin gets its own copy:
 
 ```python
 def setup(app, context):
@@ -74,10 +74,12 @@ def setup(app, context):
 ```
 
 Notes:
-- `name` is a bare module name — no `.py` suffix, no slashes. The helper raises `ValueError` for path traversal attempts and `ImportError` for missing files.
-- Repeat calls return the cached module (same `sys.modules` entry).
-- The transitive case (a sibling that itself wants its own siblings) is not yet automatic — pass `load_sibling` down as a parameter, or rely on bare imports if the helper module names are already plugin-specific.
-- Bare `import sibling` from `routes.py` still works during the transition period, but the loader prints a startup warning when it detects two plugins shipping a same-named top-level `.py` file. Migrate to `load_sibling` to silence the warning and immunize your plugin from future ecosystem collisions.
+- `name` is a bare module name — no `.py` suffix, no slashes, no `.`. The helper raises `ValueError` for path traversal / format issues and `ImportError` for missing files.
+- Both single-file siblings (`extractor.py`) and package-form siblings (`extractor/__init__.py`) work. Package form wins when both exist (matches CPython's import-resolution precedence).
+- Relative imports between siblings work — `from .shared import X` in a top-level helper, `from ..shared import X` from inside a sibling package. The synthetic parent package `plugin_<id>` carries the plugin directory in its `__path__`.
+- `from . import sibling` (attribute-style) also resolves: loaded children are exposed as attributes on the parent package.
+- Repeat calls return the cached module. Concurrent first-time calls are serialized via per-module locks so no caller observes a half-initialized module.
+- Bare `import sibling` from `routes.py` still works during the transition period, but the loader prints a startup warning when it detects two plugins shipping a same-named top-level module — covering both `.py` files and package directories. Migrate to `load_sibling` to silence the warning and immunize your plugin from future ecosystem collisions. (Don't mix bare imports and `load_sibling` for the same module — they'd execute the file twice and split module-level state.)
 
 **Frontend scripts** — `screen.js` runs in the global scope via a `<script>` tag. It can access `window.playSong`, `window.showScreen`, `window.createHighway`, the `<audio>` element, and the `window.slopsmith` event emitter.
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -106,18 +106,32 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     # collision bug) will not match this path and we'll load our own
     # under the namespaced key. Without this, load_sibling would
     # double-exec the file and any module-level singletons / caches
-    # / registrations would split into two copies. Spotted by codex
-    # review on PR for slopsmith#33.
-    bare_cached = sys.modules.get(name)
-    if bare_cached is not None:
-        bare_file = getattr(bare_cached, "__file__", None)
-        try:
-            same_file = bool(bare_file) and Path(bare_file).resolve() == sibling_path.resolve()
-        except OSError:
-            same_file = False
-        if same_file:
-            sys.modules[module_name] = bare_cached
-            return bare_cached
+    # / registrations would split into two copies.
+    #
+    # Limited to FILE-form siblings: a package-form bare import keeps
+    # `__package__`, `__spec__.name`, and `__name__` set to the
+    # un-namespaced bare name, so lazy relative imports inside the
+    # package (`from .child import X` in a function body, or
+    # `importlib.import_module(__package__ + '.child')`) would keep
+    # resolving `extractor.child` through the global sys.path cache.
+    # Two plugins that both shipped `extractor/` could still
+    # cross-load submodules on the migration path. Re-executing the
+    # package under the namespaced spec is safer; the trade-off is
+    # that module-level state in the package-form sibling will exist
+    # under both `extractor` and `plugin_<id>.extractor` until the
+    # plugin removes its bare imports. Spotted by codex review on
+    # PR for slopsmith#33.
+    if submodule_search is None:
+        bare_cached = sys.modules.get(name)
+        if bare_cached is not None:
+            bare_file = getattr(bare_cached, "__file__", None)
+            try:
+                same_file = bool(bare_file) and Path(bare_file).resolve() == sibling_path.resolve()
+            except OSError:
+                same_file = False
+            if same_file:
+                sys.modules[module_name] = bare_cached
+                return bare_cached
     spec = importlib.util.spec_from_file_location(
         module_name,
         str(sibling_path),
@@ -162,7 +176,13 @@ def _warn_on_module_collisions(plugin_specs):
     `plugin_specs` is a list of `(plugin_id, plugin_dir)` tuples for
     plugins the loader has decided to load (post-dedup).
     """
-    by_name: dict[str, list[str]] = {}
+    # Map: module_name -> {plugin_id: set_of_kinds}.
+    # Using a per-plugin nested dict deduplicates the case where ONE
+    # plugin ships both `extractor.py` and `extractor/__init__.py`
+    # — that intra-plugin layout is supported by load_sibling (file
+    # form wins) and shouldn't trip a cross-plugin collision warning.
+    # Spotted by codex review on PR for slopsmith#33.
+    by_name: dict[str, dict[str, set[str]]] = {}
     for plugin_id, plugin_dir in plugin_specs:
         try:
             for child in plugin_dir.iterdir():
@@ -180,25 +200,24 @@ def _warn_on_module_collisions(plugin_specs):
                     kind = "package"
                 if module_name is None:
                     continue
-                by_name.setdefault(module_name, []).append((plugin_id, kind))
+                by_name.setdefault(module_name, {}).setdefault(plugin_id, set()).add(kind)
         except OSError:
             # Unreadable plugin dir — the per-plugin load below will
             # surface the error in a more useful place; don't warn here.
             continue
-    for name, entries in by_name.items():
-        if len(entries) < 2:
+    for name, by_plugin in by_name.items():
+        # Count distinct plugin ids — only fire when MULTIPLE plugins
+        # ship the same module name. A single plugin shipping the
+        # name in multiple forms is fine.
+        if len(by_plugin) < 2:
             continue
-        ids_quoted = ", ".join(
-            f"'{pid}'" for pid, _ in sorted(entries, key=lambda e: e[0])
-        )
-        # Mention which form (module vs package) shows up if it's
-        # not all one or the other — helps maintainers spot the
-        # `extractor.py` vs `extractor/__init__.py` mixed case.
-        kinds = {k for _, k in entries}
+        ids_quoted = ", ".join(f"'{pid}'" for pid in sorted(by_plugin))
+        # Aggregate kinds across all plugins to label the warning.
+        kinds = {k for kind_set in by_plugin.values() for k in kind_set}
         kind_label = "module/package" if len(kinds) > 1 else next(iter(kinds))
         print(
             f"[Plugin] Module-name collision warning: '{name}' "
-            f"({kind_label}) is shipped by {len(entries)} plugins "
+            f"({kind_label}) is shipped by {len(by_plugin)} plugins "
             f"({ids_quoted}). Bare `import {name}` may load the wrong "
             f"file. Migrate to context['load_sibling']('{name}') — "
             f"see CLAUDE.md (slopsmith#33)."

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -16,6 +16,25 @@ LOADED_PLUGINS = []
 # Persistent pip install location (survives container restarts)
 _PIP_TARGET = Path(os.environ.get("CONFIG_DIR", "/config")) / "pip_packages"
 
+# Per-module-name locks for `_load_plugin_sibling` so two threads
+# calling `ctx['load_sibling']('extractor')` concurrently don't both
+# see the half-initialized module after the first has registered it
+# in sys.modules but before exec_module finishes. Stored in a dict
+# guarded by an outer lock — a fresh per-name lock is created on
+# first contention. Spotted by codex review on PR for slopsmith#33.
+import threading as _threading
+_sibling_lock_dict_lock = _threading.Lock()
+_sibling_locks: dict[str, _threading.Lock] = {}
+
+
+def _get_sibling_lock(module_name: str) -> _threading.Lock:
+    with _sibling_lock_dict_lock:
+        lock = _sibling_locks.get(module_name)
+        if lock is None:
+            lock = _threading.Lock()
+            _sibling_locks[module_name] = lock
+        return lock
+
 
 def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     """Load a sibling .py file from a plugin's directory under a namespaced
@@ -63,9 +82,12 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     # convention is identifier-shaped) so the format stays unique.
     parent_name = f"plugin_{safe_plugin_id}"
     module_name = f"{parent_name}.{name}"
-    cached = sys.modules.get(module_name)
-    if cached is not None:
-        return cached
+    # NB: no pre-lock cached lookup here. A concurrent first-time
+    # caller can briefly observe a half-initialized module that the
+    # FIRST caller registered via `sys.modules[module_name] = module`
+    # before `exec_module` finished. The cached check happens inside
+    # the lock below so it serializes against the load. Spotted by
+    # codex review on PR for slopsmith#33 round 8.
     # Resolve `name` to either a top-level `.py` file (`extractor.py`)
     # or a package directory (`extractor/__init__.py`). Package form
     # is documented as a valid plugin layout (the collision-warning
@@ -113,62 +135,53 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
         parent = types.ModuleType(parent_name)
         parent.__path__ = [str(plugin_dir)]
         sys.modules[parent_name] = parent
-    # Mixed-migration reuse: if a bare `import {name}` already loaded
-    # THIS plugin's same file (via sys.path during the transition),
-    # reuse it instead of re-executing. The path equality check ensures
-    # we only reuse when it's actually our file — a bare import that
-    # resolved to a DIFFERENT plugin's same-named module (the original
-    # collision bug) will not match this path and we'll load our own
-    # under the namespaced key. Without this, load_sibling would
-    # double-exec the file and any module-level singletons / caches
-    # / registrations would split into two copies.
-    #
-    # Limited to FILE-form siblings: a package-form bare import keeps
-    # `__package__`, `__spec__.name`, and `__name__` set to the
-    # un-namespaced bare name, so lazy relative imports inside the
-    # package (`from .child import X` in a function body, or
-    # `importlib.import_module(__package__ + '.child')`) would keep
-    # resolving `extractor.child` through the global sys.path cache.
-    # Two plugins that both shipped `extractor/` could still
-    # cross-load submodules on the migration path. Re-executing the
-    # package under the namespaced spec is safer; the trade-off is
-    # that module-level state in the package-form sibling will exist
-    # under both `extractor` and `plugin_<id>.extractor` until the
-    # plugin removes its bare imports. Spotted by codex review on
+    # NB: We DON'T reuse bare-imported same-named modules here. The
+    # alias path looked attractive — module-level singletons stay
+    # shared across `import sibling` and `load_sibling('sibling')` —
+    # but the bare module's `__package__`/`__spec__.name`/`__name__`
+    # remain set to the un-namespaced bare name. Any relative import
+    # that runs after the alias (lazy `from .shared import X` inside
+    # a function, or `importlib.import_module(__package__ + '.X')`)
+    # then routes through the bare global cache, undoing the
+    # isolation. The right answer for plugins that mix bare imports
+    # with load_sibling on the SAME module is "stop mixing"; the
+    # transition cost is that the module's state exists under two
+    # cache keys until the bare imports are removed. Documented in
+    # CLAUDE.md / codex review on PR for slopsmith#33.
+
+    # Per-module lock so concurrent first-time callers of load_sibling
+    # serialize through exec_module — the second caller waits for the
+    # first to finish before observing the registered module instead
+    # of seeing a half-initialized object. Spotted by codex review on
     # PR for slopsmith#33.
-    if submodule_search is None:
-        bare_cached = sys.modules.get(name)
-        if bare_cached is not None:
-            bare_file = getattr(bare_cached, "__file__", None)
-            try:
-                same_file = bool(bare_file) and Path(bare_file).resolve() == sibling_path.resolve()
-            except OSError:
-                same_file = False
-            if same_file:
-                sys.modules[module_name] = bare_cached
-                return bare_cached
-    spec = importlib.util.spec_from_file_location(
-        module_name,
-        str(sibling_path),
-        submodule_search_locations=submodule_search,
-    )
-    if spec is None or spec.loader is None:
-        raise ImportError(
-            f"plugin {plugin_id!r}: could not build import spec for {name!r}"
+    with _get_sibling_lock(module_name):
+        cached = sys.modules.get(module_name)
+        if cached is not None:
+            return cached
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            str(sibling_path),
+            submodule_search_locations=submodule_search,
         )
-    module = importlib.util.module_from_spec(spec)
-    # Register before exec so the sibling can self-reference (e.g. for
-    # internal `import plugin_<id>_helper` patterns) without infinite
-    # recursion through this helper.
-    sys.modules[module_name] = module
-    try:
-        spec.loader.exec_module(module)
-    except BaseException:
-        # On exec failure, drop the half-initialized module so a
-        # retry doesn't return the broken object from cache.
-        sys.modules.pop(module_name, None)
-        raise
-    return module
+        if spec is None or spec.loader is None:
+            raise ImportError(
+                f"plugin {plugin_id!r}: could not build import spec for {name!r}"
+            )
+        module = importlib.util.module_from_spec(spec)
+        # Register before exec so the sibling can self-reference (e.g.
+        # for internal `import plugin_<id>.helper` patterns) without
+        # infinite recursion through this helper. Concurrent callers
+        # don't observe this half-initialized state because they're
+        # blocked on the lock.
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except BaseException:
+            # On exec failure, drop the half-initialized module so a
+            # retry doesn't return the broken object from cache.
+            sys.modules.pop(module_name, None)
+            raise
+        return module
 
 
 def _warn_on_module_collisions(plugin_specs):

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -19,11 +19,22 @@ _PIP_TARGET = Path(os.environ.get("CONFIG_DIR", "/config")) / "pip_packages"
 
 def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     """Load a sibling .py file from a plugin's directory under a namespaced
-    module name (`plugin_{plugin_id}_{name}`). Mirrors the routes-loading
+    module name (`plugin_{plugin_id}.{name}`). Mirrors the routes-loading
     pattern at the top of `load_plugins()` and shares its `sys.modules`
     cache, so two plugins that each ship `extractor.py` get distinct
     cached modules instead of stomping each other through `sys.path`.
     See slopsmith#33."""
+    if not isinstance(plugin_id, str) or not plugin_id or "." in plugin_id:
+        # Plugin ids containing `.` would make the namespaced cache
+        # key (`plugin_<id>.<name>`) ambiguous AND would prevent
+        # building the synthetic parent package — Python would treat
+        # `foo.bar` as "module bar inside package foo" but there's no
+        # package `plugin_foo`. Manifest convention is identifier-
+        # shaped ids, so this just enforces the convention loudly.
+        # Spotted by codex review on PR for slopsmith#33.
+        raise ValueError(
+            f"load_sibling: plugin_id must be a non-empty string without '.', got {plugin_id!r}"
+        )
     if (
         not isinstance(name, str)
         or not name
@@ -72,6 +83,21 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
             f"plugin {plugin_id!r}: no sibling module {name!r} at "
             f"{file_path} or {pkg_init}"
         )
+    # Register a synthetic parent package so relative imports inside
+    # a sibling package (`from .child import X`) and explicit lookups
+    # of submodules (`importlib.import_module('plugin_<id>.<name>.X')`)
+    # can resolve through the parent. The parent has an empty
+    # __path__: the plugin's dir is intentionally NOT on it, so that
+    # all sibling lookups continue to flow through this helper and
+    # don't accidentally pull in collision-prone names. Done BEFORE
+    # the bare-reuse check below so a mixed-migration package sibling
+    # still ends up with its parent registered. Spotted by codex
+    # review on PR for slopsmith#33.
+    if parent_name not in sys.modules:
+        import types
+        parent = types.ModuleType(parent_name)
+        parent.__path__ = []
+        sys.modules[parent_name] = parent
     # Mixed-migration reuse: if a bare `import {name}` already loaded
     # THIS plugin's same file (via sys.path during the transition),
     # reuse it instead of re-executing. The path equality check ensures
@@ -92,19 +118,6 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
         if same_file:
             sys.modules[module_name] = bare_cached
             return bare_cached
-    # Register a synthetic parent package so relative imports inside
-    # a sibling package (`from .child import X`) and explicit lookups
-    # of submodules (`importlib.import_module('plugin_<id>.<name>.X')`)
-    # can resolve through the parent. The parent has an empty
-    # __path__: the plugin's dir is intentionally NOT on it, so that
-    # all sibling lookups continue to flow through this helper and
-    # don't accidentally pull in collision-prone names. Spotted by
-    # codex review on PR for slopsmith#33.
-    if parent_name not in sys.modules:
-        import types
-        parent = types.ModuleType(parent_name)
-        parent.__path__ = []
-        sys.modules[parent_name] = parent
     spec = importlib.util.spec_from_file_location(
         module_name,
         str(sibling_path),

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -24,17 +24,20 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     cache, so two plugins that each ship `extractor.py` get distinct
     cached modules instead of stomping each other through `sys.path`.
     See slopsmith#33."""
-    if not isinstance(plugin_id, str) or not plugin_id or "." in plugin_id:
-        # Plugin ids containing `.` would make the namespaced cache
-        # key (`plugin_<id>.<name>`) ambiguous AND would prevent
-        # building the synthetic parent package — Python would treat
-        # `foo.bar` as "module bar inside package foo" but there's no
-        # package `plugin_foo`. Manifest convention is identifier-
-        # shaped ids, so this just enforces the convention loudly.
-        # Spotted by codex review on PR for slopsmith#33.
+    if not isinstance(plugin_id, str) or not plugin_id:
         raise ValueError(
-            f"load_sibling: plugin_id must be a non-empty string without '.', got {plugin_id!r}"
+            f"load_sibling: plugin_id must be a non-empty string, got {plugin_id!r}"
         )
+    # Escape `.` in plugin_id when forming the synthetic parent
+    # package name. The cache key is `parent.name` and Python's
+    # import machinery treats `.` as a package boundary, so a raw
+    # plugin_id like 'foo.bar' would collide with the parent
+    # registration. Use `_x2e_` (the hex code for `.`) as a clearly
+    # marked, identifier-shaped substitution. Plugin ids containing
+    # the literal substring `_x2e_` would in theory collide with
+    # ids containing `.`; that's vanishingly unlikely. Spotted
+    # across multiple codex review rounds on PR for slopsmith#33.
+    safe_plugin_id = plugin_id.replace(".", "_x2e_") if "." in plugin_id else plugin_id
     if (
         not isinstance(name, str)
         or not name
@@ -58,7 +61,7 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     # by codex review on PR for slopsmith#33. `.` is rejected in
     # `name` above; plugin_ids with `.` are degenerate (manifest
     # convention is identifier-shaped) so the format stays unique.
-    parent_name = f"plugin_{plugin_id}"
+    parent_name = f"plugin_{safe_plugin_id}"
     module_name = f"{parent_name}.{name}"
     cached = sys.modules.get(module_name)
     if cached is not None:
@@ -90,19 +93,25 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
             f"{file_path} or {pkg_init}"
         )
     # Register a synthetic parent package so relative imports inside
-    # a sibling package (`from .child import X`) and explicit lookups
-    # of submodules (`importlib.import_module('plugin_<id>.<name>.X')`)
-    # can resolve through the parent. The parent has an empty
-    # __path__: the plugin's dir is intentionally NOT on it, so that
-    # all sibling lookups continue to flow through this helper and
-    # don't accidentally pull in collision-prone names. Done BEFORE
-    # the bare-reuse check below so a mixed-migration package sibling
-    # still ends up with its parent registered. Spotted by codex
-    # review on PR for slopsmith#33.
+    # a sibling (e.g. `helper.py` doing `from .shared import X`, or
+    # a sibling package's `__init__.py` doing the same) and explicit
+    # lookups of `plugin_<id>.<name>` submodules can resolve through
+    # the parent. The parent's `__path__` points at the plugin's
+    # directory so the standard import machinery can FIND those
+    # siblings — that's what relative imports ultimately consult. It
+    # does NOT undermine the namespace isolation, because:
+    #   • bare `import sibling` still goes through sys.path (the
+    #     transition fallback for plugins that haven't migrated)
+    #   • `import plugin_<id>.sibling` lands in the namespaced
+    #     sys.modules entry — same key load_sibling uses, so caching
+    #     stays coherent
+    # Done BEFORE the bare-reuse check below so a mixed-migration
+    # package sibling still ends up with its parent registered.
+    # Spotted by codex review on PR for slopsmith#33.
     if parent_name not in sys.modules:
         import types
         parent = types.ModuleType(parent_name)
-        parent.__path__ = []
+        parent.__path__ = [str(plugin_dir)]
         sys.modules[parent_name] = parent
     # Mixed-migration reuse: if a bare `import {name}` already loaded
     # THIS plugin's same file (via sys.path during the transition),
@@ -320,20 +329,6 @@ def load_plugins(app: FastAPI, context: dict):
                 continue
             plugin_id = manifest.get("id")
             if not plugin_id:
-                continue
-            # Reject dotted ids at discovery so plugins don't load
-            # successfully and then blow up on the first
-            # `context['load_sibling'](...)` call. The helper's
-            # synthetic parent package machinery requires a
-            # `.`-free id; the manifest convention is identifier-
-            # shaped ids anyway. Spotted by codex review on PR for
-            # slopsmith#33.
-            if "." in plugin_id:
-                print(
-                    f"[Plugin] Refusing to load '{plugin_id}' from "
-                    f"{plugin_dir}: plugin id must not contain '.' "
-                    f"(slopsmith#33). Rename the id in plugin.json."
-                )
                 continue
             if plugin_id in loaded_ids:
                 print(f"[Plugin] Skipping duplicate '{plugin_id}' from {plugins_base_dir}")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -37,12 +37,15 @@ def _get_sibling_lock(module_name: str) -> _threading.Lock:
 
 
 def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
-    """Load a sibling .py file from a plugin's directory under a namespaced
-    module name (`plugin_{plugin_id}.{name}`). Mirrors the routes-loading
-    pattern at the top of `load_plugins()` and shares its `sys.modules`
-    cache, so two plugins that each ship `extractor.py` get distinct
-    cached modules instead of stomping each other through `sys.path`.
-    See slopsmith#33."""
+    """Load a sibling module from a plugin's directory under a namespaced
+    module name (`plugin_<plugin_id>.<name>`, with `.` in plugin_id
+    escaped to `_x2e_`). Both single-file siblings (`extractor.py`)
+    and package-form siblings (`extractor/__init__.py`) are supported;
+    package form wins when both exist (matches CPython's import
+    precedence). Mirrors the routes-loading pattern in `load_plugins()`
+    and shares its `sys.modules` cache, so two plugins that each ship
+    `extractor.py` get distinct cached modules instead of stomping each
+    other through `sys.path`. See slopsmith#33."""
     if not isinstance(plugin_id, str) or not plugin_id:
         raise ValueError(
             f"load_sibling: plugin_id must be a non-empty string, got {plugin_id!r}"
@@ -75,11 +78,11 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
         )
     # Use `.` as the separator between id and name so the cache key
     # is unambiguous when plugin_ids or names contain underscores —
-    # `f"plugin_{id}_{name}"` would collide when (id='a_b', name='c')
-    # and (id='a', name='b_c') both map to `plugin_a_b_c`. Spotted
-    # by codex review on PR for slopsmith#33. `.` is rejected in
-    # `name` above; plugin_ids with `.` are degenerate (manifest
-    # convention is identifier-shaped) so the format stays unique.
+    # an `_` separator would collide when (id='a_b', name='c') and
+    # (id='a', name='b_c') both map to `plugin_a_b_c`. `.` is
+    # rejected in `name` above; `.` in plugin_id is escaped via
+    # `safe_plugin_id` so the separator stays unambiguous. Spotted
+    # across multiple codex review rounds on PR for slopsmith#33.
     parent_name = f"plugin_{safe_plugin_id}"
     module_name = f"{parent_name}.{name}"
     # NB: no pre-lock cached lookup here. A concurrent first-time
@@ -219,9 +222,10 @@ def _warn_on_module_collisions(plugin_specs):
     # Map: module_name -> {plugin_id: set_of_kinds}.
     # Using a per-plugin nested dict deduplicates the case where ONE
     # plugin ships both `extractor.py` and `extractor/__init__.py`
-    # — that intra-plugin layout is supported by load_sibling (file
-    # form wins) and shouldn't trip a cross-plugin collision warning.
-    # Spotted by codex review on PR for slopsmith#33.
+    # — that intra-plugin layout is supported by load_sibling
+    # (package form wins, matching CPython precedence) and shouldn't
+    # trip a cross-plugin collision warning. Spotted by codex review
+    # on PR for slopsmith#33.
     by_name: dict[str, dict[str, set[str]]] = {}
     for plugin_id, plugin_dir in plugin_specs:
         try:
@@ -359,15 +363,15 @@ def load_plugins(app: FastAPI, context: dict):
                 print(f"[Plugin] Skipping duplicate '{plugin_id}' from {plugins_base_dir}")
                 continue
             loaded_ids.add(plugin_id)
-            plugin_load_specs.append((plugin_id, plugin_dir, manifest, plugins_base_dir))
+            plugin_load_specs.append((plugin_id, plugin_dir, manifest))
 
     # Warn before loading so authors see the message even if a colliding
     # plugin's setup itself blows up later in the loop.
     _warn_on_module_collisions(
-        [(plugin_id, plugin_dir) for plugin_id, plugin_dir, _, _ in plugin_load_specs]
+        [(plugin_id, plugin_dir) for plugin_id, plugin_dir, _ in plugin_load_specs]
     )
 
-    for plugin_id, plugin_dir, manifest, plugins_base_dir in plugin_load_specs:
+    for plugin_id, plugin_dir, manifest in plugin_load_specs:
         # Install plugin requirements if present
         _install_requirements(plugin_dir, plugin_id)
 
@@ -384,8 +388,9 @@ def load_plugins(app: FastAPI, context: dict):
         # (so plugin A can't mutate plugin B's view) and add a
         # `load_sibling` closure scoped to THIS plugin's id + dir.
         # The helper namespaces sibling modules as
-        # `plugin_{id}_{name}` so two plugins shipping the same
-        # filename get distinct cached modules. See slopsmith#33.
+        # `plugin_<id>.<name>` (with `.` in plugin_id escaped to
+        # `_x2e_`) so two plugins shipping the same filename get
+        # distinct cached modules. See slopsmith#33.
         plugin_context = dict(context)
         plugin_context["load_sibling"] = (
             lambda name, _pid=plugin_id, _pdir=plugin_dir:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -36,6 +36,22 @@ def _get_sibling_lock(module_name: str) -> _threading.Lock:
         return lock
 
 
+def _safe_plugin_id_for_module_name(plugin_id: str) -> str:
+    """Escape `.` in a plugin_id for use as part of a Python module name.
+
+    Plugin ids are opaque manifest values that can take reverse-DNS
+    forms like `com.example.foo`. Python's import machinery treats
+    `.` as a package boundary, so a raw plugin_id in a module name
+    (`plugin_com.example.foo.<...>`) would set `__package__` to a
+    dotted path that has nothing to do with this plugin. Replace `.`
+    with `_x2e_` (the hex code for `.`) so the result is a single
+    unambiguous identifier-shaped token. Plugin ids that contain the
+    literal substring `_x2e_` would in theory collide with ids
+    containing `.`; that's vanishingly unlikely. See slopsmith#33.
+    """
+    return plugin_id.replace(".", "_x2e_") if "." in plugin_id else plugin_id
+
+
 def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     """Load a sibling module from a plugin's directory under a namespaced
     module name (`plugin_<plugin_id>.<name>`, with `.` in plugin_id
@@ -50,16 +66,7 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
         raise ValueError(
             f"load_sibling: plugin_id must be a non-empty string, got {plugin_id!r}"
         )
-    # Escape `.` in plugin_id when forming the synthetic parent
-    # package name. The cache key is `parent.name` and Python's
-    # import machinery treats `.` as a package boundary, so a raw
-    # plugin_id like 'foo.bar' would collide with the parent
-    # registration. Use `_x2e_` (the hex code for `.`) as a clearly
-    # marked, identifier-shaped substitution. Plugin ids containing
-    # the literal substring `_x2e_` would in theory collide with
-    # ids containing `.`; that's vanishingly unlikely. Spotted
-    # across multiple codex review rounds on PR for slopsmith#33.
-    safe_plugin_id = plugin_id.replace(".", "_x2e_") if "." in plugin_id else plugin_id
+    safe_plugin_id = _safe_plugin_id_for_module_name(plugin_id)
     if (
         not isinstance(name, str)
         or not name
@@ -133,11 +140,19 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     # Done BEFORE the bare-reuse check below so a mixed-migration
     # package sibling still ends up with its parent registered.
     # Spotted by codex review on PR for slopsmith#33.
-    if parent_name not in sys.modules:
-        import types
-        parent = types.ModuleType(parent_name)
-        parent.__path__ = [str(plugin_dir)]
-        sys.modules[parent_name] = parent
+    # Use setdefault so two threads loading different siblings for
+    # the same plugin can't both pass an `in sys.modules` check and
+    # then overwrite each other's parent registration. Without this,
+    # a losing thread's freshly-built parent would replace the
+    # winner's parent that already had child attributes attached
+    # via setattr below — `from . import sibling` lookups would
+    # then fail. setdefault is atomic under the GIL, so the loser's
+    # ModuleType is silently discarded. Spotted by Copilot review
+    # on PR #105 round 2.
+    import types
+    new_parent = types.ModuleType(parent_name)
+    new_parent.__path__ = [str(plugin_dir)]
+    sys.modules.setdefault(parent_name, new_parent)
     # NB: We DON'T reuse bare-imported same-named modules here. The
     # alias path looked attractive — module-level singletons stay
     # shared across `import sibling` and `load_sibling('sibling')` —
@@ -384,13 +399,17 @@ def load_plugins(app: FastAPI, context: dict):
         if plugin_dir_str not in sys.path:
             sys.path.insert(0, plugin_dir_str)
 
-        # Build a per-plugin context: shallow-copy the shared one
-        # (so plugin A can't mutate plugin B's view) and add a
-        # `load_sibling` closure scoped to THIS plugin's id + dir.
-        # The helper namespaces sibling modules as
-        # `plugin_<id>.<name>` (with `.` in plugin_id escaped to
-        # `_x2e_`) so two plugins shipping the same filename get
-        # distinct cached modules. See slopsmith#33.
+        # Build a per-plugin context: dict-copy the shared mapping
+        # so plugin A re-binding `ctx['x']` doesn't leak into plugin
+        # B's view, then add a `load_sibling` closure scoped to THIS
+        # plugin's id + dir. (Note: the COPY is shallow — values
+        # stored in context are still the same objects across
+        # plugins, so e.g. `ctx['meta_db']` mutations are still
+        # observable everywhere by design.) The helper namespaces
+        # sibling modules as `plugin_<id>.<name>` (with `.` in
+        # plugin_id escaped to `_x2e_`) so two plugins shipping the
+        # same filename get distinct cached modules. See
+        # slopsmith#33.
         plugin_context = dict(context)
         plugin_context["load_sibling"] = (
             lambda name, _pid=plugin_id, _pdir=plugin_dir:
@@ -401,7 +420,15 @@ def load_plugins(app: FastAPI, context: dict):
         routes_file = manifest.get("routes")
         if routes_file:
             try:
-                module_name = f"plugin_{plugin_id}_routes"
+                # Escape `.` in plugin_id the same way load_sibling
+                # does. Without it, a plugin id like
+                # `com.example.foo` would land at
+                # `plugin_com.example.foo_routes` — which Python
+                # parses as a dotted module path, sets
+                # `__package__` to `plugin_com.example`, and breaks
+                # any relative imports inside routes.py. Spotted by
+                # Copilot review on PR #105 round 2.
+                module_name = f"plugin_{_safe_plugin_id_for_module_name(plugin_id)}_routes"
                 spec = importlib.util.spec_from_file_location(
                     module_name, str(plugin_dir / routes_file))
                 routes_module = importlib.util.module_from_spec(spec)

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -181,6 +181,18 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
             # retry doesn't return the broken object from cache.
             sys.modules.pop(module_name, None)
             raise
+        # Expose the loaded child as an attribute on the synthetic
+        # parent. Python's standard import machinery does this after
+        # `_find_and_load` so that `from . import sibling` and
+        # `from .. import sibling` work via attribute lookup. Without
+        # it, plugins that mix load_sibling with package-style
+        # relative imports get `ImportError: cannot import name
+        # 'sibling' from 'plugin_<id>'` even though sys.modules has
+        # the module. Spotted by codex review on PR for slopsmith#33
+        # round 9.
+        parent = sys.modules.get(parent_name)
+        if parent is not None:
+            setattr(parent, name, module)
         return module
 
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -37,19 +37,34 @@ def _get_sibling_lock(module_name: str) -> _threading.Lock:
 
 
 def _safe_plugin_id_for_module_name(plugin_id: str) -> str:
-    """Escape `.` in a plugin_id for use as part of a Python module name.
+    """Bijectively encode a plugin_id for safe use as part of a Python
+    module name.
 
     Plugin ids are opaque manifest values that can take reverse-DNS
-    forms like `com.example.foo`. Python's import machinery treats
-    `.` as a package boundary, so a raw plugin_id in a module name
-    (`plugin_com.example.foo.<...>`) would set `__package__` to a
-    dotted path that has nothing to do with this plugin. Replace `.`
-    with `_x2e_` (the hex code for `.`) so the result is a single
-    unambiguous identifier-shaped token. Plugin ids that contain the
-    literal substring `_x2e_` would in theory collide with ids
-    containing `.`; that's vanishingly unlikely. See slopsmith#33.
+    forms (`com.example.foo`) or contain other characters that
+    Python's import machinery interprets specially — most
+    importantly `.`, which it treats as a package boundary.
+
+    The encoding is **bijective** so distinct plugin_ids always map
+    to distinct encoded strings (otherwise two installed plugins
+    could share a cache-key prefix and reintroduce the cross-plugin
+    collision this PR is fixing). To make `_<hex>_` sequences in
+    the output ONLY appear as a result of intentional escapes, the
+    underscore is encoded first:
+
+      `_` → `_5f_`   (hex of `_`)
+      `.` → `_2e_`   (hex of `.`, applied after the `_` pass)
+
+    With this scheme:
+      `foo`            → `foo`
+      `foo_bar`        → `foo_5f_bar`
+      `foo.bar`        → `foo_2e_bar`
+      `foo_2e_bar`     → `foo_5f_2e_5f_bar`  (distinct from `foo.bar`)
+      `com.example.x`  → `com_2e_example_2e_x`
+
+    Spotted across multiple Copilot review rounds on PR #105.
     """
-    return plugin_id.replace(".", "_x2e_") if "." in plugin_id else plugin_id
+    return plugin_id.replace("_", "_5f_").replace(".", "_2e_")
 
 
 def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
@@ -355,9 +370,9 @@ def load_plugins(app: FastAPI, context: dict):
     loaded_ids = set()
     # Two-pass discovery so we can warn about cross-plugin module-name
     # collisions BEFORE any plugin's setup runs (slopsmith#33). The
-    # first pass collects (plugin_id, plugin_dir, manifest, base_dir)
-    # tuples in load order; the second pass actually executes each
-    # plugin's setup with a per-plugin context.
+    # first pass collects (plugin_id, plugin_dir, manifest) tuples in
+    # load order; the second pass actually executes each plugin's
+    # setup with a per-plugin context.
     plugin_load_specs = []
     for plugins_base_dir in plugin_dirs:
         for plugin_dir in sorted(plugins_base_dir.iterdir()):
@@ -373,6 +388,17 @@ def load_plugins(app: FastAPI, context: dict):
                 continue
             plugin_id = manifest.get("id")
             if not plugin_id:
+                continue
+            # Validate type explicitly. A malformed manifest with a
+            # non-string id (number, list, ...) would otherwise crash
+            # later when `.replace()` runs in
+            # `_safe_plugin_id_for_module_name`. Spotted by Copilot
+            # review on PR #105 round 3.
+            if not isinstance(plugin_id, str):
+                print(
+                    f"[Plugin] Skipping {manifest_path}: 'id' must be a string, "
+                    f"got {type(plugin_id).__name__} ({plugin_id!r})"
+                )
                 continue
             if plugin_id in loaded_ids:
                 print(f"[Plugin] Skipping duplicate '{plugin_id}' from {plugins_base_dir}")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -16,25 +16,6 @@ LOADED_PLUGINS = []
 # Persistent pip install location (survives container restarts)
 _PIP_TARGET = Path(os.environ.get("CONFIG_DIR", "/config")) / "pip_packages"
 
-# Per-module-name locks for `_load_plugin_sibling` so two threads
-# calling `ctx['load_sibling']('extractor')` concurrently don't both
-# see the half-initialized module after the first has registered it
-# in sys.modules but before exec_module finishes. Stored in a dict
-# guarded by an outer lock — a fresh per-name lock is created on
-# first contention. Spotted by codex review on PR for slopsmith#33.
-import threading as _threading
-_sibling_lock_dict_lock = _threading.Lock()
-_sibling_locks: dict[str, _threading.Lock] = {}
-
-
-def _get_sibling_lock(module_name: str) -> _threading.Lock:
-    with _sibling_lock_dict_lock:
-        lock = _sibling_locks.get(module_name)
-        if lock is None:
-            lock = _threading.Lock()
-            _sibling_locks[module_name] = lock
-        return lock
-
 
 def _safe_plugin_id_for_module_name(plugin_id: str) -> str:
     """Bijectively encode a plugin_id for safe use as part of a Python
@@ -82,7 +63,6 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
         raise ValueError(
             f"load_sibling: plugin_id must be a non-empty string, got {plugin_id!r}"
         )
-    safe_plugin_id = _safe_plugin_id_for_module_name(plugin_id)
     if (
         not isinstance(name, str)
         or not name
@@ -92,142 +72,60 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
         or name.endswith(".py")
     ):
         # Reject path traversal, the redundant `.py` suffix, and any
-        # `.` (used as our separator below). The helper takes a bare
-        # module name; reject empty / non-string early so the
-        # spec_from_file_location error path doesn't have to
-        # disambiguate.
+        # `.` (the separator between id and name in the cache key).
         raise ValueError(
             f"plugin {plugin_id!r}: load_sibling expects a bare module name, got {name!r}"
         )
-    # Use `.` as the separator between id and name so the cache key
-    # is unambiguous when plugin_ids or names contain underscores —
-    # an `_` separator would collide when (id='a_b', name='c') and
-    # (id='a', name='b_c') both map to `plugin_a_b_c`. `.` is
-    # rejected in `name` above; `.` in plugin_id is escaped via
-    # `safe_plugin_id` so the separator stays unambiguous. Spotted
-    # across multiple codex review rounds on PR for slopsmith#33.
+    safe_plugin_id = _safe_plugin_id_for_module_name(plugin_id)
     parent_name = f"plugin_{safe_plugin_id}"
     module_name = f"{parent_name}.{name}"
-    # NB: no pre-lock cached lookup here. A concurrent first-time
-    # caller can briefly observe a half-initialized module that the
-    # FIRST caller registered via `sys.modules[module_name] = module`
-    # before `exec_module` finished. The cached check happens inside
-    # the lock below so it serializes against the load. Spotted by
-    # codex review on PR for slopsmith#33 round 8.
-    # Resolve `name` to either a top-level `.py` file (`extractor.py`)
-    # or a package directory (`extractor/__init__.py`). Package form
-    # is documented as a valid plugin layout (the collision-warning
-    # scanner detects it) so it must be loadable here too. Spotted
-    # by codex review on PR for slopsmith#33.
-    # Match CPython's import-resolution precedence: regular packages
-    # win over same-named `.py` modules. If a plugin ships both
-    # `extractor.py` and `extractor/__init__.py`, bare `import
-    # extractor` and `load_sibling('extractor')` must execute the
-    # same code path so plugins don't see split state. Spotted by
-    # codex review on PR for slopsmith#33.
+
+    # Pre-check that the sibling actually exists before we hand off
+    # to importlib.import_module — its ModuleNotFoundError is less
+    # specific than the message we want to surface (which lists both
+    # probed paths so a confused author sees "I checked here AND
+    # here").
     file_path = plugin_dir / f"{name}.py"
     pkg_init = plugin_dir / name / "__init__.py"
-    submodule_search = None
-    if pkg_init.is_file():
-        sibling_path = pkg_init
-        # Tell the import system that this is a package whose
-        # submodules can be looked up under `plugin_{id}.{name}.X`.
-        submodule_search = [str(pkg_init.parent)]
-    elif file_path.is_file():
-        sibling_path = file_path
-    else:
+    if not file_path.is_file() and not pkg_init.is_file():
         raise ImportError(
             f"plugin {plugin_id!r}: no sibling module {name!r} at "
             f"{file_path} or {pkg_init}"
         )
-    # Register a synthetic parent package so relative imports inside
-    # a sibling (e.g. `helper.py` doing `from .shared import X`, or
-    # a sibling package's `__init__.py` doing the same) and explicit
-    # lookups of `plugin_<id>.<name>` submodules can resolve through
-    # the parent. The parent's `__path__` points at the plugin's
-    # directory so the standard import machinery can FIND those
-    # siblings — that's what relative imports ultimately consult. It
-    # does NOT undermine the namespace isolation, because:
+
+    # Register a synthetic parent package so the standard import
+    # machinery can find this plugin's siblings via the parent's
+    # `__path__`. The parent points at the plugin's directory; this
+    # is what relative imports between siblings consult. It does NOT
+    # undermine the namespace isolation, because:
     #   • bare `import sibling` still goes through sys.path (the
     #     transition fallback for plugins that haven't migrated)
     #   • `import plugin_<id>.sibling` lands in the namespaced
-    #     sys.modules entry — same key load_sibling uses, so caching
-    #     stays coherent
-    # Done BEFORE the bare-reuse check below so a mixed-migration
-    # package sibling still ends up with its parent registered.
-    # Spotted by codex review on PR for slopsmith#33.
-    # Use setdefault so two threads loading different siblings for
-    # the same plugin can't both pass an `in sys.modules` check and
-    # then overwrite each other's parent registration. Without this,
-    # a losing thread's freshly-built parent would replace the
-    # winner's parent that already had child attributes attached
-    # via setattr below — `from . import sibling` lookups would
-    # then fail. setdefault is atomic under the GIL, so the loser's
-    # ModuleType is silently discarded. Spotted by Copilot review
-    # on PR #105 round 2.
+    #     sys.modules entry — same key load_sibling produces
+    # `setdefault` is atomic under the GIL so two threads racing to
+    # create the parent can't overwrite each other's registration.
+    # Spotted by codex/Copilot reviews on PRs for slopsmith#33.
     import types
     new_parent = types.ModuleType(parent_name)
     new_parent.__path__ = [str(plugin_dir)]
     sys.modules.setdefault(parent_name, new_parent)
-    # NB: We DON'T reuse bare-imported same-named modules here. The
-    # alias path looked attractive — module-level singletons stay
-    # shared across `import sibling` and `load_sibling('sibling')` —
-    # but the bare module's `__package__`/`__spec__.name`/`__name__`
-    # remain set to the un-namespaced bare name. Any relative import
-    # that runs after the alias (lazy `from .shared import X` inside
-    # a function, or `importlib.import_module(__package__ + '.X')`)
-    # then routes through the bare global cache, undoing the
-    # isolation. The right answer for plugins that mix bare imports
-    # with load_sibling on the SAME module is "stop mixing"; the
-    # transition cost is that the module's state exists under two
-    # cache keys until the bare imports are removed. Documented in
-    # CLAUDE.md / codex review on PR for slopsmith#33.
 
-    # Per-module lock so concurrent first-time callers of load_sibling
-    # serialize through exec_module — the second caller waits for the
-    # first to finish before observing the registered module instead
-    # of seeing a half-initialized object. Spotted by codex review on
-    # PR for slopsmith#33.
-    with _get_sibling_lock(module_name):
-        cached = sys.modules.get(module_name)
-        if cached is not None:
-            return cached
-        spec = importlib.util.spec_from_file_location(
-            module_name,
-            str(sibling_path),
-            submodule_search_locations=submodule_search,
-        )
-        if spec is None or spec.loader is None:
-            raise ImportError(
-                f"plugin {plugin_id!r}: could not build import spec for {name!r}"
-            )
-        module = importlib.util.module_from_spec(spec)
-        # Register before exec so the sibling can self-reference (e.g.
-        # for internal `import plugin_<id>.helper` patterns) without
-        # infinite recursion through this helper. Concurrent callers
-        # don't observe this half-initialized state because they're
-        # blocked on the lock.
-        sys.modules[module_name] = module
-        try:
-            spec.loader.exec_module(module)
-        except BaseException:
-            # On exec failure, drop the half-initialized module so a
-            # retry doesn't return the broken object from cache.
-            sys.modules.pop(module_name, None)
-            raise
-        # Expose the loaded child as an attribute on the synthetic
-        # parent. Python's standard import machinery does this after
-        # `_find_and_load` so that `from . import sibling` and
-        # `from .. import sibling` work via attribute lookup. Without
-        # it, plugins that mix load_sibling with package-style
-        # relative imports get `ImportError: cannot import name
-        # 'sibling' from 'plugin_<id>'` even though sys.modules has
-        # the module. Spotted by codex review on PR for slopsmith#33
-        # round 9.
-        parent = sys.modules.get(parent_name)
-        if parent is not None:
-            setattr(parent, name, module)
-        return module
+    # Delegate the actual load to importlib.import_module. It uses
+    # Python's per-module import lock, so concurrent callers — via
+    # load_sibling, relative imports inside another sibling
+    # (`from . import extractor`), or an explicit
+    # `importlib.import_module('plugin_<id>.<name>')` from anywhere
+    # — all serialize through the SAME lock. A rolled-our-own lock
+    # could only coordinate load_sibling callers; the standard lock
+    # plugs cross-API races where the half-initialized module would
+    # otherwise leak. Python's standard finder walks the parent's
+    # `__path__`, picks package over file when both exist (matching
+    # CPython precedence), exposes the child as an attribute on the
+    # parent post-load (`setattr(parent, name, child)`), and cleans
+    # up sys.modules on exec failure — all the things this helper
+    # used to do by hand. Spotted by Copilot review on PR #105
+    # round 5.
+    return importlib.import_module(module_name)
 
 
 def _warn_on_module_collisions(plugin_specs):
@@ -388,18 +286,25 @@ def load_plugins(app: FastAPI, context: dict):
                 print(f"[Plugin] Failed to read {manifest_path}: {e}")
                 continue
             plugin_id = manifest.get("id")
-            if not plugin_id:
+            if plugin_id is None:
+                # No `id` key at all — silently skip (existing
+                # behavior; manifests without an id were never
+                # meant to be valid).
                 continue
-            # Validate type explicitly. A malformed manifest with a
-            # non-string id (number, list, ...) would otherwise crash
-            # later when `.replace()` runs in
-            # `_safe_plugin_id_for_module_name`. Spotted by Copilot
-            # review on PR #105 round 3.
+            # Type-check BEFORE the empty check: falsy non-string
+            # values (`{"id": 0}`, `{"id": []}`) should produce the
+            # explicit "must be a string" warning, not be silently
+            # dropped. Spotted by Copilot review on PR #105 round 4.
             if not isinstance(plugin_id, str):
                 print(
                     f"[Plugin] Skipping {manifest_path}: 'id' must be a string, "
                     f"got {type(plugin_id).__name__} ({plugin_id!r})"
                 )
+                continue
+            if not plugin_id:
+                # Empty-string id — silently skip (matches the
+                # original `if not plugin_id: continue` semantics
+                # for empty strings).
                 continue
             if plugin_id in loaded_ids:
                 print(f"[Plugin] Skipping duplicate '{plugin_id}' from {plugins_base_dir}")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -68,16 +68,22 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     # is documented as a valid plugin layout (the collision-warning
     # scanner detects it) so it must be loadable here too. Spotted
     # by codex review on PR for slopsmith#33.
+    # Match CPython's import-resolution precedence: regular packages
+    # win over same-named `.py` modules. If a plugin ships both
+    # `extractor.py` and `extractor/__init__.py`, bare `import
+    # extractor` and `load_sibling('extractor')` must execute the
+    # same code path so plugins don't see split state. Spotted by
+    # codex review on PR for slopsmith#33.
     file_path = plugin_dir / f"{name}.py"
     pkg_init = plugin_dir / name / "__init__.py"
     submodule_search = None
-    if file_path.is_file():
-        sibling_path = file_path
-    elif pkg_init.is_file():
+    if pkg_init.is_file():
         sibling_path = pkg_init
         # Tell the import system that this is a package whose
         # submodules can be looked up under `plugin_{id}.{name}.X`.
         submodule_search = [str(pkg_init.parent)]
+    elif file_path.is_file():
+        sibling_path = file_path
     else:
         raise ImportError(
             f"plugin {plugin_id!r}: no sibling module {name!r} at "
@@ -314,6 +320,20 @@ def load_plugins(app: FastAPI, context: dict):
                 continue
             plugin_id = manifest.get("id")
             if not plugin_id:
+                continue
+            # Reject dotted ids at discovery so plugins don't load
+            # successfully and then blow up on the first
+            # `context['load_sibling'](...)` call. The helper's
+            # synthetic parent package machinery requires a
+            # `.`-free id; the manifest convention is identifier-
+            # shaped ids anyway. Spotted by codex review on PR for
+            # slopsmith#33.
+            if "." in plugin_id:
+                print(
+                    f"[Plugin] Refusing to load '{plugin_id}' from "
+                    f"{plugin_dir}: plugin id must not contain '.' "
+                    f"(slopsmith#33). Rename the id in plugin.json."
+                )
                 continue
             if plugin_id in loaded_ids:
                 print(f"[Plugin] Skipping duplicate '{plugin_id}' from {plugins_base_dir}")

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -69,14 +69,15 @@ def _safe_plugin_id_for_module_name(plugin_id: str) -> str:
 
 def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     """Load a sibling module from a plugin's directory under a namespaced
-    module name (`plugin_<plugin_id>.<name>`, with `.` in plugin_id
-    escaped to `_x2e_`). Both single-file siblings (`extractor.py`)
-    and package-form siblings (`extractor/__init__.py`) are supported;
-    package form wins when both exist (matches CPython's import
-    precedence). Mirrors the routes-loading pattern in `load_plugins()`
-    and shares its `sys.modules` cache, so two plugins that each ship
-    `extractor.py` get distinct cached modules instead of stomping each
-    other through `sys.path`. See slopsmith#33."""
+    module name (`plugin_<plugin_id>.<name>`, with plugin_id
+    bijectively encoded by `_safe_plugin_id_for_module_name` —
+    `_` -> `_5f_`, `.` -> `_2e_`). Both single-file siblings
+    (`extractor.py`) and package-form siblings (`extractor/__init__.py`)
+    are supported; package form wins when both exist (matches CPython's
+    import precedence). Mirrors the routes-loading pattern in
+    `load_plugins()` and shares its `sys.modules` cache, so two plugins
+    that each ship `extractor.py` get distinct cached modules instead
+    of stomping each other through `sys.path`. See slopsmith#33."""
     if not isinstance(plugin_id, str) or not plugin_id:
         raise ValueError(
             f"load_sibling: plugin_id must be a non-empty string, got {plugin_id!r}"
@@ -432,8 +433,9 @@ def load_plugins(app: FastAPI, context: dict):
         # stored in context are still the same objects across
         # plugins, so e.g. `ctx['meta_db']` mutations are still
         # observable everywhere by design.) The helper namespaces
-        # sibling modules as `plugin_<id>.<name>` (with `.` in
-        # plugin_id escaped to `_x2e_`) so two plugins shipping the
+        # sibling modules as `plugin_<id>.<name>` (with plugin_id
+        # bijectively encoded by _safe_plugin_id_for_module_name:
+        # `_` -> `_5f_`, `.` -> `_2e_`) so two plugins shipping the
         # same filename get distinct cached modules. See
         # slopsmith#33.
         plugin_context = dict(context)

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -51,12 +51,31 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     cached = sys.modules.get(module_name)
     if cached is not None:
         return cached
-    sibling_path = plugin_dir / f"{name}.py"
-    if not sibling_path.is_file():
+    # Resolve `name` to either a top-level `.py` file (`extractor.py`)
+    # or a package directory (`extractor/__init__.py`). Package form
+    # is documented as a valid plugin layout (the collision-warning
+    # scanner detects it) so it must be loadable here too. Spotted
+    # by codex review on PR for slopsmith#33.
+    file_path = plugin_dir / f"{name}.py"
+    pkg_init = plugin_dir / name / "__init__.py"
+    submodule_search = None
+    if file_path.is_file():
+        sibling_path = file_path
+    elif pkg_init.is_file():
+        sibling_path = pkg_init
+        # Tell the import system that this is a package whose
+        # submodules can be looked up under `plugin_{id}.{name}.X`.
+        submodule_search = [str(pkg_init.parent)]
+    else:
         raise ImportError(
-            f"plugin {plugin_id!r}: no sibling module {name!r} at {sibling_path}"
+            f"plugin {plugin_id!r}: no sibling module {name!r} at "
+            f"{file_path} or {pkg_init}"
         )
-    spec = importlib.util.spec_from_file_location(module_name, str(sibling_path))
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        str(sibling_path),
+        submodule_search_locations=submodule_search,
+    )
     if spec is None or spec.loader is None:
         raise ImportError(
             f"plugin {plugin_id!r}: could not build import spec for {name!r}"

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -17,6 +17,88 @@ LOADED_PLUGINS = []
 _PIP_TARGET = Path(os.environ.get("CONFIG_DIR", "/config")) / "pip_packages"
 
 
+def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
+    """Load a sibling .py file from a plugin's directory under a namespaced
+    module name (`plugin_{plugin_id}_{name}`). Mirrors the routes-loading
+    pattern at the top of `load_plugins()` and shares its `sys.modules`
+    cache, so two plugins that each ship `extractor.py` get distinct
+    cached modules instead of stomping each other through `sys.path`.
+    See slopsmith#33."""
+    if not isinstance(name, str) or not name or "/" in name or "\\" in name or name.endswith(".py"):
+        # Reject path traversal and the redundant `.py` suffix — the
+        # helper takes a bare module name. Reject empty / non-string
+        # early so the spec_from_file_location error path doesn't have
+        # to disambiguate.
+        raise ValueError(
+            f"plugin {plugin_id!r}: load_sibling expects a bare module name, got {name!r}"
+        )
+    module_name = f"plugin_{plugin_id}_{name}"
+    cached = sys.modules.get(module_name)
+    if cached is not None:
+        return cached
+    sibling_path = plugin_dir / f"{name}.py"
+    if not sibling_path.is_file():
+        raise ImportError(
+            f"plugin {plugin_id!r}: no sibling module {name!r} at {sibling_path}"
+        )
+    spec = importlib.util.spec_from_file_location(module_name, str(sibling_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(
+            f"plugin {plugin_id!r}: could not build import spec for {name!r}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the sibling can self-reference (e.g. for
+    # internal `import plugin_<id>_helper` patterns) without infinite
+    # recursion through this helper.
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        # On exec failure, drop the half-initialized module so a
+        # retry doesn't return the broken object from cache.
+        sys.modules.pop(module_name, None)
+        raise
+    return module
+
+
+def _warn_on_module_collisions(plugin_specs):
+    """Scan top-level `.py` files across all plugins about to be loaded.
+    Print a warning for any module name shipped by 2+ plugins, since
+    bare `import <name>` from those plugins will hit the sys.path-based
+    cache and cross-load (slopsmith#33). `routes.py` is excluded because
+    the loader already namespaces it as `plugin_{id}_routes`.
+
+    `plugin_specs` is a list of `(plugin_id, plugin_dir)` tuples for
+    plugins the loader has decided to load (post-dedup).
+    """
+    by_name: dict[str, list[str]] = {}
+    for plugin_id, plugin_dir in plugin_specs:
+        try:
+            for child in plugin_dir.iterdir():
+                if not child.is_file() or child.suffix != ".py":
+                    continue
+                # Skip routes.py — already namespaced. Skip dunder
+                # files like __init__.py — packages handle their own
+                # namespacing if a plugin opts into being a package.
+                if child.name == "routes.py" or child.name.startswith("__"):
+                    continue
+                by_name.setdefault(child.stem, []).append(plugin_id)
+        except OSError:
+            # Unreadable plugin dir — the per-plugin load below will
+            # surface the error in a more useful place; don't warn here.
+            continue
+    for name, ids in by_name.items():
+        if len(ids) < 2:
+            continue
+        ids_quoted = ", ".join(f"'{p}'" for p in sorted(ids))
+        print(
+            f"[Plugin] Module-name collision warning: '{name}.py' is shipped "
+            f"by {len(ids)} plugins ({ids_quoted}). Bare `import {name}` "
+            f"may load the wrong file. Migrate to "
+            f"context['load_sibling']('{name}') — see CLAUDE.md (slopsmith#33)."
+        )
+
+
 def _install_requirements(plugin_dir: Path, plugin_id: str):
     """Install plugin requirements.txt to a persistent location."""
     req_file = plugin_dir / "requirements.txt"
@@ -87,74 +169,99 @@ def load_plugins(app: FastAPI, context: dict):
         sys.path.insert(0, pip_target)
 
     loaded_ids = set()
-
+    # Two-pass discovery so we can warn about cross-plugin module-name
+    # collisions BEFORE any plugin's setup runs (slopsmith#33). The
+    # first pass collects (plugin_id, plugin_dir, manifest, base_dir)
+    # tuples in load order; the second pass actually executes each
+    # plugin's setup with a per-plugin context.
+    plugin_load_specs = []
     for plugins_base_dir in plugin_dirs:
         for plugin_dir in sorted(plugins_base_dir.iterdir()):
             if not plugin_dir.is_dir():
                 continue
-
             manifest_path = plugin_dir / "plugin.json"
             if not manifest_path.exists():
                 continue
-
             try:
                 manifest = json.loads(manifest_path.read_text())
             except Exception as e:
                 print(f"[Plugin] Failed to read {manifest_path}: {e}")
                 continue
-
             plugin_id = manifest.get("id")
             if not plugin_id:
                 continue
-
             if plugin_id in loaded_ids:
                 print(f"[Plugin] Skipping duplicate '{plugin_id}' from {plugins_base_dir}")
                 continue
             loaded_ids.add(plugin_id)
+            plugin_load_specs.append((plugin_id, plugin_dir, manifest, plugins_base_dir))
 
-            # Install plugin requirements if present
-            _install_requirements(plugin_dir, plugin_id)
+    # Warn before loading so authors see the message even if a colliding
+    # plugin's setup itself blows up later in the loop.
+    _warn_on_module_collisions(
+        [(plugin_id, plugin_dir) for plugin_id, plugin_dir, _, _ in plugin_load_specs]
+    )
 
-            # Add plugin directory to sys.path so it can import its own modules
-            plugin_dir_str = str(plugin_dir)
-            if plugin_dir_str not in sys.path:
-                sys.path.insert(0, plugin_dir_str)
+    for plugin_id, plugin_dir, manifest, plugins_base_dir in plugin_load_specs:
+        # Install plugin requirements if present
+        _install_requirements(plugin_dir, plugin_id)
 
-            # Load routes using importlib to avoid module name collisions
-            routes_file = manifest.get("routes")
-            if routes_file:
-                try:
-                    module_name = f"plugin_{plugin_id}_routes"
-                    spec = importlib.util.spec_from_file_location(
-                        module_name, str(plugin_dir / routes_file))
-                    routes_module = importlib.util.module_from_spec(spec)
-                    sys.modules[module_name] = routes_module
-                    spec.loader.exec_module(routes_module)
-                    if hasattr(routes_module, "setup"):
-                        routes_module.setup(app, context)
-                        print(f"[Plugin] Loaded routes for '{plugin_id}'")
-                except Exception as e:
-                    print(f"[Plugin] Failed to load routes for '{plugin_id}': {e}")
-                    import traceback
-                    traceback.print_exc()
+        # Add plugin directory to sys.path so the plugin's bare
+        # `import sibling` keeps working during the slopsmith#33
+        # transition. New plugins should prefer
+        # `context['load_sibling']('sibling')` instead — see
+        # CLAUDE.md / Plugin System / Backend routes.
+        plugin_dir_str = str(plugin_dir)
+        if plugin_dir_str not in sys.path:
+            sys.path.insert(0, plugin_dir_str)
 
-            LOADED_PLUGINS.append({
-                "id": plugin_id,
-                "name": manifest.get("name", plugin_id),
-                "nav": manifest.get("nav"),
-                # `type` is an optional manifest hint for the frontend —
-                # e.g. "visualization" lets the highway viz picker know
-                # this plugin offers a renderer. Absent → no declared
-                # role; plugin is still loaded and scripts run, it just
-                # doesn't show up in role-specific UIs. See slopsmith#36.
-                "type": manifest.get("type"),
-                "has_screen": bool(manifest.get("screen")),
-                "has_script": bool(manifest.get("script")),
-                "has_settings": bool(manifest.get("settings")),
-                "_dir": plugin_dir,
-                "_manifest": manifest,
-            })
-            print(f"[Plugin] Registered '{plugin_id}' ({manifest.get('name', '')})")
+        # Build a per-plugin context: shallow-copy the shared one
+        # (so plugin A can't mutate plugin B's view) and add a
+        # `load_sibling` closure scoped to THIS plugin's id + dir.
+        # The helper namespaces sibling modules as
+        # `plugin_{id}_{name}` so two plugins shipping the same
+        # filename get distinct cached modules. See slopsmith#33.
+        plugin_context = dict(context)
+        plugin_context["load_sibling"] = (
+            lambda name, _pid=plugin_id, _pdir=plugin_dir:
+                _load_plugin_sibling(_pid, _pdir, name)
+        )
+
+        # Load routes using importlib to avoid module name collisions
+        routes_file = manifest.get("routes")
+        if routes_file:
+            try:
+                module_name = f"plugin_{plugin_id}_routes"
+                spec = importlib.util.spec_from_file_location(
+                    module_name, str(plugin_dir / routes_file))
+                routes_module = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = routes_module
+                spec.loader.exec_module(routes_module)
+                if hasattr(routes_module, "setup"):
+                    routes_module.setup(app, plugin_context)
+                    print(f"[Plugin] Loaded routes for '{plugin_id}'")
+            except Exception as e:
+                print(f"[Plugin] Failed to load routes for '{plugin_id}': {e}")
+                import traceback
+                traceback.print_exc()
+
+        LOADED_PLUGINS.append({
+            "id": plugin_id,
+            "name": manifest.get("name", plugin_id),
+            "nav": manifest.get("nav"),
+            # `type` is an optional manifest hint for the frontend —
+            # e.g. "visualization" lets the highway viz picker know
+            # this plugin offers a renderer. Absent → no declared
+            # role; plugin is still loaded and scripts run, it just
+            # doesn't show up in role-specific UIs. See slopsmith#36.
+            "type": manifest.get("type"),
+            "has_screen": bool(manifest.get("screen")),
+            "has_script": bool(manifest.get("script")),
+            "has_settings": bool(manifest.get("settings")),
+            "_dir": plugin_dir,
+            "_manifest": manifest,
+        })
+        print(f"[Plugin] Registered '{plugin_id}' ({manifest.get('name', '')})")
 
 
 def _check_plugin_update(plugin_dir: Path) -> dict | None:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -47,7 +47,8 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     # by codex review on PR for slopsmith#33. `.` is rejected in
     # `name` above; plugin_ids with `.` are degenerate (manifest
     # convention is identifier-shaped) so the format stays unique.
-    module_name = f"plugin_{plugin_id}.{name}"
+    parent_name = f"plugin_{plugin_id}"
+    module_name = f"{parent_name}.{name}"
     cached = sys.modules.get(module_name)
     if cached is not None:
         return cached
@@ -71,6 +72,39 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
             f"plugin {plugin_id!r}: no sibling module {name!r} at "
             f"{file_path} or {pkg_init}"
         )
+    # Mixed-migration reuse: if a bare `import {name}` already loaded
+    # THIS plugin's same file (via sys.path during the transition),
+    # reuse it instead of re-executing. The path equality check ensures
+    # we only reuse when it's actually our file — a bare import that
+    # resolved to a DIFFERENT plugin's same-named module (the original
+    # collision bug) will not match this path and we'll load our own
+    # under the namespaced key. Without this, load_sibling would
+    # double-exec the file and any module-level singletons / caches
+    # / registrations would split into two copies. Spotted by codex
+    # review on PR for slopsmith#33.
+    bare_cached = sys.modules.get(name)
+    if bare_cached is not None:
+        bare_file = getattr(bare_cached, "__file__", None)
+        try:
+            same_file = bool(bare_file) and Path(bare_file).resolve() == sibling_path.resolve()
+        except OSError:
+            same_file = False
+        if same_file:
+            sys.modules[module_name] = bare_cached
+            return bare_cached
+    # Register a synthetic parent package so relative imports inside
+    # a sibling package (`from .child import X`) and explicit lookups
+    # of submodules (`importlib.import_module('plugin_<id>.<name>.X')`)
+    # can resolve through the parent. The parent has an empty
+    # __path__: the plugin's dir is intentionally NOT on it, so that
+    # all sibling lookups continue to flow through this helper and
+    # don't accidentally pull in collision-prone names. Spotted by
+    # codex review on PR for slopsmith#33.
+    if parent_name not in sys.modules:
+        import types
+        parent = types.ModuleType(parent_name)
+        parent.__path__ = []
+        sys.modules[parent_name] = parent
     spec = importlib.util.spec_from_file_location(
         module_name,
         str(sibling_path),

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -24,15 +24,30 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
     cache, so two plugins that each ship `extractor.py` get distinct
     cached modules instead of stomping each other through `sys.path`.
     See slopsmith#33."""
-    if not isinstance(name, str) or not name or "/" in name or "\\" in name or name.endswith(".py"):
-        # Reject path traversal and the redundant `.py` suffix — the
-        # helper takes a bare module name. Reject empty / non-string
-        # early so the spec_from_file_location error path doesn't have
-        # to disambiguate.
+    if (
+        not isinstance(name, str)
+        or not name
+        or "/" in name
+        or "\\" in name
+        or "." in name
+        or name.endswith(".py")
+    ):
+        # Reject path traversal, the redundant `.py` suffix, and any
+        # `.` (used as our separator below). The helper takes a bare
+        # module name; reject empty / non-string early so the
+        # spec_from_file_location error path doesn't have to
+        # disambiguate.
         raise ValueError(
             f"plugin {plugin_id!r}: load_sibling expects a bare module name, got {name!r}"
         )
-    module_name = f"plugin_{plugin_id}_{name}"
+    # Use `.` as the separator between id and name so the cache key
+    # is unambiguous when plugin_ids or names contain underscores —
+    # `f"plugin_{id}_{name}"` would collide when (id='a_b', name='c')
+    # and (id='a', name='b_c') both map to `plugin_a_b_c`. Spotted
+    # by codex review on PR for slopsmith#33. `.` is rejected in
+    # `name` above; plugin_ids with `.` are degenerate (manifest
+    # convention is identifier-shaped) so the format stays unique.
+    module_name = f"plugin_{plugin_id}.{name}"
     cached = sys.modules.get(module_name)
     if cached is not None:
         return cached
@@ -62,11 +77,21 @@ def _load_plugin_sibling(plugin_id: str, plugin_dir: Path, name: str):
 
 
 def _warn_on_module_collisions(plugin_specs):
-    """Scan top-level `.py` files across all plugins about to be loaded.
-    Print a warning for any module name shipped by 2+ plugins, since
-    bare `import <name>` from those plugins will hit the sys.path-based
-    cache and cross-load (slopsmith#33). `routes.py` is excluded because
-    the loader already namespaces it as `plugin_{id}_routes`.
+    """Scan top-level importable modules across all plugins about to
+    be loaded. Print a warning for any module name shipped by 2+
+    plugins, since bare `import <name>` from those plugins will hit
+    the sys.path-based cache and cross-load (slopsmith#33).
+
+    Both top-level `.py` files AND top-level packages (directories
+    containing `__init__.py`) are scanned — the same collision
+    pattern applies to either, e.g. one plugin's `extractor.py` vs
+    another plugin's `extractor/__init__.py` both produce a shared
+    `sys.modules['extractor']` entry. Spotted by codex review on
+    PR for slopsmith#33.
+
+    `routes.py` itself is excluded because the loader already
+    namespaces it as `plugin_{id}_routes`. Top-level dunder files
+    (like a hypothetical bare `__main__.py`) are excluded too.
 
     `plugin_specs` is a list of `(plugin_id, plugin_dir)` tuples for
     plugins the loader has decided to load (post-dedup).
@@ -75,27 +100,42 @@ def _warn_on_module_collisions(plugin_specs):
     for plugin_id, plugin_dir in plugin_specs:
         try:
             for child in plugin_dir.iterdir():
-                if not child.is_file() or child.suffix != ".py":
+                module_name = None
+                kind = None
+                if child.is_file() and child.suffix == ".py":
+                    if child.name == "routes.py" or child.name.startswith("__"):
+                        continue
+                    module_name = child.stem
+                    kind = "module"
+                elif child.is_dir() and (child / "__init__.py").is_file():
+                    if child.name.startswith("__"):
+                        continue
+                    module_name = child.name
+                    kind = "package"
+                if module_name is None:
                     continue
-                # Skip routes.py — already namespaced. Skip dunder
-                # files like __init__.py — packages handle their own
-                # namespacing if a plugin opts into being a package.
-                if child.name == "routes.py" or child.name.startswith("__"):
-                    continue
-                by_name.setdefault(child.stem, []).append(plugin_id)
+                by_name.setdefault(module_name, []).append((plugin_id, kind))
         except OSError:
             # Unreadable plugin dir — the per-plugin load below will
             # surface the error in a more useful place; don't warn here.
             continue
-    for name, ids in by_name.items():
-        if len(ids) < 2:
+    for name, entries in by_name.items():
+        if len(entries) < 2:
             continue
-        ids_quoted = ", ".join(f"'{p}'" for p in sorted(ids))
+        ids_quoted = ", ".join(
+            f"'{pid}'" for pid, _ in sorted(entries, key=lambda e: e[0])
+        )
+        # Mention which form (module vs package) shows up if it's
+        # not all one or the other — helps maintainers spot the
+        # `extractor.py` vs `extractor/__init__.py` mixed case.
+        kinds = {k for _, k in entries}
+        kind_label = "module/package" if len(kinds) > 1 else next(iter(kinds))
         print(
-            f"[Plugin] Module-name collision warning: '{name}.py' is shipped "
-            f"by {len(ids)} plugins ({ids_quoted}). Bare `import {name}` "
-            f"may load the wrong file. Migrate to "
-            f"context['load_sibling']('{name}') — see CLAUDE.md (slopsmith#33)."
+            f"[Plugin] Module-name collision warning: '{name}' "
+            f"({kind_label}) is shipped by {len(entries)} plugins "
+            f"({ids_quoted}). Bare `import {name}` may load the wrong "
+            f"file. Migrate to context['load_sibling']('{name}') — "
+            f"see CLAUDE.md (slopsmith#33)."
         )
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -100,9 +100,11 @@ def test_load_sibling_returns_per_plugin_namespaced_modules(tmp_path, reset_plug
     _run_load_plugins(plugins, fake_app, tmp_path)
     assert fake_app.state.alpha_manifest == "alpha-manifest"
     assert fake_app.state.beta_value == 42
-    # The two extractors are namespaced into distinct sys.modules entries.
-    alpha_mod = sys.modules["plugin_alpha_extractor"]
-    beta_mod = sys.modules["plugin_beta_extractor"]
+    # The two extractors are namespaced into distinct sys.modules
+    # entries. `.` separates id and name to disambiguate when either
+    # contains underscores.
+    alpha_mod = sys.modules["plugin_alpha.extractor"]
+    beta_mod = sys.modules["plugin_beta.extractor"]
     assert alpha_mod is not beta_mod
     assert getattr(alpha_mod, "MANIFEST_DIR", None) == "alpha-manifest"
     assert getattr(beta_mod, "BETA_VALUE", None) == 42
@@ -130,7 +132,7 @@ def test_load_sibling_caches_repeat_calls(tmp_path, reset_plugin_state):
     fake_app.state = type("State", (), {})()
     _run_load_plugins(plugins, fake_app, tmp_path)
     assert fake_app.state.same is True
-    assert fake_app.state.instance is sys.modules["plugin_cached_util"].INSTANCE
+    assert fake_app.state.instance is sys.modules["plugin_cached.util"].INSTANCE
 
 
 def test_load_sibling_missing_module_raises_import_error(tmp_path, reset_plugin_state):
@@ -145,7 +147,13 @@ def test_load_sibling_rejects_traversal_and_suffix(tmp_path, reset_plugin_state)
     traverse paths or carry a redundant .py suffix."""
     plugins = reset_plugin_state
     plugin_dir = _make_plugin(tmp_path, "p")
-    for bad in ("", "../etc", "sub/util", "util.py", 123, None):
+    # Reject:
+    # - empty / non-string (bare module name required)
+    # - path traversal (`/`, `\`, `../`)
+    # - redundant `.py` suffix
+    # - any `.` (used as separator in the cache key — would
+    #   otherwise allow ambiguous keys)
+    for bad in ("", "../etc", "sub/util", "util.py", "pkg.helper", 123, None):
         with pytest.raises((ValueError, TypeError)):
             plugins._load_plugin_sibling("p", plugin_dir, bad)
 
@@ -158,7 +166,7 @@ def test_collision_warning_fires_for_shared_module_name(tmp_path, reset_plugin_s
     _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
     out = capsys.readouterr().out
     assert "Module-name collision warning" in out
-    assert "extractor.py" in out
+    assert "'extractor' (module)" in out
     assert "rs1extract" in out
     assert "discextract" in out
 
@@ -185,6 +193,65 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
     _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
     out = capsys.readouterr().out
     assert "Module-name collision warning" not in out
+
+
+def test_load_sibling_disambiguates_underscored_ids_and_names(tmp_path, reset_plugin_state):
+    """`(plugin_id='a_b', name='c')` and `(plugin_id='a', name='b_c')`
+    must NOT collide in sys.modules. The `.` separator makes the cache
+    key unambiguous (the old `_` separator collapsed both to
+    `plugin_a_b_c`). Codex review on PR for slopsmith#33."""
+    plugins = reset_plugin_state
+    p1 = _make_plugin(tmp_path, "a_b", sibling_files={"c": "WHO = 'a_b/c'\n"})
+    p2 = _make_plugin(tmp_path, "a", sibling_files={"b_c": "WHO = 'a/b_c'\n"})
+    m1 = plugins._load_plugin_sibling("a_b", p1, "c")
+    m2 = plugins._load_plugin_sibling("a", p2, "b_c")
+    assert m1 is not m2
+    assert m1.WHO == "a_b/c"
+    assert m2.WHO == "a/b_c"
+    # Both keys exist independently in sys.modules.
+    assert "plugin_a_b.c" in sys.modules
+    assert "plugin_a.b_c" in sys.modules
+    assert sys.modules["plugin_a_b.c"] is m1
+    assert sys.modules["plugin_a.b_c"] is m2
+
+
+def test_collision_warning_detects_package_form(tmp_path, reset_plugin_state, capsys):
+    """A plugin shipping `extractor/__init__.py` collides with another
+    plugin's `extractor.py` the same way two `.py` files would. The
+    scanner picks up packages too. Codex review on PR for slopsmith#33."""
+    plugins = reset_plugin_state
+    # Plugin one: extractor.py
+    _make_plugin(tmp_path, "as_module", sibling_files={"extractor": "X = 1\n"})
+    # Plugin two: extractor/ (package form)
+    plugin_pkg = _make_plugin(tmp_path, "as_package")
+    pkg_dir = plugin_pkg / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("Y = 2\n")
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    assert "Module-name collision warning" in out
+    assert "extractor" in out
+    assert "as_module" in out
+    assert "as_package" in out
+    # The mixed-form label should also appear so the maintainer knows
+    # to look for both shapes.
+    assert "module/package" in out
+
+
+def test_collision_warning_detects_two_packages(tmp_path, reset_plugin_state, capsys):
+    """Two plugins each shipping the SAME package directory form."""
+    plugins = reset_plugin_state
+    for pid in ("plug_a", "plug_b"):
+        plugin_dir = _make_plugin(tmp_path, pid)
+        pkg = plugin_dir / "shared_pkg"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text(f"# {pid}\n")
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    assert "Module-name collision warning" in out
+    assert "shared_pkg" in out
+    assert "plug_a" in out
+    assert "plug_b" in out
 
 
 def test_per_plugin_context_does_not_leak_load_sibling_across_plugins(tmp_path, reset_plugin_state):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,217 @@
+"""Tests for plugins/__init__.py — namespace isolation for sibling
+modules and startup-time collision detection (slopsmith#33).
+
+The plugin loader used to insert each plugin directory onto `sys.path`,
+which made bare `import sibling` fall through Python's per-name cache
+in `sys.modules`. Two plugins shipping a same-named top-level module
+(`extractor.py`, `util.py`, …) would step on each other. The loader
+now exposes `context['load_sibling'](name)` that loads the sibling
+under a namespaced module name `plugin_{plugin_id}_{name}`, plus a
+warning at startup so existing plugins are visible.
+"""
+
+import importlib
+import json
+import sys
+
+import pytest
+
+
+@pytest.fixture()
+def reset_plugin_state():
+    """Clear loader module-level state and restore on teardown.
+
+    `plugins.LOADED_PLUGINS` and any `plugin_*` keys we add to
+    `sys.modules` would otherwise leak across tests within a session.
+    """
+    plugins = importlib.import_module("plugins")
+    saved_loaded = list(plugins.LOADED_PLUGINS)
+    saved_modules = {k: v for k, v in sys.modules.items() if k.startswith("plugin_")}
+    plugins.LOADED_PLUGINS.clear()
+    for k in list(sys.modules):
+        if k.startswith("plugin_"):
+            del sys.modules[k]
+    try:
+        yield plugins
+    finally:
+        plugins.LOADED_PLUGINS.clear()
+        plugins.LOADED_PLUGINS.extend(saved_loaded)
+        for k in list(sys.modules):
+            if k.startswith("plugin_"):
+                del sys.modules[k]
+        sys.modules.update(saved_modules)
+
+
+def _make_plugin(plugin_root, plugin_id, *, sibling_files=None, routes_body=None):
+    """Create a minimal plugin directory under `plugin_root`.
+
+    `sibling_files` is a dict of `{module_name: file_body}` written as
+    `{module_name}.py` next to routes. `routes_body` is the contents of
+    routes.py — defaults to a no-op `setup` so the plugin loads cleanly.
+    """
+    plugin_dir = plugin_root / plugin_id
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": plugin_id, "name": plugin_id, "routes": "routes.py"})
+    )
+    (plugin_dir / "routes.py").write_text(
+        routes_body if routes_body is not None else "def setup(app, ctx):\n    pass\n"
+    )
+    for name, body in (sibling_files or {}).items():
+        (plugin_dir / f"{name}.py").write_text(body)
+    return plugin_dir
+
+
+def _run_load_plugins(plugins, app, tmp_path, context=None):
+    """Drive load_plugins against a tmp plugin root, restoring module
+    state on the way out so each test is isolated."""
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = tmp_path
+    try:
+        plugins.load_plugins(app, context if context is not None else {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+
+def test_load_sibling_returns_per_plugin_namespaced_modules(tmp_path, reset_plugin_state):
+    """Two plugins shipping `extractor.py` with different exports must
+    each see their OWN file via load_sibling — no cross-contamination."""
+    plugins = reset_plugin_state
+    _make_plugin(
+        tmp_path, "alpha",
+        sibling_files={"extractor": "MANIFEST_DIR = 'alpha-manifest'\n"},
+        routes_body=(
+            "def setup(app, ctx):\n"
+            "    extractor = ctx['load_sibling']('extractor')\n"
+            "    app.state.alpha_manifest = extractor.MANIFEST_DIR\n"
+        ),
+    )
+    _make_plugin(
+        tmp_path, "beta",
+        sibling_files={"extractor": "BETA_VALUE = 42\n"},
+        routes_body=(
+            "def setup(app, ctx):\n"
+            "    extractor = ctx['load_sibling']('extractor')\n"
+            "    app.state.beta_value = extractor.BETA_VALUE\n"
+        ),
+    )
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    _run_load_plugins(plugins, fake_app, tmp_path)
+    assert fake_app.state.alpha_manifest == "alpha-manifest"
+    assert fake_app.state.beta_value == 42
+    # The two extractors are namespaced into distinct sys.modules entries.
+    alpha_mod = sys.modules["plugin_alpha_extractor"]
+    beta_mod = sys.modules["plugin_beta_extractor"]
+    assert alpha_mod is not beta_mod
+    assert getattr(alpha_mod, "MANIFEST_DIR", None) == "alpha-manifest"
+    assert getattr(beta_mod, "BETA_VALUE", None) == 42
+    # Negative cross-check: alpha's extractor must NOT carry beta's exports.
+    assert not hasattr(alpha_mod, "BETA_VALUE")
+    assert not hasattr(beta_mod, "MANIFEST_DIR")
+
+
+def test_load_sibling_caches_repeat_calls(tmp_path, reset_plugin_state):
+    """Two `load_sibling('util')` calls within the same plugin return
+    the identical module object — no double exec_module."""
+    plugins = reset_plugin_state
+    _make_plugin(
+        tmp_path, "cached",
+        sibling_files={"util": "INSTANCE = object()\n"},
+        routes_body=(
+            "def setup(app, ctx):\n"
+            "    a = ctx['load_sibling']('util')\n"
+            "    b = ctx['load_sibling']('util')\n"
+            "    app.state.same = a is b\n"
+            "    app.state.instance = a.INSTANCE\n"
+        ),
+    )
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    _run_load_plugins(plugins, fake_app, tmp_path)
+    assert fake_app.state.same is True
+    assert fake_app.state.instance is sys.modules["plugin_cached_util"].INSTANCE
+
+
+def test_load_sibling_missing_module_raises_import_error(tmp_path, reset_plugin_state):
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "bare")
+    with pytest.raises(ImportError):
+        plugins._load_plugin_sibling("bare", plugin_dir, "does_not_exist")
+
+
+def test_load_sibling_rejects_traversal_and_suffix(tmp_path, reset_plugin_state):
+    """The helper takes a bare module name; reject anything that could
+    traverse paths or carry a redundant .py suffix."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "p")
+    for bad in ("", "../etc", "sub/util", "util.py", 123, None):
+        with pytest.raises((ValueError, TypeError)):
+            plugins._load_plugin_sibling("p", plugin_dir, bad)
+
+
+def test_collision_warning_fires_for_shared_module_name(tmp_path, reset_plugin_state, capsys):
+    """Two plugins both shipping extractor.py must trigger the warning."""
+    plugins = reset_plugin_state
+    _make_plugin(tmp_path, "rs1extract", sibling_files={"extractor": "X = 1\n"})
+    _make_plugin(tmp_path, "discextract", sibling_files={"extractor": "Y = 2\n"})
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    assert "Module-name collision warning" in out
+    assert "extractor.py" in out
+    assert "rs1extract" in out
+    assert "discextract" in out
+
+
+def test_collision_warning_silent_when_names_unique(tmp_path, reset_plugin_state, capsys):
+    plugins = reset_plugin_state
+    _make_plugin(tmp_path, "alpha", sibling_files={"alpha_helper": "A = 1\n"})
+    _make_plugin(tmp_path, "beta", sibling_files={"beta_helper": "B = 2\n"})
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    assert "Module-name collision warning" not in out
+
+
+def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_state, capsys):
+    """routes.py is already namespaced by the loader; __init__.py
+    belongs to a plugin that opted into being a package and namespaces
+    itself. Neither should trip the collision warning even when both
+    plugins ship one."""
+    plugins = reset_plugin_state
+    p1 = _make_plugin(tmp_path, "one", sibling_files={"unique_one": "V = 1\n"})
+    p2 = _make_plugin(tmp_path, "two", sibling_files={"unique_two": "V = 2\n"})
+    (p1 / "__init__.py").write_text("")
+    (p2 / "__init__.py").write_text("")
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    assert "Module-name collision warning" not in out
+
+
+def test_per_plugin_context_does_not_leak_load_sibling_across_plugins(tmp_path, reset_plugin_state):
+    """Plugin A's `load_sibling` must close over plugin A's id+dir.
+    If both plugins received the SAME closure (the bug we are
+    preventing), plugin A calling `load_sibling('thing')` would
+    load whatever the loop's last-iteration closure pointed at —
+    typically the alphabetically-last plugin's directory."""
+    plugins = reset_plugin_state
+    _make_plugin(
+        tmp_path, "aaa",
+        sibling_files={"thing": "ORIGIN = 'aaa'\n"},
+        routes_body=(
+            "def setup(app, ctx):\n"
+            "    app.state.aaa_origin = ctx['load_sibling']('thing').ORIGIN\n"
+        ),
+    )
+    _make_plugin(
+        tmp_path, "zzz",
+        sibling_files={"thing": "ORIGIN = 'zzz'\n"},
+        routes_body=(
+            "def setup(app, ctx):\n"
+            "    app.state.zzz_origin = ctx['load_sibling']('thing').ORIGIN\n"
+        ),
+    )
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    _run_load_plugins(plugins, fake_app, tmp_path)
+    assert fake_app.state.aaa_origin == "aaa"
+    assert fake_app.state.zzz_origin == "zzz"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -27,7 +27,7 @@ _BARE_NAMES_USED = ("util", "extractor")
 
 
 @pytest.fixture()
-def reset_plugin_state():
+def reset_plugin_state(monkeypatch):
     """Clear loader module-level state and restore on teardown.
 
     Saves and restores:
@@ -35,11 +35,14 @@ def reset_plugin_state():
       * any `plugin_*` keys we add to `sys.modules`
       * the bare names this module simulates (`util`, `extractor`)
       * `sys.path` — `plugins.load_plugins()` mutates it
-    so each test runs against a clean slate AND nothing leaks into
-    the rest of the suite. Per-module locks are owned by the
-    standard import system (`importlib._bootstrap._module_locks`)
-    and are not our responsibility to reset.
+    Also unsets `SLOPSMITH_PLUGINS_DIR` for the test's duration
+    (via monkeypatch) so a CI env that pre-sets it can't leak
+    real user plugins into a tmp_path-driven test. Per-module
+    locks are owned by the standard import system
+    (`importlib._bootstrap._module_locks`) and are not our
+    responsibility to reset.
     """
+    monkeypatch.delenv("SLOPSMITH_PLUGINS_DIR", raising=False)
     plugins = importlib.import_module("plugins")
     saved_loaded = list(plugins.LOADED_PLUGINS)
     saved_modules = {k: v for k, v in sys.modules.items() if k.startswith("plugin_")}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -6,8 +6,9 @@ which made bare `import sibling` fall through Python's per-name cache
 in `sys.modules`. Two plugins shipping a same-named top-level module
 (`extractor.py`, `util.py`, …) would step on each other. The loader
 now exposes `context['load_sibling'](name)` that loads the sibling
-under a namespaced module name `plugin_{plugin_id}_{name}`, plus a
-warning at startup so existing plugins are visible.
+under a namespaced module name `plugin_<plugin_id>.<name>` (with `.`
+in plugin_id escaped to `_x2e_`), plus a warning at startup so
+existing colliding plugins are visible.
 """
 
 import importlib
@@ -17,29 +18,50 @@ import sys
 import pytest
 
 
+# Bare module names that this test module pre-populates into
+# sys.modules to simulate the bare-import path. Saved/restored by
+# the reset_plugin_state fixture so they don't leak to other test
+# files. Codex / Copilot review on PR for slopsmith#33.
+_BARE_NAMES_USED = ("util", "extractor")
+
+
 @pytest.fixture()
 def reset_plugin_state():
     """Clear loader module-level state and restore on teardown.
 
-    `plugins.LOADED_PLUGINS` and any `plugin_*` keys we add to
-    `sys.modules` would otherwise leak across tests within a session.
+    Saves and restores:
+      * `plugins.LOADED_PLUGINS`
+      * any `plugin_*` keys we add to `sys.modules`
+      * the bare names this module simulates (`util`, `extractor`)
+      * `sys.path` — `plugins.load_plugins()` mutates it
+      * `plugins._sibling_locks` — the per-module-name lock dict
+    so each test runs against a clean slate AND nothing leaks into
+    the rest of the suite.
     """
     plugins = importlib.import_module("plugins")
     saved_loaded = list(plugins.LOADED_PLUGINS)
     saved_modules = {k: v for k, v in sys.modules.items() if k.startswith("plugin_")}
+    saved_bare = {k: sys.modules[k] for k in _BARE_NAMES_USED if k in sys.modules}
+    saved_path = list(sys.path)
+    saved_locks = dict(plugins._sibling_locks)
     plugins.LOADED_PLUGINS.clear()
+    plugins._sibling_locks.clear()
     for k in list(sys.modules):
-        if k.startswith("plugin_"):
+        if k.startswith("plugin_") or k in _BARE_NAMES_USED:
             del sys.modules[k]
     try:
         yield plugins
     finally:
         plugins.LOADED_PLUGINS.clear()
         plugins.LOADED_PLUGINS.extend(saved_loaded)
+        plugins._sibling_locks.clear()
+        plugins._sibling_locks.update(saved_locks)
         for k in list(sys.modules):
-            if k.startswith("plugin_"):
+            if k.startswith("plugin_") or k in _BARE_NAMES_USED:
                 del sys.modules[k]
         sys.modules.update(saved_modules)
+        sys.modules.update(saved_bare)
+        sys.path[:] = saved_path
 
 
 def _make_plugin(plugin_root, plugin_id, *, sibling_files=None, routes_body=None):
@@ -198,9 +220,10 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
 def test_collision_warning_dedupes_per_plugin(tmp_path, reset_plugin_state, capsys):
     """A single plugin shipping BOTH `extractor.py` and
     `extractor/__init__.py` is a supported intra-plugin layout
-    (load_sibling deterministically prefers the file form). The
-    warning must NOT count it as a 2-plugin collision and emit a
-    bogus message listing the same plugin id twice. Codex round 5."""
+    (load_sibling deterministically prefers the package form,
+    matching CPython's import precedence). The warning must NOT
+    count it as a 2-plugin collision and emit a bogus message
+    listing the same plugin id twice. Codex round 5."""
     plugins = reset_plugin_state
     plugin_dir = _make_plugin(tmp_path, "lonely")
     (plugin_dir / "extractor.py").write_text("FROM = 'file'\n")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -195,34 +195,6 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
     assert "Module-name collision warning" not in out
 
 
-def test_load_plugins_rejects_dotted_ids_at_discovery(tmp_path, reset_plugin_state, capsys):
-    """A plugin whose manifest id contains `.` is refused at
-    discovery and skipped. The helper's synthetic-parent machinery
-    can't handle dotted ids — better to fail loudly at startup
-    than to silently register the plugin and have the first
-    `context['load_sibling'](...)` call blow up. Codex round 6."""
-    plugins = reset_plugin_state
-    _make_plugin(tmp_path, "valid_id", sibling_files={"util": "X = 1\n"})
-    # Manually craft a plugin with a dotted id — _make_plugin would
-    # also create the directory under that name; that's fine for the
-    # test as long as the loader sees the manifest and skips it.
-    bad_dir = tmp_path / "dotted"
-    bad_dir.mkdir()
-    (bad_dir / "plugin.json").write_text(
-        '{"id": "foo.bar", "name": "dotted"}'
-    )
-    (bad_dir / "routes.py").write_text("def setup(app, ctx): pass\n")
-    fake_app = type("FakeApp", (), {})()
-    _run_load_plugins(plugins, fake_app, tmp_path)
-    out = capsys.readouterr().out
-    # Bad plugin gets refused, valid_id loads.
-    assert "Refusing to load 'foo.bar'" in out
-    assert "must not contain '.'" in out
-    loaded_ids = {p["id"] for p in plugins.LOADED_PLUGINS}
-    assert "foo.bar" not in loaded_ids
-    assert "valid_id" in loaded_ids
-
-
 def test_collision_warning_dedupes_per_plugin(tmp_path, reset_plugin_state, capsys):
     """A single plugin shipping BOTH `extractor.py` and
     `extractor/__init__.py` is a supported intra-plugin layout
@@ -309,19 +281,71 @@ def test_load_sibling_does_not_alias_bare_imported_package(tmp_path, reset_plugi
     assert child.FROM == "leaf"
 
 
-def test_load_sibling_rejects_dotted_plugin_id(tmp_path, reset_plugin_state):
-    """A plugin_id containing `.` would make the namespaced key
-    ambiguous (Python would treat `plugin_foo.bar` as a real package
-    structure). Reject such ids with a clear error so the manifest
-    convention is enforced loudly. Codex round 4."""
+def test_load_sibling_handles_dotted_plugin_id_via_escape(tmp_path, reset_plugin_state):
+    """Plugins with reverse-DNS-style ids (`foo.bar`) must still be
+    able to use load_sibling — the helper escapes `.` in the
+    plugin_id portion of the cache key so the synthetic parent
+    package is still well-formed. Spotted across codex review
+    rounds on PR for slopsmith#33."""
+    plugins = reset_plugin_state
+    plugin_dir = tmp_path / "rdns"
+    plugin_dir.mkdir()
+    (plugin_dir / "util.py").write_text("VALUE = 'reverse-dns'\n")
+    util = plugins._load_plugin_sibling("com.example.foo", plugin_dir, "util")
+    assert util.VALUE == "reverse-dns"
+    # The cache key uses the escaped form so it doesn't fight with
+    # Python's package resolution.
+    assert "plugin_com_x2e_example_x2e_foo.util" in sys.modules
+    assert sys.modules["plugin_com_x2e_example_x2e_foo.util"] is util
+
+
+def test_load_sibling_rejects_empty_plugin_id(tmp_path, reset_plugin_state):
+    """Empty / non-string plugin_id is still rejected — the helper
+    needs SOMETHING to namespace under."""
     plugins = reset_plugin_state
     plugin_dir = _make_plugin(tmp_path, "valid_id", sibling_files={"util": "X = 1\n"})
-    with pytest.raises(ValueError, match="without '.'"):
-        plugins._load_plugin_sibling("foo.bar", plugin_dir, "util")
-    # And empty / non-string ids are rejected too.
     for bad in ("", None, 123):
         with pytest.raises((ValueError, TypeError)):
             plugins._load_plugin_sibling(bad, plugin_dir, "util")
+
+
+def test_load_sibling_supports_relative_imports_between_siblings(tmp_path, reset_plugin_state):
+    """A sibling loaded via load_sibling that does `from .shared
+    import X` (relative import to another top-level sibling) must
+    resolve. The synthetic parent's __path__ points at the plugin
+    directory so the import machinery can find sibling files via
+    the standard relative-import path. Codex round 7."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "rel")
+    (plugin_dir / "shared.py").write_text("SHARED_VALUE = 'shared'\n")
+    (plugin_dir / "extractor.py").write_text(
+        "from .shared import SHARED_VALUE\n"
+        "RE_EXPORT = SHARED_VALUE\n"
+    )
+    extractor = plugins._load_plugin_sibling("rel", plugin_dir, "extractor")
+    assert extractor.RE_EXPORT == "shared"
+    # The relatively-imported sibling is registered under the
+    # namespaced key, NOT polluted into the global `shared` slot
+    # (collision risk with other plugins' `shared.py`).
+    assert "plugin_rel.shared" in sys.modules
+
+
+def test_load_sibling_package_relative_import_to_outside_sibling(tmp_path, reset_plugin_state):
+    """A package-form sibling whose __init__.py does
+    `from ..shared import X` reaches the parent and finds another
+    sibling. Verifies the package + parent-__path__ wiring works
+    end-to-end. Codex round 7."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "pkgrel")
+    (plugin_dir / "shared.py").write_text("VAL = 42\n")
+    pkg_dir = plugin_dir / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text(
+        "from ..shared import VAL\n"
+        "VALUE = VAL\n"
+    )
+    extractor = plugins._load_plugin_sibling("pkgrel", plugin_dir, "extractor")
+    assert extractor.VALUE == 42
 
 
 def test_load_sibling_package_relative_import_works(tmp_path, reset_plugin_state):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -195,6 +195,92 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
     assert "Module-name collision warning" not in out
 
 
+def test_collision_warning_dedupes_per_plugin(tmp_path, reset_plugin_state, capsys):
+    """A single plugin shipping BOTH `extractor.py` and
+    `extractor/__init__.py` is a supported intra-plugin layout
+    (load_sibling deterministically prefers the file form). The
+    warning must NOT count it as a 2-plugin collision and emit a
+    bogus message listing the same plugin id twice. Codex round 5."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "lonely")
+    (plugin_dir / "extractor.py").write_text("FROM = 'file'\n")
+    pkg_dir = plugin_dir / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("FROM = 'package'\n")
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    # Only one plugin is involved, so no cross-plugin warning fires.
+    assert "Module-name collision warning" not in out
+
+
+def test_collision_warning_still_fires_when_two_plugins_each_have_both_forms(
+    tmp_path, reset_plugin_state, capsys
+):
+    """Two plugins each shipping both forms of `extractor` IS a
+    real cross-plugin collision and must be reported. Codex round 5
+    sanity check on the dedup logic."""
+    plugins = reset_plugin_state
+    for pid in ("alpha", "beta"):
+        plugin_dir = _make_plugin(tmp_path, pid)
+        (plugin_dir / "extractor.py").write_text(f"OWNER = '{pid}-file'\n")
+        pkg_dir = plugin_dir / "extractor"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(f"OWNER = '{pid}-package'\n")
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    warning_lines = [ln for ln in out.splitlines() if "Module-name collision warning" in ln]
+    assert len(warning_lines) == 1
+    warning = warning_lines[0]
+    assert "alpha" in warning
+    assert "beta" in warning
+    # The warning text should list each plugin id ONCE, even though
+    # both plugins ship two forms of `extractor`.
+    assert warning.count("'alpha'") == 1
+    assert warning.count("'beta'") == 1
+    # Both forms reported in the kind label.
+    assert "module/package" in warning
+
+
+def test_load_sibling_does_not_alias_bare_imported_package(tmp_path, reset_plugin_state):
+    """A bare-imported package keeps `__package__` and
+    `__spec__.name` as the un-namespaced bare name, so lazy
+    relative imports inside it would still resolve through the
+    global cache. To avoid that, load_sibling does NOT reuse a
+    bare-imported package — it re-executes under the namespaced
+    spec instead. Two copies of the package coexist (one bare,
+    one namespaced); module-level state diverges. This is
+    documented as the trade-off; the alternative would silently
+    leak submodule cross-loads. Codex round 5."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "pkgsafe")
+    pkg_dir = plugin_dir / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("MARK = object()\n")
+    (pkg_dir / "child.py").write_text("FROM = 'leaf'\n")
+    # Pre-populate sys.modules['extractor'] as if a bare import had
+    # already pulled in the package.
+    spec = importlib.util.spec_from_file_location(
+        "extractor",
+        str(pkg_dir / "__init__.py"),
+        submodule_search_locations=[str(pkg_dir)],
+    )
+    bare_pkg = importlib.util.module_from_spec(spec)
+    sys.modules["extractor"] = bare_pkg
+    spec.loader.exec_module(bare_pkg)
+    bare_mark = bare_pkg.MARK
+    # load_sibling re-executes under the namespaced spec rather
+    # than aliasing the bare package.
+    via_helper = plugins._load_plugin_sibling("pkgsafe", plugin_dir, "extractor")
+    assert via_helper is not bare_pkg
+    # Different MARK objects confirm the namespaced version was
+    # actually re-executed.
+    assert via_helper.MARK is not bare_mark
+    # The namespaced submodule resolves through the namespaced
+    # package, NOT through `extractor.child`.
+    child = importlib.import_module("plugin_pkgsafe.extractor.child")
+    assert child.FROM == "leaf"
+
+
 def test_load_sibling_rejects_dotted_plugin_id(tmp_path, reset_plugin_state):
     """A plugin_id containing `.` would make the namespaced key
     ambiguous (Python would treat `plugin_foo.bar` as a real package
@@ -208,38 +294,6 @@ def test_load_sibling_rejects_dotted_plugin_id(tmp_path, reset_plugin_state):
     for bad in ("", None, 123):
         with pytest.raises((ValueError, TypeError)):
             plugins._load_plugin_sibling(bad, plugin_dir, "util")
-
-
-def test_load_sibling_creates_parent_even_when_reusing_bare_package(tmp_path, reset_plugin_state):
-    """Mixed-migration corner: a plugin bare-imports a package
-    sibling first, then later calls load_sibling for the same
-    package. The reuse path used to short-circuit before creating
-    the synthetic parent, so submodule imports failed afterward.
-    Codex round 4."""
-    plugins = reset_plugin_state
-    plugin_dir = _make_plugin(tmp_path, "mixedpkg")
-    pkg_dir = plugin_dir / "extractor"
-    pkg_dir.mkdir()
-    (pkg_dir / "__init__.py").write_text("ROOT = 'init'\n")
-    (pkg_dir / "child.py").write_text("CHILD = 'leaf'\n")
-    # Simulate bare `import extractor` resolving the package via
-    # sys.path during transition.
-    spec = importlib.util.spec_from_file_location(
-        "extractor",
-        str(pkg_dir / "__init__.py"),
-        submodule_search_locations=[str(pkg_dir)],
-    )
-    bare_pkg = importlib.util.module_from_spec(spec)
-    sys.modules["extractor"] = bare_pkg
-    spec.loader.exec_module(bare_pkg)
-    # Now switch to load_sibling.
-    via_helper = plugins._load_plugin_sibling("mixedpkg", plugin_dir, "extractor")
-    assert via_helper is bare_pkg
-    # The synthetic parent must exist so submodule imports through
-    # the namespaced key still work after the reuse.
-    assert "plugin_mixedpkg" in sys.modules
-    child = importlib.import_module("plugin_mixedpkg.extractor.child")
-    assert child.CHILD == "leaf"
 
 
 def test_load_sibling_package_relative_import_works(tmp_path, reset_plugin_state):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -309,6 +309,36 @@ def test_load_sibling_rejects_empty_plugin_id(tmp_path, reset_plugin_state):
             plugins._load_plugin_sibling(bad, plugin_dir, "util")
 
 
+def test_load_sibling_exposes_child_as_parent_attribute(tmp_path, reset_plugin_state):
+    """After load_sibling caches a child, Python's package-style
+    relative imports (`from . import sibling`, `from .. import
+    sibling`) need to find the child as an ATTRIBUTE on the parent
+    package — not just in sys.modules. The standard import
+    machinery sets that attribute; load_sibling must mimic the
+    behavior. Codex round 9."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "expose")
+    (plugin_dir / "extractor.py").write_text("VAL = 'extr'\n")
+    # Another sibling does `from . import extractor` — pure
+    # attribute lookup on the synthetic parent.
+    (plugin_dir / "consumer.py").write_text(
+        "from . import extractor\n"
+        "GOT = extractor.VAL\n"
+    )
+    # Load the consumer first; while it's executing, the
+    # `from . import extractor` triggers extractor's import
+    # through the parent package's __path__. After it loads,
+    # extractor must be visible as an attribute on the parent.
+    consumer = plugins._load_plugin_sibling("expose", plugin_dir, "consumer")
+    assert consumer.GOT == "extr"
+    parent = sys.modules["plugin_expose"]
+    assert hasattr(parent, "extractor")
+    assert parent.extractor is sys.modules["plugin_expose.extractor"]
+    # And consumer is exposed on the parent the same way.
+    assert hasattr(parent, "consumer")
+    assert parent.consumer is consumer
+
+
 def test_load_sibling_supports_relative_imports_between_siblings(tmp_path, reset_plugin_state):
     """A sibling loaded via load_sibling that does `from .shared
     import X` (relative import to another top-level sibling) must

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -35,18 +35,17 @@ def reset_plugin_state():
       * any `plugin_*` keys we add to `sys.modules`
       * the bare names this module simulates (`util`, `extractor`)
       * `sys.path` — `plugins.load_plugins()` mutates it
-      * `plugins._sibling_locks` — the per-module-name lock dict
     so each test runs against a clean slate AND nothing leaks into
-    the rest of the suite.
+    the rest of the suite. Per-module locks are owned by the
+    standard import system (`importlib._bootstrap._module_locks`)
+    and are not our responsibility to reset.
     """
     plugins = importlib.import_module("plugins")
     saved_loaded = list(plugins.LOADED_PLUGINS)
     saved_modules = {k: v for k, v in sys.modules.items() if k.startswith("plugin_")}
     saved_bare = {k: sys.modules[k] for k in _BARE_NAMES_USED if k in sys.modules}
     saved_path = list(sys.path)
-    saved_locks = dict(plugins._sibling_locks)
     plugins.LOADED_PLUGINS.clear()
-    plugins._sibling_locks.clear()
     for k in list(sys.modules):
         if k.startswith("plugin_") or k in _BARE_NAMES_USED:
             del sys.modules[k]
@@ -55,8 +54,6 @@ def reset_plugin_state():
     finally:
         plugins.LOADED_PLUGINS.clear()
         plugins.LOADED_PLUGINS.extend(saved_loaded)
-        plugins._sibling_locks.clear()
-        plugins._sibling_locks.update(saved_locks)
         for k in list(sys.modules):
             if k.startswith("plugin_") or k in _BARE_NAMES_USED:
                 del sys.modules[k]
@@ -506,6 +503,26 @@ def test_load_plugins_skips_non_string_id(tmp_path, reset_plugin_state, capsys):
     loaded_ids = {p["id"] for p in plugins.LOADED_PLUGINS}
     assert 42 not in loaded_ids
     assert "good" in loaded_ids
+
+
+def test_load_plugins_warns_on_falsy_non_string_id(tmp_path, reset_plugin_state, capsys):
+    """`{"id": 0}` and `{"id": []}` are falsy non-strings. The
+    type-check must run BEFORE the falsy-empty check so the user
+    gets the explicit "must be a string" warning instead of a
+    silent skip. Copilot review on PR #105 round 4."""
+    plugins = reset_plugin_state
+    for i, bad_value in enumerate(("0", "[]", "false")):  # JSON literals
+        bad_dir = tmp_path / f"bad{i}"
+        bad_dir.mkdir()
+        (bad_dir / "plugin.json").write_text(f'{{"id": {bad_value}, "name": "x"}}')
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+    out = capsys.readouterr().out
+    # Each malformed manifest produces a "must be a string" warning;
+    # none are silently dropped.
+    assert out.count("must be a string") == 3
+    assert "int" in out  # for {"id": 0}
+    assert "list" in out  # for {"id": []}
+    assert "bool" in out  # for {"id": false}
 
 
 def test_load_plugins_escapes_dotted_id_in_routes_module_name(tmp_path, reset_plugin_state):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -195,6 +195,53 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
     assert "Module-name collision warning" not in out
 
 
+def test_load_sibling_rejects_dotted_plugin_id(tmp_path, reset_plugin_state):
+    """A plugin_id containing `.` would make the namespaced key
+    ambiguous (Python would treat `plugin_foo.bar` as a real package
+    structure). Reject such ids with a clear error so the manifest
+    convention is enforced loudly. Codex round 4."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "valid_id", sibling_files={"util": "X = 1\n"})
+    with pytest.raises(ValueError, match="without '.'"):
+        plugins._load_plugin_sibling("foo.bar", plugin_dir, "util")
+    # And empty / non-string ids are rejected too.
+    for bad in ("", None, 123):
+        with pytest.raises((ValueError, TypeError)):
+            plugins._load_plugin_sibling(bad, plugin_dir, "util")
+
+
+def test_load_sibling_creates_parent_even_when_reusing_bare_package(tmp_path, reset_plugin_state):
+    """Mixed-migration corner: a plugin bare-imports a package
+    sibling first, then later calls load_sibling for the same
+    package. The reuse path used to short-circuit before creating
+    the synthetic parent, so submodule imports failed afterward.
+    Codex round 4."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "mixedpkg")
+    pkg_dir = plugin_dir / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("ROOT = 'init'\n")
+    (pkg_dir / "child.py").write_text("CHILD = 'leaf'\n")
+    # Simulate bare `import extractor` resolving the package via
+    # sys.path during transition.
+    spec = importlib.util.spec_from_file_location(
+        "extractor",
+        str(pkg_dir / "__init__.py"),
+        submodule_search_locations=[str(pkg_dir)],
+    )
+    bare_pkg = importlib.util.module_from_spec(spec)
+    sys.modules["extractor"] = bare_pkg
+    spec.loader.exec_module(bare_pkg)
+    # Now switch to load_sibling.
+    via_helper = plugins._load_plugin_sibling("mixedpkg", plugin_dir, "extractor")
+    assert via_helper is bare_pkg
+    # The synthetic parent must exist so submodule imports through
+    # the namespaced key still work after the reuse.
+    assert "plugin_mixedpkg" in sys.modules
+    child = importlib.import_module("plugin_mixedpkg.extractor.child")
+    assert child.CHILD == "leaf"
+
+
 def test_load_sibling_package_relative_import_works(tmp_path, reset_plugin_state):
     """A package-form sibling whose __init__.py uses `from .child
     import X` must load. Without registering the synthetic parent

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,7 +7,8 @@ in `sys.modules`. Two plugins shipping a same-named top-level module
 (`extractor.py`, `util.py`, …) would step on each other. The loader
 now exposes `context['load_sibling'](name)` that loads the sibling
 under a namespaced module name `plugin_<plugin_id>.<name>` (with `.`
-in plugin_id escaped to `_x2e_`), plus a warning at startup so
+in plugin_id bijectively encoded — `_` -> `_5f_`, `.` -> `_2e_`),
+plus a warning at startup so
 existing colliding plugins are visible.
 """
 
@@ -316,10 +317,10 @@ def test_load_sibling_handles_dotted_plugin_id_via_escape(tmp_path, reset_plugin
     (plugin_dir / "util.py").write_text("VALUE = 'reverse-dns'\n")
     util = plugins._load_plugin_sibling("com.example.foo", plugin_dir, "util")
     assert util.VALUE == "reverse-dns"
-    # The cache key uses the escaped form so it doesn't fight with
-    # Python's package resolution.
-    assert "plugin_com_x2e_example_x2e_foo.util" in sys.modules
-    assert sys.modules["plugin_com_x2e_example_x2e_foo.util"] is util
+    # The cache key uses the bijectively-encoded form so it doesn't
+    # fight with Python's package resolution. `.` -> `_2e_`.
+    assert "plugin_com_2e_example_2e_foo.util" in sys.modules
+    assert sys.modules["plugin_com_2e_example_2e_foo.util"] is util
 
 
 def test_load_sibling_rejects_empty_plugin_id(tmp_path, reset_plugin_state):
@@ -458,14 +459,63 @@ def test_load_sibling_does_not_alias_bare_imported_file_module(tmp_path, reset_p
     assert via_helper.__package__ == "plugin_mixmig"
 
 
+def test_safe_plugin_id_encoding_is_collision_free(reset_plugin_state):
+    """Distinct plugin_ids must always map to distinct encoded
+    forms. The previous `.` -> `_x2e_` (only when `.` was present)
+    was not bijective: ids `foo.bar` and `foo_x2e_bar` both produced
+    `foo_x2e_bar`. With the bijective `_` -> `_5f_`, `.` -> `_2e_`
+    encoding (in that order), no two distinct plugin_ids map to the
+    same output. Copilot review on PR #105 round 3."""
+    plugins = reset_plugin_state
+    samples = [
+        "foo",
+        "foo_bar",
+        "foo.bar",
+        "foo_2e_bar",
+        "foo_5f_bar",
+        "foo_5f_2e_5f_bar",
+        "com.example.foo",
+        "com_example_foo",
+        "com_2e_example_2e_foo",
+        "",  # empty edge — empty maps to empty, distinct from all others
+        "_",
+        ".",
+        "._",
+        "_.",
+    ]
+    encoded = [plugins._safe_plugin_id_for_module_name(s) for s in samples]
+    # Bijective: distinct inputs -> distinct outputs.
+    assert len(set(encoded)) == len(samples), dict(zip(samples, encoded))
+
+
+def test_load_plugins_skips_non_string_id(tmp_path, reset_plugin_state, capsys):
+    """A malformed manifest with a non-string id (e.g. number) is
+    skipped with a clear message rather than crashing later inside
+    `_safe_plugin_id_for_module_name`'s `.replace()` call. Copilot
+    review on PR #105 round 3."""
+    plugins = reset_plugin_state
+    bad_dir = tmp_path / "bad"
+    bad_dir.mkdir()
+    (bad_dir / "plugin.json").write_text('{"id": 42, "name": "bad"}')
+    _make_plugin(tmp_path, "good", sibling_files={"util": "X = 1\n"})
+    fake_app = type("FakeApp", (), {})()
+    _run_load_plugins(plugins, fake_app, tmp_path)
+    out = capsys.readouterr().out
+    assert "must be a string" in out
+    assert "int" in out  # type name surfaced
+    loaded_ids = {p["id"] for p in plugins.LOADED_PLUGINS}
+    assert 42 not in loaded_ids
+    assert "good" in loaded_ids
+
+
 def test_load_plugins_escapes_dotted_id_in_routes_module_name(tmp_path, reset_plugin_state):
     """A plugin with a reverse-DNS id like `com.example.foo` must
     have its routes module registered under a `.`-free name, or
     Python would treat the cache key as a dotted package path and
     set `__package__` to an unintended parent (relative imports in
     routes.py would then resolve against something else entirely).
-    The same `_x2e_` escape used by load_sibling now applies to
-    routes too. Copilot review on PR #105 round 2."""
+    The same `.` -> `_2e_` encoding used by load_sibling now
+    applies to routes too. Copilot review on PR #105 round 2."""
     plugins = reset_plugin_state
     plugin_dir = tmp_path / "rdns_routes"
     plugin_dir.mkdir()
@@ -482,8 +532,8 @@ def test_load_plugins_escapes_dotted_id_in_routes_module_name(tmp_path, reset_pl
     # Routes module is registered under the escaped name and is a
     # single identifier-shaped key — NOT a dotted path that Python
     # would try to resolve as a real package.
-    assert "plugin_com_x2e_example_x2e_foo_routes" in sys.modules
-    routes_mod = sys.modules["plugin_com_x2e_example_x2e_foo_routes"]
+    assert "plugin_com_2e_example_2e_foo_routes" in sys.modules
+    routes_mod = sys.modules["plugin_com_2e_example_2e_foo_routes"]
     # __package__ is empty (top-level module), not a dotted parent.
     assert (routes_mod.__package__ or "") == ""
 
@@ -647,8 +697,9 @@ def test_load_sibling_missing_in_both_forms_raises_with_useful_message(tmp_path,
 
 def test_load_sibling_disambiguates_underscored_ids_and_names(tmp_path, reset_plugin_state):
     """`(plugin_id='a_b', name='c')` and `(plugin_id='a', name='b_c')`
-    must NOT collide in sys.modules. The `.` separator makes the cache
-    key unambiguous (the old `_` separator collapsed both to
+    must NOT collide in sys.modules. The `.` separator + bijective
+    `_` -> `_5f_` encoding of plugin_id make the cache key
+    unambiguous (the old `_` separator collapsed both to
     `plugin_a_b_c`). Codex review on PR for slopsmith#33."""
     plugins = reset_plugin_state
     p1 = _make_plugin(tmp_path, "a_b", sibling_files={"c": "WHO = 'a_b/c'\n"})
@@ -658,10 +709,16 @@ def test_load_sibling_disambiguates_underscored_ids_and_names(tmp_path, reset_pl
     assert m1 is not m2
     assert m1.WHO == "a_b/c"
     assert m2.WHO == "a/b_c"
-    # Both keys exist independently in sys.modules.
-    assert "plugin_a_b.c" in sys.modules
+    # Both keys exist independently in sys.modules. plugin_id `a_b`
+    # encodes to `a_5f_b` so the parent is `plugin_a_5f_b`. The
+    # NAME portion is not encoded (it's only the plugin_id that
+    # could be confused with the `.` separator). So:
+    #   id='a_b', name='c'   -> plugin_a_5f_b.c
+    #   id='a',   name='b_c' -> plugin_a.b_c
+    # The old `_` separator collapsed both to `plugin_a_b_c`.
+    assert "plugin_a_5f_b.c" in sys.modules
     assert "plugin_a.b_c" in sys.modules
-    assert sys.modules["plugin_a_b.c"] is m1
+    assert sys.modules["plugin_a_5f_b.c"] is m1
     assert sys.modules["plugin_a.b_c"] is m2
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -195,6 +195,34 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
     assert "Module-name collision warning" not in out
 
 
+def test_load_plugins_rejects_dotted_ids_at_discovery(tmp_path, reset_plugin_state, capsys):
+    """A plugin whose manifest id contains `.` is refused at
+    discovery and skipped. The helper's synthetic-parent machinery
+    can't handle dotted ids — better to fail loudly at startup
+    than to silently register the plugin and have the first
+    `context['load_sibling'](...)` call blow up. Codex round 6."""
+    plugins = reset_plugin_state
+    _make_plugin(tmp_path, "valid_id", sibling_files={"util": "X = 1\n"})
+    # Manually craft a plugin with a dotted id — _make_plugin would
+    # also create the directory under that name; that's fine for the
+    # test as long as the loader sees the manifest and skips it.
+    bad_dir = tmp_path / "dotted"
+    bad_dir.mkdir()
+    (bad_dir / "plugin.json").write_text(
+        '{"id": "foo.bar", "name": "dotted"}'
+    )
+    (bad_dir / "routes.py").write_text("def setup(app, ctx): pass\n")
+    fake_app = type("FakeApp", (), {})()
+    _run_load_plugins(plugins, fake_app, tmp_path)
+    out = capsys.readouterr().out
+    # Bad plugin gets refused, valid_id loads.
+    assert "Refusing to load 'foo.bar'" in out
+    assert "must not contain '.'" in out
+    loaded_ids = {p["id"] for p in plugins.LOADED_PLUGINS}
+    assert "foo.bar" not in loaded_ids
+    assert "valid_id" in loaded_ids
+
+
 def test_collision_warning_dedupes_per_plugin(tmp_path, reset_plugin_state, capsys):
     """A single plugin shipping BOTH `extractor.py` and
     `extractor/__init__.py` is a supported intra-plugin layout
@@ -390,11 +418,12 @@ def test_load_sibling_loads_package_form(tmp_path, reset_plugin_state):
     assert child.CHILD_VALUE == 8
 
 
-def test_load_sibling_prefers_file_over_package_when_both_exist(tmp_path, reset_plugin_state):
+def test_load_sibling_prefers_package_over_file_when_both_exist(tmp_path, reset_plugin_state):
     """If a plugin ships BOTH `extractor.py` and `extractor/__init__.py`
-    in the same directory, the file form wins (matches Python's own
-    import precedence — namespace packages last). Documents the
-    deterministic behavior in case anyone hits this corner."""
+    in the same directory, the package form wins — matches CPython's
+    own import-resolution precedence so bare `import extractor` and
+    `load_sibling('extractor')` always run the same code path.
+    Spotted by codex review on PR for slopsmith#33."""
     plugins = reset_plugin_state
     plugin_dir = _make_plugin(tmp_path, "both")
     (plugin_dir / "extractor.py").write_text("FROM = 'file'\n")
@@ -402,7 +431,7 @@ def test_load_sibling_prefers_file_over_package_when_both_exist(tmp_path, reset_
     pkg_dir.mkdir()
     (pkg_dir / "__init__.py").write_text("FROM = 'package'\n")
     extractor = plugins._load_plugin_sibling("both", plugin_dir, "extractor")
-    assert extractor.FROM == "file"
+    assert extractor.FROM == "package"
 
 
 def test_load_sibling_missing_in_both_forms_raises_with_useful_message(tmp_path, reset_plugin_state):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -195,6 +195,80 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
     assert "Module-name collision warning" not in out
 
 
+def test_load_sibling_package_relative_import_works(tmp_path, reset_plugin_state):
+    """A package-form sibling whose __init__.py uses `from .child
+    import X` must load. Without registering the synthetic parent
+    package `plugin_<id>` in sys.modules first, Python can't resolve
+    the relative import. Codex round 3 caught this."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "relpkg")
+    pkg_dir = plugin_dir / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "child.py").write_text("CHILD_VALUE = 99\n")
+    (pkg_dir / "__init__.py").write_text(
+        "from .child import CHILD_VALUE\n"
+        "RE_EXPORT = CHILD_VALUE\n"
+    )
+    extractor = plugins._load_plugin_sibling("relpkg", plugin_dir, "extractor")
+    assert extractor.RE_EXPORT == 99
+    # Parent package was registered as a synthetic ModuleType.
+    assert "plugin_relpkg" in sys.modules
+
+
+def test_load_sibling_reuses_bare_imported_same_file(tmp_path, reset_plugin_state):
+    """If a plugin still has bare `import util` somewhere AND also
+    calls `load_sibling('util')`, both should return the SAME module
+    object so module-level state isn't duplicated. The reuse check
+    is gated on path equality so a bare import of a DIFFERENT
+    plugin's same-named util.py is NOT mistakenly returned. Codex
+    round 3."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "mixmig")
+    util_path = plugin_dir / "util.py"
+    util_path.write_text("STATE = []\nSTATE.append('initial')\n")
+    # Simulate the bare-import path: load util.py under the bare
+    # name `util` first, the way `import util` would after sys.path
+    # insertion.
+    spec = importlib.util.spec_from_file_location("util", str(util_path))
+    bare_mod = importlib.util.module_from_spec(spec)
+    sys.modules["util"] = bare_mod
+    spec.loader.exec_module(bare_mod)
+    bare_mod.STATE.append("bare-only-mutation")
+    # Now invoke load_sibling for the same plugin's util.py.
+    via_helper = plugins._load_plugin_sibling("mixmig", plugin_dir, "util")
+    # Same module object — the helper detected the path match and
+    # reused the cached bare import instead of re-executing util.py.
+    assert via_helper is bare_mod
+    # The mutation done on the bare module is visible via the helper.
+    assert "bare-only-mutation" in via_helper.STATE
+    # The namespaced key now also points at the SAME object so future
+    # load_sibling calls hit the cache.
+    assert sys.modules["plugin_mixmig.util"] is bare_mod
+
+
+def test_load_sibling_does_not_reuse_other_plugins_bare_import(tmp_path, reset_plugin_state):
+    """If sys.path has already cached a util.py from PLUGIN A under
+    the bare name `util`, plugin B's load_sibling('util') must NOT
+    return plugin A's module — it has to load plugin B's own copy
+    under the namespaced key. This is the whole point of the
+    isolation fix; the reuse path can't accidentally undo it."""
+    plugins = reset_plugin_state
+    plugin_a = _make_plugin(tmp_path, "plug_a")
+    plugin_b = _make_plugin(tmp_path, "plug_b")
+    (plugin_a / "util.py").write_text("OWNER = 'a'\n")
+    (plugin_b / "util.py").write_text("OWNER = 'b'\n")
+    # Simulate plugin A's bare import landing in sys.modules['util'].
+    spec_a = importlib.util.spec_from_file_location("util", str(plugin_a / "util.py"))
+    bare_a = importlib.util.module_from_spec(spec_a)
+    sys.modules["util"] = bare_a
+    spec_a.loader.exec_module(bare_a)
+    assert bare_a.OWNER == "a"
+    # Plugin B's load_sibling must give plugin B's util, NOT plugin A's.
+    b_util = plugins._load_plugin_sibling("plug_b", plugin_b, "util")
+    assert b_util is not bare_a
+    assert b_util.OWNER == "b"
+
+
 def test_load_sibling_loads_package_form(tmp_path, reset_plugin_state):
     """A plugin shipping a sibling as a package directory
     (`extractor/__init__.py`) should be loadable through

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -458,6 +458,76 @@ def test_load_sibling_does_not_alias_bare_imported_file_module(tmp_path, reset_p
     assert via_helper.__package__ == "plugin_mixmig"
 
 
+def test_load_plugins_escapes_dotted_id_in_routes_module_name(tmp_path, reset_plugin_state):
+    """A plugin with a reverse-DNS id like `com.example.foo` must
+    have its routes module registered under a `.`-free name, or
+    Python would treat the cache key as a dotted package path and
+    set `__package__` to an unintended parent (relative imports in
+    routes.py would then resolve against something else entirely).
+    The same `_x2e_` escape used by load_sibling now applies to
+    routes too. Copilot review on PR #105 round 2."""
+    plugins = reset_plugin_state
+    plugin_dir = tmp_path / "rdns_routes"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "com.example.foo", "name": "rdns", "routes": "routes.py"})
+    )
+    (plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    app.state.routes_loaded = True\n"
+    )
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    _run_load_plugins(plugins, fake_app, tmp_path)
+    assert fake_app.state.routes_loaded is True
+    # Routes module is registered under the escaped name and is a
+    # single identifier-shaped key — NOT a dotted path that Python
+    # would try to resolve as a real package.
+    assert "plugin_com_x2e_example_x2e_foo_routes" in sys.modules
+    routes_mod = sys.modules["plugin_com_x2e_example_x2e_foo_routes"]
+    # __package__ is empty (top-level module), not a dotted parent.
+    assert (routes_mod.__package__ or "") == ""
+
+
+def test_load_sibling_parent_registration_is_atomic(tmp_path, reset_plugin_state):
+    """Two threads loading DIFFERENT siblings for the same plugin
+    must agree on the synthetic parent. If they each constructed a
+    fresh ModuleType and assigned to sys.modules[parent_name]
+    without coordination, the second assignment could replace the
+    first — and child attributes already attached to the
+    first parent would disappear, breaking `from . import sibling`.
+    setdefault makes the registration atomic. Copilot round 2."""
+    import threading
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "atomic")
+    # Two slow siblings so the threads have time to overlap.
+    (plugin_dir / "alpha.py").write_text("import time\ntime.sleep(0.05)\nVALUE = 'a'\n")
+    (plugin_dir / "beta.py").write_text("import time\ntime.sleep(0.05)\nVALUE = 'b'\n")
+    errors: list = []
+
+    def worker(name):
+        try:
+            plugins._load_plugin_sibling("atomic", plugin_dir, name)
+        except BaseException as e:  # pragma: no cover
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=worker, args=("alpha",)),
+        threading.Thread(target=worker, args=("beta",)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors
+    parent = sys.modules["plugin_atomic"]
+    # Both children are exposed as attributes on the SAME parent —
+    # neither was lost to a parent-replacement race.
+    assert hasattr(parent, "alpha")
+    assert hasattr(parent, "beta")
+    assert parent.alpha.VALUE == "a"
+    assert parent.beta.VALUE == "b"
+
+
 def test_load_sibling_concurrent_first_call_returns_fully_initialized(tmp_path, reset_plugin_state):
     """Two threads racing on the same first-time load_sibling call
     should both receive a fully-initialized module object — neither

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -195,6 +195,54 @@ def test_collision_warning_excludes_routes_and_dunders(tmp_path, reset_plugin_st
     assert "Module-name collision warning" not in out
 
 
+def test_load_sibling_loads_package_form(tmp_path, reset_plugin_state):
+    """A plugin shipping a sibling as a package directory
+    (`extractor/__init__.py`) should be loadable through
+    load_sibling exactly like a single-file `.py` sibling. The
+    collision-warning scanner directs maintainers of package-form
+    plugins toward load_sibling, so the helper has to actually
+    support them. Codex review on PR for slopsmith#33."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "pkgplugin")
+    pkg_dir = plugin_dir / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("ROOT_VALUE = 7\n")
+    (pkg_dir / "child.py").write_text("CHILD_VALUE = 8\n")
+    extractor = plugins._load_plugin_sibling("pkgplugin", plugin_dir, "extractor")
+    assert extractor.ROOT_VALUE == 7
+    # Submodule lookup works because spec carried submodule_search_locations.
+    child = importlib.import_module("plugin_pkgplugin.extractor.child")
+    assert child.CHILD_VALUE == 8
+
+
+def test_load_sibling_prefers_file_over_package_when_both_exist(tmp_path, reset_plugin_state):
+    """If a plugin ships BOTH `extractor.py` and `extractor/__init__.py`
+    in the same directory, the file form wins (matches Python's own
+    import precedence — namespace packages last). Documents the
+    deterministic behavior in case anyone hits this corner."""
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "both")
+    (plugin_dir / "extractor.py").write_text("FROM = 'file'\n")
+    pkg_dir = plugin_dir / "extractor"
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").write_text("FROM = 'package'\n")
+    extractor = plugins._load_plugin_sibling("both", plugin_dir, "extractor")
+    assert extractor.FROM == "file"
+
+
+def test_load_sibling_missing_in_both_forms_raises_with_useful_message(tmp_path, reset_plugin_state):
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "empty")
+    with pytest.raises(ImportError) as exc:
+        plugins._load_plugin_sibling("empty", plugin_dir, "missing")
+    msg = str(exc.value)
+    # Error message should mention BOTH probed locations so a
+    # confused author sees "I checked here AND here" not "I checked
+    # only the .py form".
+    assert "missing.py" in msg
+    assert "missing" in msg and "__init__.py" in msg
+
+
 def test_load_sibling_disambiguates_underscored_ids_and_names(tmp_path, reset_plugin_state):
     """`(plugin_id='a_b', name='c')` and `(plugin_id='a', name='b_c')`
     must NOT collide in sys.modules. The `.` separator makes the cache

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -368,35 +368,86 @@ def test_load_sibling_package_relative_import_works(tmp_path, reset_plugin_state
     assert "plugin_relpkg" in sys.modules
 
 
-def test_load_sibling_reuses_bare_imported_same_file(tmp_path, reset_plugin_state):
-    """If a plugin still has bare `import util` somewhere AND also
-    calls `load_sibling('util')`, both should return the SAME module
-    object so module-level state isn't duplicated. The reuse check
-    is gated on path equality so a bare import of a DIFFERENT
-    plugin's same-named util.py is NOT mistakenly returned. Codex
-    round 3."""
+def test_load_sibling_does_not_alias_bare_imported_file_module(tmp_path, reset_plugin_state):
+    """Mixed migration: bare `import util` already cached this
+    plugin's util.py under the global `util` name. load_sibling
+    does NOT alias the bare module into the namespaced cache —
+    it re-executes under the namespaced spec. The bare module's
+    `__package__` / `__name__` / `__spec__` would otherwise stay
+    set to the un-namespaced bare name, and any later relative
+    import inside util.py (`from .shared import X` in a function
+    body) would route through the bare global cache, undoing the
+    isolation. Trade-off: module-level state in util splits across
+    two copies until the plugin removes its bare imports. Spotted
+    by codex review on PR for slopsmith#33 round 8."""
     plugins = reset_plugin_state
     plugin_dir = _make_plugin(tmp_path, "mixmig")
     util_path = plugin_dir / "util.py"
-    util_path.write_text("STATE = []\nSTATE.append('initial')\n")
-    # Simulate the bare-import path: load util.py under the bare
-    # name `util` first, the way `import util` would after sys.path
-    # insertion.
+    util_path.write_text("MARK = object()\n")
     spec = importlib.util.spec_from_file_location("util", str(util_path))
     bare_mod = importlib.util.module_from_spec(spec)
     sys.modules["util"] = bare_mod
     spec.loader.exec_module(bare_mod)
-    bare_mod.STATE.append("bare-only-mutation")
-    # Now invoke load_sibling for the same plugin's util.py.
+    bare_mark = bare_mod.MARK
     via_helper = plugins._load_plugin_sibling("mixmig", plugin_dir, "util")
-    # Same module object — the helper detected the path match and
-    # reused the cached bare import instead of re-executing util.py.
-    assert via_helper is bare_mod
-    # The mutation done on the bare module is visible via the helper.
-    assert "bare-only-mutation" in via_helper.STATE
-    # The namespaced key now also points at the SAME object so future
-    # load_sibling calls hit the cache.
-    assert sys.modules["plugin_mixmig.util"] is bare_mod
+    # Different module objects — the helper re-executed instead
+    # of aliasing.
+    assert via_helper is not bare_mod
+    assert via_helper.MARK is not bare_mark
+    # Namespaced key has the namespaced object; bare key still has
+    # the bare-imported object.
+    assert sys.modules["plugin_mixmig.util"] is via_helper
+    assert sys.modules["util"] is bare_mod
+    # Critically, via_helper has the correct namespaced metadata so
+    # later relative imports inside it would route through the
+    # synthetic parent.
+    assert via_helper.__name__ == "plugin_mixmig.util"
+    assert via_helper.__package__ == "plugin_mixmig"
+
+
+def test_load_sibling_concurrent_first_call_returns_fully_initialized(tmp_path, reset_plugin_state):
+    """Two threads racing on the same first-time load_sibling call
+    should both receive a fully-initialized module object — neither
+    can observe the half-built module that's briefly registered in
+    sys.modules between `module_from_spec` and the end of
+    `exec_module`. The per-module lock added in round 8 enforces
+    this."""
+    import threading
+    plugins = reset_plugin_state
+    plugin_dir = _make_plugin(tmp_path, "racy")
+    # The sibling's __init__ does meaningful work BEFORE setting
+    # `READY = True`, so a partially-initialized module would lack
+    # the attribute even though the module object exists in
+    # sys.modules.
+    (plugin_dir / "slow.py").write_text(
+        "import time\n"
+        "time.sleep(0.05)\n"
+        "READY = True\n"
+        "VALUE = 'done'\n"
+    )
+    results: list = []
+    errors: list = []
+
+    def worker():
+        try:
+            mod = plugins._load_plugin_sibling("racy", plugin_dir, "slow")
+            results.append((mod, getattr(mod, "READY", None), getattr(mod, "VALUE", None)))
+        except BaseException as e:  # pragma: no cover - bug path
+            errors.append(e)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors
+    assert len(results) == 8
+    # Every caller sees the same fully-initialized module.
+    first_mod, _, _ = results[0]
+    for mod, ready, value in results:
+        assert mod is first_mod
+        assert ready is True
+        assert value == "done"
 
 
 def test_load_sibling_does_not_reuse_other_plugins_bare_import(tmp_path, reset_plugin_state):


### PR DESCRIPTION
Closes #33.

## Summary

The plugin loader inserts each plugin's directory onto `sys.path` so plugins can `from extractor import X`. Python caches imports by module name in `sys.modules`, so two plugins shipping a same-named top-level module (`extractor.py`, `util.py`, …) collide: whichever loads first wins, the other's import fails or pulls the wrong file. A real Discord user hit this with `slopsmith-plugin-rs1extract` × `slopsmith-plugin-discextract` both shipping `extractor.py`. Both were renamed but the systemic issue remained.

This PR implements the issue's recommended approach (Option 1) plus a startup warning (Option 3) and CLAUDE.md docs (Option 2).

## What changed

**`plugins/__init__.py`**

- `context["load_sibling"](name)` — per-plugin closure that loads a sibling `.py` file or package directory under a namespaced module name `plugin_<id>.<name>`. Mirrors the existing routes-loading pattern (`importlib.util.spec_from_file_location`).
- Per-plugin context is a shallow copy of the shared one with the closure injected. Plugins can't mutate each other's view; closures correctly capture per-iteration `plugin_id`/`plugin_dir` via default-arg trick.
- Synthetic parent package (`plugin_<id>`) registered in `sys.modules` with `__path__ = [plugin_dir]` so relative imports between siblings work (`from .shared import X`, `from . import sibling`).
- Loaded children exposed as attributes on the parent (mimics CPython's standard `_find_and_load` post-step) so `from . import sibling` resolves via attribute lookup, not just sys.modules.
- Per-module-name locks so concurrent first-time `load_sibling` calls serialize through `exec_module` (cached check moved inside the lock to plug the half-init race).
- Plugin id `.` characters escaped to `_x2e_` in the cache key — reverse-DNS-style ids (`com.example.foo`) keep working without colliding with the package separator.
- Two-pass discovery: collect plugins first, then warn at startup about cross-plugin module-name collisions before any setup runs. Detects both `.py` and package (`extractor/__init__.py`) forms; dedupes per plugin id; labels the warning "module/package/mixed". Excludes `routes.py` (already namespaced) and dunder files.
- `sys.path` insertion is preserved during the transition so existing plugins keep working with bare imports.

**`CLAUDE.md`** — new "Sibling imports — use `load_sibling`, not bare imports" section under Plugin System / Backend routes, with example, validation rules, and migration notes.

**`tests/test_plugins.py`** — 26 new pytest cases covering: per-plugin namespacing, caching, missing modules, input validation (path traversal, `.py` suffix, `.` in name, non-string), collision warnings (file/package/mixed/dedup-per-plugin), closure-capture isolation, package-form siblings, file-vs-package precedence (package wins, matching CPython), parent-package relative imports (`.` and `..`), reverse-DNS plugin ids via escape, parent-as-attribute exposure, no-alias for bare-imported modules (file + package), no-cross-pollution between plugins' bare imports, and concurrent first-load thread-safety.

## Codex review

10 rounds of `codex review` hardening before pushing. Final round reports no findings. The 9 fix commits are split out so each individual change is auditable; happy to squash on merge if you prefer.

## Test plan

- [x] `python -m pytest tests/test_plugins.py -v` — all 26 plugin tests pass
- [x] `python -m pytest -q` — full suite 225 passed (was 207 before this PR)
- [ ] Manual: install two plugins shipping same-named top-level modules; observe the new collision warning at startup; confirm load_sibling returns each plugin's correct file independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)