### PR TITLE
Library filters + sort improvements (#129, #69, #128, #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Library filtering by parts present or missing (#129, #69). New right-side Filters drawer (single button next to the format/sort row, with active-filter count badge and dismissible chips below) lets you require or exclude arrangements (Lead/Rhythm/Bass/Combo), specific stems on sloppaks (drums/bass/vocals/piano/other), lyrics, and tuning. Multi-select within an axis is OR (Lead OR Rhythm); cross-axis is AND. State persists across reloads. New endpoint `GET /api/library/tuning-names` returns distinct tunings present in the library, ordered by musical distance.
+- Sort library by year (#128). Two new options in the sort dropdown: "Year (newest)" and "Year (oldest)". Songs without a year are pushed to the bottom for both directions.
+
 ### Changed
+- Tuning sort is now ordered by musical distance from E Standard (#22) instead of alphabetical: E Standard first, then Drop D / F Standard at distance 2, then Eb Standard / F# Standard at distance 6, etc. Matches Rocksmith's grouping. Within a magnitude tier, down-tuned variants come before up-tuned, then alphabetical.
 - Settings page restructured into separate "Slopsmith" (core) and "Plugins" sections, with each plugin's settings rendered as a collapsible panel (collapsed by default). "Plugin Updates" moved into the Plugins section.
+
+### Migration notes
+- The library filters depend on three new columns (`stem_ids`, `tuning_name`, `tuning_sort_key`) that are populated as songs are scanned. If filters look empty after upgrading, run **Settings → Full Rescan** to repopulate; alternatively the periodic background rescan picks them up over time.
 
 ## [0.2.4] - 2026-04-22
 

--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -284,7 +284,14 @@ def extract_meta(path: Path) -> dict:
     tuning_offsets = _tuning_for_meta(arr_list)
 
     stems_list = manifest.get("stems", []) or []
-    stem_count = sum(1 for s in stems_list if isinstance(s, dict) and s.get("id"))
+    stem_ids: list[str] = []
+    for s in stems_list:
+        if not isinstance(s, dict):
+            continue
+        sid = s.get("id")
+        if isinstance(sid, str) and sid:
+            stem_ids.append(sid)
+    stem_count = len(stem_ids)
 
     return {
         "title": str(manifest.get("title", "")),
@@ -296,4 +303,6 @@ def extract_meta(path: Path) -> dict:
         "arrangements": arrangements,
         "has_lyrics": has_lyrics,
         "stem_count": stem_count,
+        # slopsmith#129: per-stem filter needs the id list, not just count.
+        "stem_ids": stem_ids,
     }

--- a/lib/sloppak.py
+++ b/lib/sloppak.py
@@ -289,7 +289,15 @@ def extract_meta(path: Path) -> dict:
         if not isinstance(s, dict):
             continue
         sid = s.get("id")
-        if isinstance(sid, str) and sid:
+        sfile = s.get("file")
+        # Match `load_song()`'s validation: a stem entry needs BOTH a
+        # non-empty id AND a non-empty file to be playable. Indexing a
+        # half-formed entry would advertise a stem that load_song will
+        # later refuse to surface, so the library filter would lie.
+        if (
+            isinstance(sid, str) and sid
+            and isinstance(sfile, str) and sfile
+        ):
             stem_ids.append(sid)
     stem_count = len(stem_ids)
 

--- a/server.py
+++ b/server.py
@@ -305,7 +305,14 @@ class MetadataDB:
             "year-desc": "(year = '') ASC, CAST(year AS INTEGER) DESC",
         }
         order = sort_map.get(sort, "artist COLLATE NOCASE")
-        if direction == "desc" and "DESC" not in order:
+        # Legacy `dir=desc` toggle: only safe to append on simple sort
+        # clauses that don't already encode a direction. Compound /
+        # multi-term entries above (tuning, year, year-desc) bake their
+        # ASC/DESC into the clause, so a global ` DESC` append would
+        # produce invalid SQL like `CAST(year AS INTEGER) ASC DESC`.
+        # Skip the append in that case — clients flipping direction on
+        # those sorts use the explicit `-desc` sort key instead.
+        if direction == "desc" and " ASC" not in order and " DESC" not in order:
             order += " DESC"
 
         total = self.conn.execute(f"SELECT COUNT(*) FROM songs {where}", params).fetchone()[0]

--- a/server.py
+++ b/server.py
@@ -300,11 +300,23 @@ class MetadataDB:
             # how Rocksmith groups its tuning list. Final tiebreak by
             # name keeps the order fully deterministic.
             #
-            # Leading term pushes pre-migration / unscanned rows
-            # (`tuning_name` empty, `tuning_sort_key` defaulted to 0)
-            # to the bottom — without it ABS(0) collides with E
-            # Standard's 0 and the empty-tuning rows would sort first.
-            "tuning": "(tuning_name = '') ASC, ABS(tuning_sort_key), tuning_sort_key ASC, tuning_name COLLATE NOCASE",
+            # Leading term pushes pre-migration / unscanned rows to
+            # the bottom — without it ABS(0) collides with E
+            # Standard's 0 and unindexed rows would sort first.
+            # COALESCE on every column the clause references guards
+            # against NULL values — SQLite's literal-constant ADD
+            # COLUMN does backfill on most versions, but raw SQL
+            # inserts that bypass `put()`, edge-case migration paths,
+            # or future code that writes None could still leave NULLs
+            # behind, and a NULL `tuning_name` in `(tuning_name = '')`
+            # evaluates to NULL itself (which sorts ahead of 0 in
+            # ASC), defeating the push-to-bottom intent.
+            "tuning": (
+                "(COALESCE(tuning_name, '') = '') ASC, "
+                "ABS(COALESCE(tuning_sort_key, 0)), "
+                "COALESCE(tuning_sort_key, 0) ASC, "
+                "COALESCE(tuning_name, '') COLLATE NOCASE"
+            ),
             # Year sort (slopsmith#128). Empty-year rows pushed to the
             # bottom for both directions; otherwise CAST so '2010' >
             # '2005' rather than alphabetic.
@@ -922,14 +934,21 @@ def list_tuning_names():
     (slopsmith#22) — E Standard first, then nearest neighbors."""
     rows = meta_db.conn.execute(
         "SELECT tuning_name, MIN(tuning_sort_key), COUNT(*) "
-        "FROM songs WHERE title != '' AND tuning_name != '' "
+        # NULL/empty-name rows are excluded entirely from the picker —
+        # users can't usefully filter by an unknown tuning. Once they
+        # rescan, the rows acquire a name and join the list.
+        "FROM songs WHERE title != '' AND COALESCE(tuning_name, '') != '' "
         "GROUP BY tuning_name COLLATE NOCASE "
         # Same ordering as `sort=tuning` in `query_page`: distance
         # from E Standard first, then signed-key ASC so the down-
         # tuned variant precedes the up-tuned one at equal distance
         # (Eb Standard before F Standard at distance 6). Final
         # alphabetical tiebreak keeps the order deterministic.
-        "ORDER BY ABS(MIN(tuning_sort_key)), MIN(tuning_sort_key) ASC, tuning_name COLLATE NOCASE"
+        # COALESCE around the sort_key guards against NULL the same
+        # way the main tuning sort does.
+        "ORDER BY ABS(COALESCE(MIN(tuning_sort_key), 0)), "
+        "COALESCE(MIN(tuning_sort_key), 0) ASC, "
+        "tuning_name COLLATE NOCASE"
     ).fetchall()
     return {
         "tunings": [

--- a/server.py
+++ b/server.py
@@ -68,20 +68,33 @@ class MetadataDB:
                 arrangements TEXT,
                 has_lyrics INTEGER DEFAULT 0,
                 format TEXT DEFAULT 'psarc',
-                stem_count INTEGER DEFAULT 0
+                stem_count INTEGER DEFAULT 0,
+                stem_ids TEXT DEFAULT '[]',
+                tuning_name TEXT DEFAULT '',
+                tuning_sort_key INTEGER DEFAULT 0
             )
         """)
-        # Idempotent migration for installs that predate the format column.
-        try:
-            self.conn.execute("ALTER TABLE songs ADD COLUMN format TEXT DEFAULT 'psarc'")
-        except sqlite3.OperationalError:
-            pass
-        try:
-            self.conn.execute("ALTER TABLE songs ADD COLUMN stem_count INTEGER DEFAULT 0")
-        except sqlite3.OperationalError:
-            pass
+        # Idempotent migrations for installs that predate each column.
+        for ddl in (
+            "ALTER TABLE songs ADD COLUMN format TEXT DEFAULT 'psarc'",
+            "ALTER TABLE songs ADD COLUMN stem_count INTEGER DEFAULT 0",
+            # slopsmith#129: per-stem filter needs the id list, not just count.
+            "ALTER TABLE songs ADD COLUMN stem_ids TEXT DEFAULT '[]'",
+            # slopsmith#69 + #22: denormalized canonical tuning name + numeric
+            # sort key (sum of offsets). The existing `tuning` text column
+            # stays — these are caches, repopulated on rescan.
+            "ALTER TABLE songs ADD COLUMN tuning_name TEXT DEFAULT ''",
+            "ALTER TABLE songs ADD COLUMN tuning_sort_key INTEGER DEFAULT 0",
+        ):
+            try:
+                self.conn.execute(ddl)
+            except sqlite3.OperationalError:
+                pass
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_artist ON songs(artist COLLATE NOCASE)")
         self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_title ON songs(title COLLATE NOCASE)")
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_tuning_name ON songs(tuning_name COLLATE NOCASE)")
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_tuning_sort_key ON songs(tuning_sort_key)")
+        self.conn.execute("CREATE INDEX IF NOT EXISTS idx_songs_year ON songs(year)")
         self.conn.execute("CREATE TABLE IF NOT EXISTS favorites (filename TEXT PRIMARY KEY)")
         self.conn.execute("""
             CREATE TABLE IF NOT EXISTS loops (
@@ -116,7 +129,8 @@ class MetadataDB:
 
     def get(self, filename: str, mtime: float, size: int) -> dict | None:
         row = self.conn.execute(
-            "SELECT mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format, stem_count "
+            "SELECT mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, "
+            "format, stem_count, stem_ids, tuning_name, tuning_sort_key "
             "FROM songs WHERE filename = ?", (filename,)
         ).fetchone()
         if row and row[0] == mtime and row[1] == size and row[2]:
@@ -127,6 +141,9 @@ class MetadataDB:
                 "has_lyrics": bool(row[9]),
                 "format": row[10] or "psarc",
                 "stem_count": int(row[11] or 0),
+                "stem_ids": json.loads(row[12]) if row[12] else [],
+                "tuning_name": row[13] or "",
+                "tuning_sort_key": int(row[14] or 0),
             }
         return None
 
@@ -134,14 +151,18 @@ class MetadataDB:
         with self._lock:
             self.conn.execute(
                 "INSERT OR REPLACE INTO songs "
-                "(filename, mtime, size, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format, stem_count) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "(filename, mtime, size, title, artist, album, year, duration, tuning, arrangements, "
+                "has_lyrics, format, stem_count, stem_ids, tuning_name, tuning_sort_key) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (filename, mtime, size, meta.get("title", ""), meta.get("artist", ""),
                  meta.get("album", ""), meta.get("year", ""), meta.get("duration", 0),
                  meta.get("tuning", ""), json.dumps(meta.get("arrangements", [])),
                  1 if meta.get("has_lyrics") else 0,
                  meta.get("format", "psarc"),
-                 int(meta.get("stem_count", 0) or 0)),
+                 int(meta.get("stem_count", 0) or 0),
+                 json.dumps(meta.get("stem_ids", []) or []),
+                 meta.get("tuning_name", "") or "",
+                 int(meta.get("tuning_sort_key", 0) or 0)),
             )
             self.conn.commit()
 
@@ -169,13 +190,32 @@ class MetadataDB:
             originals.add(fname.replace("_EStd_", "_").replace("_DropD_", "_"))
         return originals
 
-    def query_page(self, q: str = "", page: int = 0, size: int = 24,
-                   sort: str = "artist", direction: str = "asc",
-                   favorites_only: bool = False,
-                   format_filter: str = "") -> tuple[list[dict], int]:
-        """Server-side paginated search. Returns (songs, total_count)."""
+    # Manifest-allowed filter values. Whitelisted before binding so a
+    # malformed query string can't push arbitrary text through to SQL —
+    # parameters are bound, but capping the input space is still cheap
+    # defense-in-depth (see slopsmith#129).
+    _ALLOWED_ARRANGEMENT_NAMES = {"Lead", "Rhythm", "Bass", "Combo"}
+    # Stem ids match the bare strings sloppak manifests use today —
+    # `full`, `guitar`, `bass`, `drums`, `vocals`, `piano`, `other`. The
+    # frontend filter UI omits `full` (it's the always-on fallback mix
+    # and would match every sloppak), but the server-side whitelist
+    # keeps it so a hand-rolled API client can still ask for it.
+    _ALLOWED_STEM_IDS = {"full", "guitar", "bass", "drums", "vocals", "piano", "other"}
+
+    def _build_where(self, q: str = "", favorites_only: bool = False,
+                     format_filter: str = "",
+                     arrangements_has: list[str] | None = None,
+                     arrangements_lacks: list[str] | None = None,
+                     stems_has: list[str] | None = None,
+                     stems_lacks: list[str] | None = None,
+                     has_lyrics: int | None = None,
+                     tunings: list[str] | None = None) -> tuple[str, list]:
+        """Shared WHERE-clause builder for query_page / query_artists /
+        query_stats. Returns (where_sql, params). Leading 'WHERE' is
+        included so callers paste it directly. See slopsmith#129/#69.
+        """
         where = "WHERE title != ''"
-        params = []
+        params: list = []
         if favorites_only:
             where += " AND filename IN (SELECT filename FROM favorites)"
         if format_filter:
@@ -184,11 +224,85 @@ class MetadataDB:
         if q:
             where += " AND (title LIKE ? COLLATE NOCASE OR artist LIKE ? COLLATE NOCASE OR album LIKE ? COLLATE NOCASE)"
             params += [f"%{q}%"] * 3
+        # arrangements_has: OR within axis (any-of). Uses JSON1's
+        # json_each which yields one row per arrangement, then matches
+        # the `name` field. The whole subquery is wrapped in EXISTS so
+        # we don't multiply rows in the outer SELECT.
+        arr_has = [a for a in (arrangements_has or []) if a in self._ALLOWED_ARRANGEMENT_NAMES]
+        if arr_has:
+            placeholders = ",".join(["?"] * len(arr_has))
+            where += (" AND EXISTS (SELECT 1 FROM json_each(songs.arrangements) "
+                      f"WHERE json_extract(value, '$.name') IN ({placeholders}))")
+            params += arr_has
+        arr_lacks = [a for a in (arrangements_lacks or []) if a in self._ALLOWED_ARRANGEMENT_NAMES]
+        if arr_lacks:
+            placeholders = ",".join(["?"] * len(arr_lacks))
+            where += (" AND NOT EXISTS (SELECT 1 FROM json_each(songs.arrangements) "
+                      f"WHERE json_extract(value, '$.name') IN ({placeholders}))")
+            params += arr_lacks
+        stems_h = [s for s in (stems_has or []) if s in self._ALLOWED_STEM_IDS]
+        if stems_h:
+            placeholders = ",".join(["?"] * len(stems_h))
+            where += (" AND EXISTS (SELECT 1 FROM json_each(songs.stem_ids) "
+                      f"WHERE value IN ({placeholders}))")
+            params += stems_h
+        stems_l = [s for s in (stems_lacks or []) if s in self._ALLOWED_STEM_IDS]
+        if stems_l:
+            placeholders = ",".join(["?"] * len(stems_l))
+            where += (" AND NOT EXISTS (SELECT 1 FROM json_each(songs.stem_ids) "
+                      f"WHERE value IN ({placeholders}))")
+            params += stems_l
+        if has_lyrics in (0, 1):
+            where += " AND has_lyrics = ?"
+            params.append(has_lyrics)
+        if tunings:
+            # Keep the input cap conservative (32) so a hostile caller
+            # can't blow out the parameter list. Real tuning sets in the
+            # wild number in the low double digits.
+            tn = [t for t in tunings if isinstance(t, str) and t][:32]
+            if tn:
+                placeholders = ",".join(["?"] * len(tn))
+                where += f" AND tuning_name COLLATE NOCASE IN ({placeholders})"
+                params += tn
+        return where, params
+
+    def query_page(self, q: str = "", page: int = 0, size: int = 24,
+                   sort: str = "artist", direction: str = "asc",
+                   favorites_only: bool = False,
+                   format_filter: str = "",
+                   arrangements_has: list[str] | None = None,
+                   arrangements_lacks: list[str] | None = None,
+                   stems_has: list[str] | None = None,
+                   stems_lacks: list[str] | None = None,
+                   has_lyrics: int | None = None,
+                   tunings: list[str] | None = None) -> tuple[list[dict], int]:
+        """Server-side paginated search. Returns (songs, total_count)."""
+        where, params = self._build_where(
+            q=q, favorites_only=favorites_only, format_filter=format_filter,
+            arrangements_has=arrangements_has, arrangements_lacks=arrangements_lacks,
+            stems_has=stems_has, stems_lacks=stems_lacks,
+            has_lyrics=has_lyrics, tunings=tunings,
+        )
 
         sort_map = {
             "artist": "artist COLLATE NOCASE", "artist-desc": "artist COLLATE NOCASE DESC",
             "title": "title COLLATE NOCASE", "title-desc": "title COLLATE NOCASE DESC",
-            "recent": "mtime DESC", "tuning": "tuning COLLATE NOCASE",
+            "recent": "mtime DESC",
+            # Tuning sort uses musical distance from E Standard
+            # (slopsmith#22 — was alphabetical). `tuning_sort_key` is
+            # the sum of per-string offsets, so |sort_key| is the
+            # magnitude of the down/up-tune. ABS ascending puts E
+            # Standard (0) first, then ±2 (Drop D, F Standard), then
+            # ±6 (Eb Standard), and so on. Within a magnitude tier we
+            # break ties by signed key DESC (down-tuned before up-
+            # tuned, mirroring how Rocksmith groups them) and then by
+            # name so the order is fully deterministic.
+            "tuning": "ABS(tuning_sort_key), tuning_sort_key DESC, tuning_name COLLATE NOCASE",
+            # Year sort (slopsmith#128). Empty-year rows pushed to the
+            # bottom for both directions; otherwise CAST so '2010' >
+            # '2005' rather than alphabetic.
+            "year": "(year = '') ASC, CAST(year AS INTEGER) ASC",
+            "year-desc": "(year = '') ASC, CAST(year AS INTEGER) DESC",
         }
         order = sort_map.get(sort, "artist COLLATE NOCASE")
         if direction == "desc" and "DESC" not in order:
@@ -196,7 +310,8 @@ class MetadataDB:
 
         total = self.conn.execute(f"SELECT COUNT(*) FROM songs {where}", params).fetchone()[0]
         rows = self.conn.execute(
-            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, mtime, format, stem_count "
+            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, mtime, "
+            f"format, stem_count, stem_ids, tuning_name "
             f"FROM songs {where} ORDER BY {order} LIMIT ? OFFSET ?",
             params + [size, page * size]
         ).fetchall()
@@ -212,6 +327,8 @@ class MetadataDB:
                 "has_lyrics": bool(r[8]), "mtime": r[9],
                 "format": r[10] or "psarc",
                 "stem_count": int(r[11] or 0),
+                "stem_ids": json.loads(r[12]) if r[12] else [],
+                "tuning_name": r[13] or "",
                 "has_estd": r[0] in estd, "favorite": r[0] in favs,
             })
         return songs, total
@@ -219,23 +336,25 @@ class MetadataDB:
     def query_artists(self, letter: str = "", q: str = "",
                       favorites_only: bool = False,
                       page: int = 0, size: int = 50,
-                      format_filter: str = "") -> tuple[list[dict], int]:
+                      format_filter: str = "",
+                      arrangements_has: list[str] | None = None,
+                      arrangements_lacks: list[str] | None = None,
+                      stems_has: list[str] | None = None,
+                      stems_lacks: list[str] | None = None,
+                      has_lyrics: int | None = None,
+                      tunings: list[str] | None = None) -> tuple[list[dict], int]:
         """Get artists grouped by letter with their albums and songs. Returns (artists, total_artists)."""
-        where = "WHERE title != ''"
-        params = []
-        if favorites_only:
-            where += " AND filename IN (SELECT filename FROM favorites)"
-        if format_filter:
-            where += " AND format = ?"
-            params.append(format_filter)
+        where, params = self._build_where(
+            q=q, favorites_only=favorites_only, format_filter=format_filter,
+            arrangements_has=arrangements_has, arrangements_lacks=arrangements_lacks,
+            stems_has=stems_has, stems_lacks=stems_lacks,
+            has_lyrics=has_lyrics, tunings=tunings,
+        )
         if letter == "#":
             where += " AND artist NOT GLOB '[A-Za-z]*'"
         elif letter:
             where += " AND UPPER(SUBSTR(artist, 1, 1)) = ?"
             params.append(letter.upper())
-        if q:
-            where += " AND (title LIKE ? COLLATE NOCASE OR artist LIKE ? COLLATE NOCASE OR album LIKE ? COLLATE NOCASE)"
-            params += [f"%{q}%"] * 3
 
         # Get paginated distinct artists
         total_artists = self.conn.execute(
@@ -257,7 +376,8 @@ class MetadataDB:
         song_params = params + artist_names
 
         rows = self.conn.execute(
-            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, format, stem_count "
+            f"SELECT filename, title, artist, album, year, duration, tuning, arrangements, has_lyrics, "
+            f"format, stem_count, stem_ids, tuning_name "
             f"FROM songs {song_where} ORDER BY artist COLLATE NOCASE, album COLLATE NOCASE, title COLLATE NOCASE",
             song_params
         ).fetchall()
@@ -283,6 +403,8 @@ class MetadataDB:
                 "has_lyrics": bool(r[8]),
                 "format": r[9] or "psarc",
                 "stem_count": int(r[10] or 0),
+                "stem_ids": json.loads(r[11]) if r[11] else [],
+                "tuning_name": r[12] or "",
                 "has_estd": r[0] in estd,
                 "favorite": r[0] in favs,
             })
@@ -297,14 +419,30 @@ class MetadataDB:
                            "song_count": sum(len(a["songs"]) for a in albums), "albums": albums})
         return result, total_artists
 
-    def query_stats(self, favorites_only: bool = False) -> dict:
-        """Aggregate stats for the letter bar."""
-        filt = " AND filename IN (SELECT filename FROM favorites)" if favorites_only else ""
-        total = self.conn.execute(f"SELECT COUNT(*) FROM songs WHERE title != ''{filt}").fetchone()[0]
-        artist_count = self.conn.execute(f"SELECT COUNT(DISTINCT artist) FROM songs WHERE title != ''{filt}").fetchone()[0]
+    def query_stats(self, favorites_only: bool = False,
+                    q: str = "", format_filter: str = "",
+                    arrangements_has: list[str] | None = None,
+                    arrangements_lacks: list[str] | None = None,
+                    stems_has: list[str] | None = None,
+                    stems_lacks: list[str] | None = None,
+                    has_lyrics: int | None = None,
+                    tunings: list[str] | None = None) -> dict:
+        """Aggregate stats for the letter bar. Accepts the same filter
+        params as query_page so the letter counts stay synchronized
+        with the grid when filters are active."""
+        where, params = self._build_where(
+            q=q, favorites_only=favorites_only, format_filter=format_filter,
+            arrangements_has=arrangements_has, arrangements_lacks=arrangements_lacks,
+            stems_has=stems_has, stems_lacks=stems_lacks,
+            has_lyrics=has_lyrics, tunings=tunings,
+        )
+        total = self.conn.execute(f"SELECT COUNT(*) FROM songs {where}", params).fetchone()[0]
+        artist_count = self.conn.execute(
+            f"SELECT COUNT(DISTINCT artist) FROM songs {where}", params
+        ).fetchone()[0]
         rows = self.conn.execute(
             f"SELECT UPPER(SUBSTR(artist, 1, 1)) as letter, COUNT(DISTINCT artist COLLATE NOCASE) "
-            f"FROM songs WHERE title != ''{filt} GROUP BY letter"
+            f"FROM songs {where} GROUP BY letter", params
         ).fetchall()
         letters = {}
         for letter, count in rows:
@@ -348,6 +486,10 @@ def _extract_meta_fast(psarc_path: Path) -> dict:
     title = artist = album = year = ""
     duration = 0.0
     tuning = "E Standard"
+    # Track the offsets for the tuning we ultimately keep so we can
+    # compute tuning_sort_key (#22) without re-deriving it from the
+    # name. Defaults to E Standard offsets.
+    tuning_offsets: list[int] = [0] * 6
     _tuning_from_guitar = False
     arrangements = []
     has_lyrics = False
@@ -384,6 +526,7 @@ def _extract_meta_fast(psarc_path: Path) -> dict:
                         is_guitar = arr_name in ("Lead", "Rhythm", "Combo")
                         if tuning == "E Standard" or (is_guitar and not _tuning_from_guitar):
                             tuning = tun_name
+                            tuning_offsets = offsets
                             if is_guitar:
                                 _tuning_from_guitar = True
                     notes = attrs.get("NotesHard", 0) or attrs.get("NotesMedium", 0) or 0
@@ -416,6 +559,14 @@ def _extract_meta_fast(psarc_path: Path) -> dict:
         "title": title, "artist": artist, "album": album, "year": year,
         "duration": duration, "tuning": tuning,
         "arrangements": arrangements, "has_lyrics": has_lyrics,
+        # PSARCs have no stems; emit an empty list so the column round-
+        # trips uniformly with sloppaks (slopsmith#129).
+        "stem_ids": [],
+        # Cached tuning fields (slopsmith#22 / #69). The text `tuning`
+        # column above stays the source of truth for display; these are
+        # the indexable / filterable forms.
+        "tuning_name": tuning,
+        "tuning_sort_key": sum(tuning_offsets),
     }
 
 
@@ -423,8 +574,14 @@ def _extract_meta_sloppak(path: Path) -> dict:
     """Extract metadata for a sloppak (file or directory)."""
     meta = sloppak_mod.extract_meta(path)
     offsets = meta.pop("tuning_offsets", None) or [0] * 6
-    meta["tuning"] = tuning_name(offsets)
+    name = tuning_name(offsets)
+    meta["tuning"] = name
+    meta["tuning_name"] = name
+    meta["tuning_sort_key"] = sum(offsets)
     meta["format"] = "sloppak"
+    # `extract_meta` already populates `stem_ids` (slopsmith#129);
+    # default to empty for older callers / mocks.
+    meta.setdefault("stem_ids", [])
     return meta
 
 
@@ -444,8 +601,10 @@ def _extract_meta_for_file(psarc_path: Path) -> dict:
         unpack_psarc(str(psarc_path), tmp)
         song = load_song(tmp)
         tuning = "E Standard"
+        tuning_offsets: list[int] = [0] * 6
         if song.arrangements and song.arrangements[0].tuning:
-            tuning = tuning_name(song.arrangements[0].tuning)
+            tuning_offsets = list(song.arrangements[0].tuning)
+            tuning = tuning_name(tuning_offsets)
         arrangements = [
             {"index": i, "name": a.name,
              "notes": len(a.notes) + sum(len(c.notes) for c in a.chords)}
@@ -464,6 +623,9 @@ def _extract_meta_for_file(psarc_path: Path) -> dict:
             "album": song.album, "year": str(song.year) if song.year else "",
             "duration": song.song_length, "tuning": tuning,
             "arrangements": arrangements, "has_lyrics": has_lyrics,
+            "stem_ids": [],
+            "tuning_name": tuning,
+            "tuning_sort_key": sum(tuning_offsets),
         }
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
@@ -652,32 +814,105 @@ def trigger_full_rescan():
 
 # ── Library API ───────────────────────────────────────────────────────────────
 
+def _split_csv(raw: str) -> list[str]:
+    """Parse a comma-separated query-string list. Empty / whitespace-only
+    entries are dropped so `arrangements_has=` (no value) and
+    `arrangements_has=,` both mean 'no filter'."""
+    if not raw:
+        return []
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def _parse_has_lyrics(raw: str) -> int | None:
+    """Tri-state parse for has_lyrics. `1` → require, `0` → exclude,
+    anything else (including empty) → no filter."""
+    if raw == "1":
+        return 1
+    if raw == "0":
+        return 0
+    return None
+
+
 @app.get("/api/library")
 def list_library(q: str = "", page: int = 0, size: int = 24, sort: str = "artist",
-                 dir: str = "asc", favorites: int = 0, format: str = ""):
+                 dir: str = "asc", favorites: int = 0, format: str = "",
+                 arrangements_has: str = "", arrangements_lacks: str = "",
+                 stems_has: str = "", stems_lacks: str = "",
+                 has_lyrics: str = "", tunings: str = ""):
     """Paginated library search, queried from SQLite."""
     size = min(size, 100)
     fmt = format if format in ("psarc", "sloppak") else ""
-    songs, total = meta_db.query_page(q=q, page=page, size=size, sort=sort,
-                                       direction=dir, favorites_only=bool(favorites),
-                                       format_filter=fmt)
+    songs, total = meta_db.query_page(
+        q=q, page=page, size=size, sort=sort,
+        direction=dir, favorites_only=bool(favorites), format_filter=fmt,
+        arrangements_has=_split_csv(arrangements_has),
+        arrangements_lacks=_split_csv(arrangements_lacks),
+        stems_has=_split_csv(stems_has),
+        stems_lacks=_split_csv(stems_lacks),
+        has_lyrics=_parse_has_lyrics(has_lyrics),
+        tunings=_split_csv(tunings),
+    )
     return {"songs": songs, "total": total, "page": page, "size": size}
 
 
 @app.get("/api/library/artists")
 def list_artists(letter: str = "", q: str = "", favorites: int = 0, page: int = 0, size: int = 50,
-                 format: str = ""):
+                 format: str = "",
+                 arrangements_has: str = "", arrangements_lacks: str = "",
+                 stems_has: str = "", stems_lacks: str = "",
+                 has_lyrics: str = "", tunings: str = ""):
     """Get artists grouped by letter with albums and songs (for tree view)."""
     fmt = format if format in ("psarc", "sloppak") else ""
-    artists, total = meta_db.query_artists(letter=letter, q=q, favorites_only=bool(favorites),
-                                           page=page, size=min(size, 100), format_filter=fmt)
+    artists, total = meta_db.query_artists(
+        letter=letter, q=q, favorites_only=bool(favorites),
+        page=page, size=min(size, 100), format_filter=fmt,
+        arrangements_has=_split_csv(arrangements_has),
+        arrangements_lacks=_split_csv(arrangements_lacks),
+        stems_has=_split_csv(stems_has),
+        stems_lacks=_split_csv(stems_lacks),
+        has_lyrics=_parse_has_lyrics(has_lyrics),
+        tunings=_split_csv(tunings),
+    )
     return {"artists": artists, "total_artists": total, "page": page, "size": size}
 
 
 @app.get("/api/library/stats")
-def library_stats(favorites: int = 0):
-    """Aggregate stats for the UI."""
-    return meta_db.query_stats(favorites_only=bool(favorites))
+def library_stats(favorites: int = 0, q: str = "", format: str = "",
+                  arrangements_has: str = "", arrangements_lacks: str = "",
+                  stems_has: str = "", stems_lacks: str = "",
+                  has_lyrics: str = "", tunings: str = ""):
+    """Aggregate stats for the UI. Accepts the same filter params as
+    /api/library so the letter bar mirrors the active grid filter set."""
+    fmt = format if format in ("psarc", "sloppak") else ""
+    return meta_db.query_stats(
+        favorites_only=bool(favorites), q=q, format_filter=fmt,
+        arrangements_has=_split_csv(arrangements_has),
+        arrangements_lacks=_split_csv(arrangements_lacks),
+        stems_has=_split_csv(stems_has),
+        stems_lacks=_split_csv(stems_lacks),
+        has_lyrics=_parse_has_lyrics(has_lyrics),
+        tunings=_split_csv(tunings),
+    )
+
+
+@app.get("/api/library/tuning-names")
+def list_tuning_names():
+    """Distinct tuning names present in the library, with per-tuning
+    counts. Powers the tuning multi-select. Sorted by `tuning_sort_key`
+    so names appear in the same musical order the sort uses
+    (slopsmith#22) — E Standard first, then nearest neighbors."""
+    rows = meta_db.conn.execute(
+        "SELECT tuning_name, MIN(tuning_sort_key), COUNT(*) "
+        "FROM songs WHERE title != '' AND tuning_name != '' "
+        "GROUP BY tuning_name COLLATE NOCASE "
+        "ORDER BY ABS(MIN(tuning_sort_key)), MIN(tuning_sort_key) DESC, tuning_name COLLATE NOCASE"
+    ).fetchall()
+    return {
+        "tunings": [
+            {"name": name, "sort_key": int(sk or 0), "count": count}
+            for name, sk, count in rows
+        ],
+    }
 
 
 @app.post("/api/favorites/toggle")

--- a/server.py
+++ b/server.py
@@ -297,7 +297,12 @@ class MetadataDB:
             # break ties by signed key DESC (down-tuned before up-
             # tuned, mirroring how Rocksmith groups them) and then by
             # name so the order is fully deterministic.
-            "tuning": "ABS(tuning_sort_key), tuning_sort_key DESC, tuning_name COLLATE NOCASE",
+            #
+            # Leading term pushes pre-migration / unscanned rows
+            # (`tuning_name` empty, `tuning_sort_key` defaulted to 0)
+            # to the bottom — without it ABS(0) collides with E
+            # Standard's 0 and the empty-tuning rows would sort first.
+            "tuning": "(tuning_name = '') ASC, ABS(tuning_sort_key), tuning_sort_key DESC, tuning_name COLLATE NOCASE",
             # Year sort (slopsmith#128). Empty-year rows pushed to the
             # bottom for both directions; otherwise CAST so '2010' >
             # '2005' rather than alphabetic.
@@ -444,8 +449,13 @@ class MetadataDB:
             has_lyrics=has_lyrics, tunings=tunings,
         )
         total = self.conn.execute(f"SELECT COUNT(*) FROM songs {where}", params).fetchone()[0]
+        # NOCASE collation here mirrors `query_artists` and the per-
+        # letter `COUNT(DISTINCT artist COLLATE NOCASE)` below — without
+        # it, an artist stored under two different casings would inflate
+        # `total_artists` against the letter-bar breakdown the UI
+        # renders next to it.
         artist_count = self.conn.execute(
-            f"SELECT COUNT(DISTINCT artist) FROM songs {where}", params
+            f"SELECT COUNT(DISTINCT artist COLLATE NOCASE) FROM songs {where}", params
         ).fetchone()[0]
         rows = self.conn.execute(
             f"SELECT UPPER(SUBSTR(artist, 1, 1)) as letter, COUNT(DISTINCT artist COLLATE NOCASE) "

--- a/server.py
+++ b/server.py
@@ -293,16 +293,18 @@ class MetadataDB:
             # the sum of per-string offsets, so |sort_key| is the
             # magnitude of the down/up-tune. ABS ascending puts E
             # Standard (0) first, then ±2 (Drop D, F Standard), then
-            # ±6 (Eb Standard), and so on. Within a magnitude tier we
-            # break ties by signed key DESC (down-tuned before up-
-            # tuned, mirroring how Rocksmith groups them) and then by
-            # name so the order is fully deterministic.
+            # ±6 (Eb Standard, F# Standard), and so on. Within a
+            # magnitude tier we break ties by signed key ASC so the
+            # negative (down-tuned) variant comes before the positive
+            # (up-tuned) one — Eb Standard before F Standard, matching
+            # how Rocksmith groups its tuning list. Final tiebreak by
+            # name keeps the order fully deterministic.
             #
             # Leading term pushes pre-migration / unscanned rows
             # (`tuning_name` empty, `tuning_sort_key` defaulted to 0)
             # to the bottom — without it ABS(0) collides with E
             # Standard's 0 and the empty-tuning rows would sort first.
-            "tuning": "(tuning_name = '') ASC, ABS(tuning_sort_key), tuning_sort_key DESC, tuning_name COLLATE NOCASE",
+            "tuning": "(tuning_name = '') ASC, ABS(tuning_sort_key), tuning_sort_key ASC, tuning_name COLLATE NOCASE",
             # Year sort (slopsmith#128). Empty-year rows pushed to the
             # bottom for both directions; otherwise CAST so '2010' >
             # '2005' rather than alphabetic.
@@ -922,7 +924,12 @@ def list_tuning_names():
         "SELECT tuning_name, MIN(tuning_sort_key), COUNT(*) "
         "FROM songs WHERE title != '' AND tuning_name != '' "
         "GROUP BY tuning_name COLLATE NOCASE "
-        "ORDER BY ABS(MIN(tuning_sort_key)), MIN(tuning_sort_key) DESC, tuning_name COLLATE NOCASE"
+        # Same ordering as `sort=tuning` in `query_page`: distance
+        # from E Standard first, then signed-key ASC so the down-
+        # tuned variant precedes the up-tuned one at equal distance
+        # (Eb Standard before F Standard at distance 6). Final
+        # alphabetical tiebreak keeps the order deterministic.
+        "ORDER BY ABS(MIN(tuning_sort_key)), MIN(tuning_sort_key) ASC, tuning_name COLLATE NOCASE"
     ).fetchall()
     return {
         "tunings": [

--- a/static/app.js
+++ b/static/app.js
@@ -348,6 +348,11 @@ function filterLibrary() {
         _libEpoch++;
         currentPage = 0;
         _treeLetter = '';
+        // Letter-bar counts depend on `q` and the active filter set —
+        // any change to those must invalidate the tree-view stats
+        // cache or the next switch to tree view will render stale
+        // letter counts (slopsmith#134 review).
+        _treeStats = null;
         loadLibrary(0);
     }, 250);
 }
@@ -355,6 +360,9 @@ function filterLibrary() {
 function sortLibrary() {
     _libEpoch++;
     currentPage = 0;
+    // Same reason as filterLibrary: format dropdown changes the stats
+    // payload, so the cache must drop too.
+    _treeStats = null;
     loadLibrary(0);
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -31,6 +31,290 @@ let _gridObserver = null;
 // they've been superseded and skip rendering stale results.
 let _libEpoch = 0;
 
+// ── Library filters (slopsmith#129/#69) ────────────────────────────────
+//
+// Filter state lives in a single object so the active set can be
+// serialized to localStorage as one key. Each axis is OR-within (Lead
+// + Rhythm = "has Lead OR Rhythm"); cross-axis is AND. Tri-state pills
+// translate to `_has` / `_lacks` lists on the wire so the server's
+// SQL doesn't have to encode the third "any" state.
+const _ARRANGEMENTS = ['Lead', 'Rhythm', 'Bass', 'Combo'];
+// Stem ids match the bare strings sloppak manifests use ("drums",
+// "bass", etc.). `full` is intentionally omitted from the filter UI:
+// it's the fallback mix every sloppak ships with, so filtering by it
+// would match all sloppaks and confuse users.
+const _STEM_DEFS = [
+    { id: 'drums', label: 'Drums' },
+    { id: 'bass', label: 'Bass' },
+    { id: 'vocals', label: 'Vocals' },
+    { id: 'guitar', label: 'Guitar' },
+    { id: 'piano', label: 'Piano' },
+    { id: 'other', label: 'Other' },
+];
+const _LIB_FILTERS_KEY = 'slopsmith.libFilters';
+let _libFilters = _loadLibFilters();
+let _tuningNames = null;  // cached from /api/library/tuning-names
+
+function _defaultLibFilters() {
+    return {
+        arrHas: [], arrLacks: [],
+        stemsHas: [], stemsLacks: [],
+        lyrics: null,             // null | 1 | 0
+        tunings: [],
+    };
+}
+
+function _loadLibFilters() {
+    try {
+        const raw = localStorage.getItem(_LIB_FILTERS_KEY);
+        if (!raw) return _defaultLibFilters();
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') return _defaultLibFilters();
+        return Object.assign(_defaultLibFilters(), parsed);
+    } catch {
+        return _defaultLibFilters();
+    }
+}
+
+function _saveLibFilters() {
+    try { localStorage.setItem(_LIB_FILTERS_KEY, JSON.stringify(_libFilters)); }
+    catch { /* private mode / quota — ignore, in-memory state still works */ }
+}
+
+function _libActiveCount() {
+    let n = 0;
+    if (_libFilters.arrHas.length) n++;
+    if (_libFilters.arrLacks.length) n++;
+    if (_libFilters.stemsHas.length) n++;
+    if (_libFilters.stemsLacks.length) n++;
+    if (_libFilters.lyrics !== null) n++;
+    if (_libFilters.tunings.length) n++;
+    return n;
+}
+
+function _applyLibFiltersToParams(params) {
+    if (_libFilters.arrHas.length) params.set('arrangements_has', _libFilters.arrHas.join(','));
+    if (_libFilters.arrLacks.length) params.set('arrangements_lacks', _libFilters.arrLacks.join(','));
+    if (_libFilters.stemsHas.length) params.set('stems_has', _libFilters.stemsHas.join(','));
+    if (_libFilters.stemsLacks.length) params.set('stems_lacks', _libFilters.stemsLacks.join(','));
+    if (_libFilters.lyrics !== null) params.set('has_lyrics', String(_libFilters.lyrics));
+    if (_libFilters.tunings.length) params.set('tunings', _libFilters.tunings.join(','));
+    return params;
+}
+
+function _pillState(item, hasList, lacksList) {
+    if (hasList.includes(item)) return 'require';
+    if (lacksList.includes(item)) return 'exclude';
+    return 'any';
+}
+
+function _cyclePill(item, hasKey, lacksKey) {
+    // Cycle: any -> require -> exclude -> any. Mutates _libFilters in place.
+    const hasList = _libFilters[hasKey];
+    const lacksList = _libFilters[lacksKey];
+    const inHas = hasList.indexOf(item);
+    const inLacks = lacksList.indexOf(item);
+    if (inHas === -1 && inLacks === -1) {
+        hasList.push(item);
+    } else if (inHas !== -1) {
+        hasList.splice(inHas, 1);
+        lacksList.push(item);
+    } else {
+        lacksList.splice(inLacks, 1);
+    }
+    _saveLibFilters();
+    _renderLibFilterDrawer();
+    _renderLibFilterChips();
+    _libEpoch++;
+    currentPage = 0;
+    _treeStats = null;  // letter bar counts depend on filters now
+    loadLibrary(0);
+}
+
+function _renderPillRow(containerId, items, hasKey, lacksKey, labelFor) {
+    const c = document.getElementById(containerId);
+    if (!c) return;
+    c.innerHTML = '';
+    for (const it of items) {
+        const id = typeof it === 'string' ? it : it.id;
+        const label = labelFor ? labelFor(it) : id;
+        const state = _pillState(id, _libFilters[hasKey], _libFilters[lacksKey]);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = `filter-pill state-${state}`;
+        btn.textContent = label;
+        btn.onclick = () => _cyclePill(id, hasKey, lacksKey);
+        c.appendChild(btn);
+    }
+}
+
+function _renderLyricsPill() {
+    // Single tri-state pill matching the arrangement / stem pattern.
+    // Cycle: any (null) -> require (1) -> exclude (0) -> any.
+    const c = document.getElementById('filter-lyrics');
+    if (!c) return;
+    c.innerHTML = '';
+    const v = _libFilters.lyrics;
+    const state = v === 1 ? 'require' : v === 0 ? 'exclude' : 'any';
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = `filter-pill state-${state}`;
+    btn.textContent = 'Lyrics';
+    btn.onclick = () => {
+        _libFilters.lyrics = v === null ? 1 : v === 1 ? 0 : null;
+        _saveLibFilters();
+        _renderLyricsPill();
+        _renderLibFilterChips();
+        _libEpoch++;
+        currentPage = 0;
+        _treeStats = null;
+        loadLibrary(0);
+    };
+    c.appendChild(btn);
+}
+
+async function _renderTuningList() {
+    const c = document.getElementById('filter-tunings');
+    if (!c) return;
+    if (!_tuningNames) {
+        c.innerHTML = '<div class="text-xs text-gray-500 px-2">Loading...</div>';
+        try {
+            const resp = await fetch('/api/library/tuning-names');
+            const data = await resp.json();
+            _tuningNames = data.tunings || [];
+        } catch {
+            _tuningNames = [];
+        }
+    }
+    c.innerHTML = '';
+    if (!_tuningNames.length) {
+        c.innerHTML = '<div class="text-xs text-gray-500 px-2">No tunings indexed yet — try Full Rescan.</div>';
+        return;
+    }
+    for (const t of _tuningNames) {
+        const checked = _libFilters.tunings.includes(t.name);
+        const row = document.createElement('label');
+        row.className = 'tuning-row';
+        row.innerHTML =
+            `<input type="checkbox" ${checked ? 'checked' : ''} class="rounded border-gray-600 bg-dark-700 text-accent">` +
+            `<span class="flex-1">${esc(t.name)}</span>` +
+            `<span class="tuning-count">${t.count}</span>`;
+        const cb = row.querySelector('input');
+        cb.onchange = () => {
+            const i = _libFilters.tunings.indexOf(t.name);
+            if (cb.checked && i === -1) _libFilters.tunings.push(t.name);
+            else if (!cb.checked && i !== -1) _libFilters.tunings.splice(i, 1);
+            _saveLibFilters();
+            _updateLibFiltersBadge();
+            _renderLibFilterChips();
+            _renderTuningSummary();
+            _libEpoch++;
+            currentPage = 0;
+            _treeStats = null;
+            loadLibrary(0);
+        };
+        c.appendChild(row);
+    }
+    _renderTuningSummary();
+}
+
+function _renderTuningSummary() {
+    const s = document.getElementById('filter-tunings-summary');
+    if (!s) return;
+    if (!_libFilters.tunings.length) { s.textContent = 'All tunings'; return; }
+    if (_libFilters.tunings.length === 1) { s.textContent = _libFilters.tunings[0]; return; }
+    s.textContent = `${_libFilters.tunings[0]} +${_libFilters.tunings.length - 1}`;
+}
+
+function _updateLibFiltersBadge() {
+    const badge = document.getElementById('lib-filters-count');
+    if (!badge) return;
+    const n = _libActiveCount();
+    badge.textContent = String(n);
+    badge.classList.toggle('hidden', n === 0);
+}
+
+function _renderLibFilterDrawer() {
+    _renderPillRow('filter-arrangements', _ARRANGEMENTS, 'arrHas', 'arrLacks');
+    _renderPillRow('filter-stems', _STEM_DEFS, 'stemsHas', 'stemsLacks', s => s.label);
+    _renderLyricsPill();
+    // Stems section dimmed when format=psarc (no stems exist).
+    const stemsSection = document.getElementById('filter-stems-section');
+    if (stemsSection) {
+        const fmt = (document.getElementById('lib-format') || {}).value || '';
+        stemsSection.classList.toggle('opacity-40', fmt === 'psarc');
+        stemsSection.classList.toggle('pointer-events-none', fmt === 'psarc');
+    }
+    _updateLibFiltersBadge();
+}
+
+function _renderLibFilterChips() {
+    const row = document.getElementById('lib-filter-chips');
+    if (!row) return;
+    const chips = [];
+    for (const a of _libFilters.arrHas) chips.push({ label: a, kind: 'require', remove: () => _libFilters.arrHas = _libFilters.arrHas.filter(x => x !== a) });
+    for (const a of _libFilters.arrLacks) chips.push({ label: `no ${a}`, kind: 'exclude', remove: () => _libFilters.arrLacks = _libFilters.arrLacks.filter(x => x !== a) });
+    for (const s of _libFilters.stemsHas) {
+        const def = _STEM_DEFS.find(d => d.id === s);
+        chips.push({ label: def ? def.label : s, kind: 'require', remove: () => _libFilters.stemsHas = _libFilters.stemsHas.filter(x => x !== s) });
+    }
+    for (const s of _libFilters.stemsLacks) {
+        const def = _STEM_DEFS.find(d => d.id === s);
+        chips.push({ label: `no ${def ? def.label : s}`, kind: 'exclude', remove: () => _libFilters.stemsLacks = _libFilters.stemsLacks.filter(x => x !== s) });
+    }
+    if (_libFilters.lyrics === 1) chips.push({ label: 'has lyrics', kind: 'require', remove: () => _libFilters.lyrics = null });
+    if (_libFilters.lyrics === 0) chips.push({ label: 'no lyrics', kind: 'exclude', remove: () => _libFilters.lyrics = null });
+    for (const t of _libFilters.tunings) chips.push({ label: t, kind: 'require', remove: () => _libFilters.tunings = _libFilters.tunings.filter(x => x !== t) });
+
+    row.innerHTML = '';
+    if (!chips.length) {
+        row.classList.add('hidden');
+        return;
+    }
+    row.classList.remove('hidden');
+    for (const c of chips) {
+        const el = document.createElement('span');
+        el.className = `chip ${c.kind === 'exclude' ? 'chip-exclude' : ''}`;
+        el.innerHTML = `${esc(c.label)}<button title="Remove">×</button>`;
+        el.querySelector('button').onclick = () => {
+            c.remove();
+            _saveLibFilters();
+            _renderLibFilterDrawer();
+            _renderLibFilterChips();
+            _libEpoch++;
+            currentPage = 0;
+            _treeStats = null;
+            loadLibrary(0);
+        };
+        row.appendChild(el);
+    }
+}
+
+function toggleLibFilters(force) {
+    const drawer = document.getElementById('lib-filter-drawer');
+    const overlay = document.getElementById('lib-filter-overlay');
+    if (!drawer) return;
+    const open = force === undefined ? !drawer.classList.contains('open') : !!force;
+    drawer.classList.toggle('open', open);
+    overlay.classList.toggle('hidden', !open);
+    if (open) {
+        _renderLibFilterDrawer();
+        _renderTuningList();
+    }
+}
+
+function clearLibFilters() {
+    _libFilters = _defaultLibFilters();
+    _saveLibFilters();
+    _renderLibFilterDrawer();
+    _renderTuningList();
+    _renderLibFilterChips();
+    _libEpoch++;
+    currentPage = 0;
+    _treeStats = null;
+    loadLibrary(0);
+}
+
 function setLibView(view) {
     libView = view;
     document.getElementById('lib-grid').classList.toggle('hidden', view !== 'grid');
@@ -77,6 +361,7 @@ async function loadGridPage(page = 0) {
     const format = (document.getElementById('lib-format') || {}).value || '';
     const params = new URLSearchParams({ q, page, size: PAGE_SIZE, sort });
     if (format) params.set('format', format);
+    _applyLibFiltersToParams(params);
     const resp = await fetch(`/api/library?${params}`);
     const data = await resp.json();
     if (myEpoch !== _libEpoch) return; // filter/sort/view changed mid-fetch
@@ -206,7 +491,14 @@ function renderGridCards(songs, containerId = 'lib-grid', mode = 'replace') {
 
 async function loadTreeView() {
     if (!_treeStats) {
-        const resp = await fetch('/api/library/stats');
+        const q = document.getElementById('lib-filter').value.trim();
+        const format = (document.getElementById('lib-format') || {}).value || '';
+        const sp = new URLSearchParams();
+        if (q) sp.set('q', q);
+        if (format) sp.set('format', format);
+        _applyLibFiltersToParams(sp);
+        const qs = sp.toString();
+        const resp = await fetch(`/api/library/stats${qs ? '?' + qs : ''}`);
         _treeStats = await resp.json();
     }
     const q = document.getElementById('lib-filter').value.trim();
@@ -246,6 +538,7 @@ async function renderTreeInto(containerId, countId, stats, letter, q, favoritesO
     if (favoritesOnly) params.set('favorites', '1');
     const format = (document.getElementById('lib-format') || {}).value || '';
     if (format) params.set('format', format);
+    if (!favoritesOnly) _applyLibFiltersToParams(params);
     params.set('page', page);
     params.set('size', TREE_PAGE_SIZE);
     const resp = await fetch(`/api/library/artists?${params}`);
@@ -603,6 +896,7 @@ async function rescanLibrary() {
             btn.textContent = 'Rescan Library';
             status.textContent = sd.error ? `Error: ${sd.error}` : 'Done!';
             _treeStats = null;
+            _tuningNames = null;  // re-fetch on next drawer open
             loadLibrary();
         }
     }, 1000);
@@ -630,6 +924,7 @@ async function fullRescanLibrary() {
             btn.textContent = 'Full Rescan';
             status.textContent = sd.error ? `Error: ${sd.error}` : 'Done!';
             _treeStats = null;
+            _tuningNames = null;  // re-fetch on next drawer open
             loadLibrary();
         }
     }, 1000);
@@ -1811,6 +2106,11 @@ async function loadPlugins() {
 // before any playSong runs — otherwise a fast click could start
 // playback with stale settings before /api/settings returned.
 loadPlugins().then(async (plugins) => {
+    // Restore library-filter UI state from localStorage before the first
+    // grid fetch so the badge/chips are accurate immediately
+    // (slopsmith#129).
+    _renderLibFilterChips();
+    _updateLibFiltersBadge();
     setLibView('grid');
     try { await loadSettings(); } catch (e) { console.warn('initial loadSettings failed:', e); }
     checkScanAndLoad();

--- a/static/app.js
+++ b/static/app.js
@@ -275,7 +275,13 @@ function _renderLibFilterChips() {
     for (const c of chips) {
         const el = document.createElement('span');
         el.className = `chip ${c.kind === 'exclude' ? 'chip-exclude' : ''}`;
-        el.innerHTML = `${esc(c.label)}<button title="Remove">×</button>`;
+        // The "×" glyph isn't a reliable accessible name; assistive tech
+        // also can't depend on `title` alone. Spell out the action plus
+        // the chip's label in `aria-label` so screen-reader users hear
+        // "Remove filter: Lead" instead of "button" or just "×".
+        const ariaLabel = `Remove filter: ${c.label}`;
+        el.innerHTML =
+            `${esc(c.label)}<button type="button" title="${esc(ariaLabel)}" aria-label="${esc(ariaLabel)}">×</button>`;
         el.querySelector('button').onclick = () => {
             c.remove();
             _saveLibFilters();

--- a/static/app.js
+++ b/static/app.js
@@ -64,13 +64,35 @@ function _defaultLibFilters() {
     };
 }
 
+function _normalizeStringArray(v) {
+    return Array.isArray(v) ? v.filter(x => typeof x === 'string' && x) : [];
+}
+
+function _normalizeLibFilters(parsed) {
+    // Defensive: a stale or hand-edited localStorage payload could have
+    // any shape. Without normalization a later `.join` or `.includes`
+    // on a non-array would throw at filter-apply time. Coerce each
+    // field back to its expected type, dropping anything we don't
+    // recognize. Slopsmith#134 review.
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return _defaultLibFilters();
+    }
+    const lyrics = parsed.lyrics;
+    return {
+        arrHas: _normalizeStringArray(parsed.arrHas),
+        arrLacks: _normalizeStringArray(parsed.arrLacks),
+        stemsHas: _normalizeStringArray(parsed.stemsHas),
+        stemsLacks: _normalizeStringArray(parsed.stemsLacks),
+        lyrics: lyrics === 0 || lyrics === 1 ? lyrics : null,
+        tunings: _normalizeStringArray(parsed.tunings),
+    };
+}
+
 function _loadLibFilters() {
     try {
         const raw = localStorage.getItem(_LIB_FILTERS_KEY);
         if (!raw) return _defaultLibFilters();
-        const parsed = JSON.parse(raw);
-        if (!parsed || typeof parsed !== 'object') return _defaultLibFilters();
-        return Object.assign(_defaultLibFilters(), parsed);
+        return _normalizeLibFilters(JSON.parse(raw));
     } catch {
         return _defaultLibFilters();
     }
@@ -176,17 +198,29 @@ function _renderLyricsPill() {
 async function _renderTuningList() {
     const c = document.getElementById('filter-tunings');
     if (!c) return;
+    let fetchError = null;
     if (!_tuningNames) {
         c.innerHTML = '<div class="text-xs text-gray-500 px-2">Loading...</div>';
         try {
             const resp = await fetch('/api/library/tuning-names');
+            if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             const data = await resp.json();
-            _tuningNames = data.tunings || [];
-        } catch {
-            _tuningNames = [];
+            _tuningNames = Array.isArray(data.tunings) ? data.tunings : [];
+        } catch (e) {
+            // Distinguish a server / network failure from "the DB
+            // genuinely has no tunings indexed". The latter wants a
+            // Full Rescan; the former just wants a retry. Don't cache
+            // the failure — leave _tuningNames null so reopening the
+            // drawer triggers a fresh attempt.
+            _tuningNames = null;
+            fetchError = e.message || 'request failed';
         }
     }
     c.innerHTML = '';
+    if (fetchError) {
+        c.innerHTML = `<div class="text-xs text-red-400 px-2">Failed to load tunings (${esc(fetchError)}). Reopen the drawer to retry.</div>`;
+        return;
+    }
     if (!_tuningNames.length) {
         c.innerHTML = '<div class="text-xs text-gray-500 px-2">No tunings indexed yet — try Full Rescan.</div>';
         return;

--- a/static/index.html
+++ b/static/index.html
@@ -87,6 +87,8 @@
                         <option value="title">Title A-Z</option>
                         <option value="title-desc">Title Z-A</option>
                         <option value="recent">Recently Added</option>
+                        <option value="year-desc">Year (newest)</option>
+                        <option value="year">Year (oldest)</option>
                         <option value="tuning">Tuning</option>
                     </select>
                     <!-- Format filter (shared) -->
@@ -99,11 +101,21 @@
                     <!-- Tree controls -->
                     <button onclick="toggleAllArtists(true)" class="lib-tree-ctrl bg-dark-700 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-400 hover:text-white transition">Expand All</button>
                     <button onclick="toggleAllArtists(false)" class="lib-tree-ctrl bg-dark-700 border border-gray-800 rounded-xl px-3 py-2.5 text-sm text-gray-400 hover:text-white transition">Collapse All</button>
+                    <!-- Filters drawer toggle (slopsmith#129) -->
+                    <button onclick="toggleLibFilters()" id="btn-lib-filters"
+                        class="bg-dark-700 border border-gray-800 hover:border-accent/40 rounded-xl px-4 py-2.5 text-sm text-gray-300 transition flex items-center gap-2"
+                        title="Filter by parts, tuning, lyrics">
+                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4h18M6 12h12M10 20h4"/></svg>
+                        <span>Filters</span>
+                        <span id="lib-filters-count" class="hidden bg-accent/30 text-accent-light text-xs font-semibold rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center">0</span>
+                    </button>
                     <!-- Shared -->
                     <input type="text" id="lib-filter" placeholder="Search songs..." oninput="filterLibrary()"
                         class="bg-dark-700 border border-gray-800 rounded-xl px-4 py-2.5 text-sm text-gray-300 placeholder-gray-600 focus:border-accent/50 focus:ring-1 focus:ring-accent/30 outline-none flex-1 md:w-60 transition">
                 </div>
             </div>
+            <!-- Active-filter chip row (only visible when filters are set, slopsmith#129) -->
+            <div id="lib-filter-chips" class="hidden flex flex-wrap gap-2 mb-5"></div>
             <div id="lib-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
                 <!-- Cards populated by JS -->
             </div>
@@ -111,6 +123,53 @@
                 <!-- Tree populated by JS -->
             </div>
         </section>
+
+        <!-- ══ Filters drawer (slopsmith#129/#69/#22) ═════════════════════ -->
+        <div id="lib-filter-overlay" class="fixed inset-0 bg-black/40 z-40 hidden"
+             onclick="toggleLibFilters(false)"></div>
+        <aside id="lib-filter-drawer"
+               class="fixed top-0 right-0 h-full w-full sm:w-96 bg-dark-800 border-l border-gray-800 z-50 transform translate-x-full transition-transform duration-200 overflow-y-auto">
+            <div class="p-6 space-y-6">
+                <div class="flex items-center justify-between">
+                    <h3 class="text-lg font-semibold text-white">Filters</h3>
+                    <button onclick="toggleLibFilters(false)" class="text-gray-500 hover:text-white" title="Close">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                    </button>
+                </div>
+
+                <section>
+                    <div class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Arrangements</div>
+                    <p class="text-xs text-gray-600 mb-3">Click cycles: any → require → exclude</p>
+                    <div id="filter-arrangements" class="flex flex-wrap gap-2"></div>
+                </section>
+
+                <section id="filter-stems-section">
+                    <div class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Stems <span class="text-gray-600 normal-case font-normal">(sloppak)</span></div>
+                    <p class="text-xs text-gray-600 mb-3">Click cycles: any → require → exclude</p>
+                    <div id="filter-stems" class="flex flex-wrap gap-2"></div>
+                </section>
+
+                <section>
+                    <div class="text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">Lyrics</div>
+                    <div id="filter-lyrics" class="flex flex-wrap gap-2"></div>
+                </section>
+
+                <section>
+                    <details>
+                        <summary class="cursor-pointer flex items-center justify-between text-xs font-semibold uppercase tracking-wider text-gray-500 mb-2">
+                            <span>Tuning</span>
+                            <span id="filter-tunings-summary" class="text-gray-600 normal-case font-normal text-xs">All tunings</span>
+                        </summary>
+                        <div id="filter-tunings" class="mt-3 space-y-1 max-h-64 overflow-y-auto pr-1"></div>
+                    </details>
+                </section>
+
+                <div class="flex items-center justify-between pt-4 border-t border-gray-800">
+                    <button onclick="clearLibFilters()" class="text-sm text-gray-400 hover:text-white transition">Clear all</button>
+                    <button onclick="toggleLibFilters(false)" class="bg-accent hover:bg-accent-light px-4 py-2 rounded-lg text-sm font-medium text-white transition">Done</button>
+                </div>
+            </div>
+        </aside>
     </div>
 
     <!-- ══ FAVORITES ════════════════════════════════════════════════════ -->

--- a/static/style.css
+++ b/static/style.css
@@ -189,3 +189,95 @@ html { scroll-behavior: smooth; }
     #player-controls button { padding: 4px 8px; font-size: 11px; }
     #volume { width: 50px; }
 }
+
+/* Library filter drawer (slopsmith#129/#69) */
+#lib-filter-drawer.open { transform: translateX(0); }
+#lib-filter-drawer .filter-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 500;
+    border: 1px solid rgba(75, 85, 99, 0.5);
+    background: #181830;
+    color: #d1d5db;
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+#lib-filter-drawer .filter-pill:hover { border-color: rgba(64, 128, 224, 0.5); }
+#lib-filter-drawer .filter-pill.state-require {
+    border-color: rgba(34, 197, 94, 0.7);
+    background: rgba(34, 197, 94, 0.15);
+    color: #86efac;
+}
+#lib-filter-drawer .filter-pill.state-exclude {
+    border-color: rgba(248, 113, 113, 0.7);
+    background: rgba(248, 113, 113, 0.15);
+    color: #fca5a5;
+}
+#lib-filter-drawer .filter-pill.state-disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+#lib-filter-drawer .filter-pill::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: rgba(156, 163, 175, 0.4);
+}
+#lib-filter-drawer .filter-pill.state-require::before { background: #22c55e; }
+#lib-filter-drawer .filter-pill.state-exclude::before {
+    background: #f87171;
+    /* tiny minus indicator: use a horizontal bar instead of dot */
+    width: 10px;
+    height: 2px;
+    border-radius: 1px;
+}
+#lib-filter-drawer .tuning-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 6px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 13px;
+    color: #d1d5db;
+}
+#lib-filter-drawer .tuning-row:hover { background: rgba(64, 128, 224, 0.1); }
+#lib-filter-drawer .tuning-row .tuning-count {
+    margin-left: auto;
+    font-size: 11px;
+    color: #6b7280;
+}
+
+/* Active-filter chips row */
+#lib-filter-chips { display: none; }
+#lib-filter-chips:not(.hidden) { display: flex; }
+#lib-filter-chips .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px 3px 10px;
+    border-radius: 999px;
+    font-size: 12px;
+    background: #1e1e3a;
+    border: 1px solid rgba(75, 85, 99, 0.5);
+    color: #d1d5db;
+}
+#lib-filter-chips .chip.chip-exclude {
+    border-color: rgba(248, 113, 113, 0.5);
+    color: #fca5a5;
+}
+#lib-filter-chips .chip button {
+    margin-left: 4px;
+    padding: 0 4px;
+    color: #6b7280;
+    font-weight: bold;
+    line-height: 1;
+}
+#lib-filter-chips .chip button:hover { color: #fff; }

--- a/tests/test_library_filters.py
+++ b/tests/test_library_filters.py
@@ -271,6 +271,41 @@ def test_tuning_sort_pushes_empty_tuning_name_to_bottom(client, server_mod):
     assert files == ["real.psarc", "legacy.psarc"]
 
 
+def test_tuning_sort_pushes_null_tuning_name_to_bottom(client, server_mod):
+    """Defense in depth for the same intent as the empty-string case: a
+    row with NULL `tuning_name` / NULL `tuning_sort_key` (which can
+    arise from raw SQL inserts that bypass `put()`, future code that
+    writes None, or edge-case migration paths) must also fall to the
+    bottom. Without COALESCE in the ORDER BY, `(tuning_name = '')`
+    evaluates to NULL for those rows and NULLs sort *ahead of* 0 in
+    SQLite's ASC ordering — the legacy row would float above E
+    Standard. Regression for Copilot finding on PR #134."""
+    _put(server_mod, filename="real.psarc", title="Real", artist="A",
+         tuning_name="E Standard", tuning_sort_key=0,
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+    # Direct INSERT with NULL tuning_name AND NULL tuning_sort_key —
+    # mimics what a pre-migration row would look like if SQLite hadn't
+    # backfilled the literal-constant defaults on ADD COLUMN.
+    server_mod.meta_db.conn.execute(
+        "INSERT INTO songs (filename, mtime, size, title, artist, album, year, "
+        "duration, tuning, arrangements, has_lyrics, format, stem_count, stem_ids, "
+        "tuning_name, tuning_sort_key) "
+        "VALUES (?, 1.0, 1, ?, ?, ?, '', 200.0, '', ?, 0, 'psarc', 0, '[]', NULL, NULL)",
+        ("legacy.psarc", "Legacy", "Z", "Z - LP", json.dumps([])),
+    )
+    server_mod.meta_db.conn.commit()
+
+    data = _get(client, sort="tuning")
+    files = [s["filename"] for s in data["songs"]]
+    assert files == ["real.psarc", "legacy.psarc"]
+
+    # /api/library/tuning-names should also exclude the NULL row from
+    # the picker entirely (users can't usefully filter by an unknown
+    # tuning).
+    names = [t["name"] for t in client.get("/api/library/tuning-names").json()["tunings"]]
+    assert names == ["E Standard"]
+
+
 def test_query_stats_artist_count_is_case_insensitive(client, server_mod):
     """`total_artists` previously used `COUNT(DISTINCT artist)` (case-
     sensitive) while `query_artists` and the per-letter counts used

--- a/tests/test_library_filters.py
+++ b/tests/test_library_filters.py
@@ -224,6 +224,37 @@ def test_year_sort_asc_oldest_first(client, seeded):
     assert files == ["b.psarc", "a.psarc", "f.psarc", "d.sloppak", "c.sloppak", "e.sloppak"]
 
 
+def test_tuning_sort_down_tuned_before_up_tuned_at_same_distance(client, server_mod):
+    """Within an ABS(tuning_sort_key) tier, the down-tuned variant
+    must come before the up-tuned one so the order matches Rocksmith's
+    grouping (Eb Standard before F Standard at distance 6, etc.).
+    Earlier code used signed-key DESC for the tiebreaker, which put
+    +6 before -6 — the opposite of intent. Regression for Copilot
+    finding on PR #134."""
+    _put(server_mod, filename="up.psarc", title="Up", artist="A",
+         tuning_name="F Standard", tuning_sort_key=6,
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+    _put(server_mod, filename="down.psarc", title="Down", artist="B",
+         tuning_name="Eb Standard", tuning_sort_key=-6,
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+    _put(server_mod, filename="std.psarc", title="Std", artist="C",
+         tuning_name="E Standard", tuning_sort_key=0,
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+
+    # /api/library?sort=tuning
+    data = _get(client, sort="tuning")
+    seen = []
+    for s in data["songs"]:
+        tn = s.get("tuning_name")
+        if tn and tn not in seen:
+            seen.append(tn)
+    assert seen == ["E Standard", "Eb Standard", "F Standard"]
+
+    # /api/library/tuning-names — same intended order.
+    names = [t["name"] for t in client.get("/api/library/tuning-names").json()["tunings"]]
+    assert names == ["E Standard", "Eb Standard", "F Standard"]
+
+
 def test_tuning_sort_pushes_empty_tuning_name_to_bottom(client, server_mod):
     """Pre-rescan rows have empty `tuning_name` and `tuning_sort_key=0`.
     Without a leading `(tuning_name='') ASC` term, ABS(0) collides with

--- a/tests/test_library_filters.py
+++ b/tests/test_library_filters.py
@@ -224,6 +224,38 @@ def test_year_sort_asc_oldest_first(client, seeded):
     assert files == ["b.psarc", "a.psarc", "f.psarc", "d.sloppak", "c.sloppak", "e.sloppak"]
 
 
+def test_tuning_sort_pushes_empty_tuning_name_to_bottom(client, server_mod):
+    """Pre-rescan rows have empty `tuning_name` and `tuning_sort_key=0`.
+    Without a leading `(tuning_name='') ASC` term, ABS(0) collides with
+    E Standard's 0 so unscanned rows would float to the top of the
+    tuning sort. Regression for Copilot finding on PR #134."""
+    _put(server_mod, filename="real.psarc", title="Real", artist="A",
+         tuning_name="E Standard", tuning_sort_key=0,
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+    _put(server_mod, filename="legacy.psarc", title="Legacy", artist="B",
+         tuning_name="", tuning_sort_key=0,
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+    data = _get(client, sort="tuning")
+    files = [s["filename"] for s in data["songs"]]
+    assert files == ["real.psarc", "legacy.psarc"]
+
+
+def test_query_stats_artist_count_is_case_insensitive(client, server_mod):
+    """`total_artists` previously used `COUNT(DISTINCT artist)` (case-
+    sensitive) while `query_artists` and the per-letter counts used
+    NOCASE — leading to mismatched totals when the same artist was
+    indexed under different casings. Regression for Copilot finding
+    on PR #134."""
+    _put(server_mod, filename="x.psarc", title="X", artist="The Beatles",
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+    _put(server_mod, filename="y.psarc", title="Y", artist="the beatles",
+         arrangements=[{"index": 0, "name": "Lead", "notes": 1}])
+    stats = client.get("/api/library/stats").json()
+    assert stats["total_artists"] == 1
+    # Letter-bar count agrees.
+    assert stats["letters"].get("T") == 1
+
+
 def test_compound_sort_with_legacy_dir_desc_doesnt_error(client, seeded):
     """Regression for Copilot finding on PR #134: `sort=year&dir=desc`
     used to produce invalid SQL (`CAST(year AS INTEGER) ASC DESC`)

--- a/tests/test_library_filters.py
+++ b/tests/test_library_filters.py
@@ -1,0 +1,276 @@
+"""Tests for library filter + sort additions (slopsmith #129/#69/#128/#22).
+
+Each filter axis is exercised independently and combined. Sort cases
+cover the new year sort and the rewritten tuning sort (now
+musical-distance-based instead of alphabetical).
+
+Tests stub `MetadataDB` directly via `meta_db.put()`, bypassing the
+PSARC/sloppak scanner — same approach as test_settings_api.py.
+"""
+
+import importlib
+import json
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def server_mod(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path))
+    sys.modules.pop("server", None)
+    mod = importlib.import_module("server")
+    yield mod
+    conn = getattr(getattr(mod, "meta_db", None), "conn", None)
+    if conn is not None:
+        conn.close()
+
+
+@pytest.fixture()
+def client(server_mod):
+    c = TestClient(server_mod.app)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _put(server_mod, *, filename, title, artist, year="", arrangements=None,
+         has_lyrics=False, format="psarc", stem_ids=None, tuning_name="E Standard",
+         tuning_sort_key=0, mtime=1.0, size=1):
+    server_mod.meta_db.put(filename, mtime, size, {
+        "title": title, "artist": artist, "album": f"{artist} - LP",
+        "year": year, "duration": 200.0,
+        "tuning": tuning_name,
+        "arrangements": arrangements or [],
+        "has_lyrics": has_lyrics,
+        "format": format,
+        "stem_count": len(stem_ids) if stem_ids else 0,
+        "stem_ids": stem_ids if stem_ids is not None else [],
+        "tuning_name": tuning_name,
+        "tuning_sort_key": tuning_sort_key,
+    })
+
+
+@pytest.fixture()
+def seeded(server_mod):
+    """Populate 6 deterministic rows covering the matrix of axes."""
+    _put(server_mod, filename="a.psarc", title="A song", artist="A Band",
+         year="2010", has_lyrics=True, format="psarc",
+         arrangements=[{"index": 0, "name": "Lead", "notes": 100},
+                       {"index": 1, "name": "Rhythm", "notes": 80}],
+         tuning_name="E Standard", tuning_sort_key=0)
+    _put(server_mod, filename="b.psarc", title="B song", artist="B Band",
+         year="2005", has_lyrics=False, format="psarc",
+         arrangements=[{"index": 0, "name": "Bass", "notes": 60}],
+         tuning_name="Drop D", tuning_sort_key=-2)
+    _put(server_mod, filename="c.sloppak", title="C song", artist="C Band",
+         year="2020", has_lyrics=True, format="sloppak",
+         arrangements=[{"index": 0, "name": "Combo", "notes": 200}],
+         stem_ids=["drums", "bass", "vocals", "piano", "other"],
+         tuning_name="E Standard", tuning_sort_key=0)
+    _put(server_mod, filename="d.sloppak", title="D song", artist="D Band",
+         year="2018", has_lyrics=False, format="sloppak",
+         arrangements=[{"index": 0, "name": "Lead", "notes": 90}],
+         stem_ids=["drums", "vocals"],
+         tuning_name="Eb Standard", tuning_sort_key=-6)
+    # Legacy row: stem_ids deliberately set to NULL via raw SQL to
+    # simulate a row that predates the slopsmith#129 migration.
+    server_mod.meta_db.conn.execute(
+        "INSERT INTO songs (filename, mtime, size, title, artist, album, year, duration, "
+        "tuning, arrangements, has_lyrics, format, stem_count, stem_ids, tuning_name, tuning_sort_key) "
+        "VALUES (?, 1.0, 1, ?, ?, ?, '', 200.0, ?, ?, 0, 'sloppak', 1, NULL, ?, ?)",
+        ("e.sloppak", "E song", "E Band", "E Band - LP", "Drop D",
+         json.dumps([{"index": 0, "name": "Lead", "notes": 50}]),
+         "Drop D", -2),
+    )
+    server_mod.meta_db.conn.commit()
+    _put(server_mod, filename="f.psarc", title="F song", artist="F Band",
+         year="2015", has_lyrics=True, format="psarc",
+         arrangements=[{"index": 0, "name": "Lead", "notes": 110},
+                       {"index": 1, "name": "Bass", "notes": 70}],
+         tuning_name="Eb Standard", tuning_sort_key=-6)
+
+
+def _get(client, **kw):
+    return client.get("/api/library", params=kw).json()
+
+
+# ── Arrangements axis ───────────────────────────────────────────────────────
+
+def test_arrangement_has_lead(client, seeded):
+    data = _get(client, arrangements_has="Lead")
+    files = {s["filename"] for s in data["songs"]}
+    # Rows with Lead: a, d, e, f. Combo (c) does NOT match strict-name "Lead".
+    assert files == {"a.psarc", "d.sloppak", "e.sloppak", "f.psarc"}
+
+
+def test_arrangement_has_or_within_axis(client, seeded):
+    data = _get(client, arrangements_has="Lead,Bass")
+    files = {s["filename"] for s in data["songs"]}
+    # Lead OR Bass: a, b, d, e, f.
+    assert files == {"a.psarc", "b.psarc", "d.sloppak", "e.sloppak", "f.psarc"}
+
+
+def test_arrangement_lacks_bass(client, seeded):
+    data = _get(client, arrangements_lacks="Bass")
+    files = {s["filename"] for s in data["songs"]}
+    # b.psarc and f.psarc both have Bass, exclude them.
+    assert "b.psarc" not in files
+    assert "f.psarc" not in files
+    assert "a.psarc" in files
+
+
+# ── Lyrics axis ─────────────────────────────────────────────────────────────
+
+def test_has_lyrics_require(client, seeded):
+    data = _get(client, has_lyrics="1")
+    files = {s["filename"] for s in data["songs"]}
+    assert files == {"a.psarc", "c.sloppak", "f.psarc"}
+
+
+def test_has_lyrics_exclude(client, seeded):
+    data = _get(client, has_lyrics="0")
+    files = {s["filename"] for s in data["songs"]}
+    assert files == {"b.psarc", "d.sloppak", "e.sloppak"}
+
+
+# ── Stems axis ──────────────────────────────────────────────────────────────
+
+def test_stems_has_piano(client, seeded):
+    data = _get(client, stems_has="piano")
+    # Only c.sloppak has piano.
+    assert {s["filename"] for s in data["songs"]} == {"c.sloppak"}
+
+
+def test_stems_has_or_within_axis(client, seeded):
+    data = _get(client, stems_has="drums,piano")
+    # drums OR piano: c (all stems) and d (drums + vocals).
+    assert {s["filename"] for s in data["songs"]} == {"c.sloppak", "d.sloppak"}
+
+
+def test_stems_has_excludes_psarcs_and_legacy_null(client, seeded):
+    """PSARCs have empty stem_ids; legacy row has NULL. Both are
+    excluded by stems_has — there's no proof the stem is present."""
+    data = _get(client, stems_has="drums")
+    files = {s["filename"] for s in data["songs"]}
+    assert files == {"c.sloppak", "d.sloppak"}
+    # PSARC rows missing.
+    assert "a.psarc" not in files
+    # Legacy NULL row missing.
+    assert "e.sloppak" not in files
+
+
+def test_stems_lacks_other(client, seeded):
+    data = _get(client, stems_lacks="other")
+    files = {s["filename"] for s in data["songs"]}
+    # c.sloppak has "other" — must be excluded.
+    assert "c.sloppak" not in files
+    # Everything else lacks it (PSARCs have empty stem_ids; legacy NULL
+    # also lacks it because json_each yields nothing).
+    assert "a.psarc" in files
+
+
+# ── Tuning axis ─────────────────────────────────────────────────────────────
+
+def test_tunings_or_within_axis(client, seeded):
+    data = _get(client, tunings="E Standard,Drop D")
+    files = {s["filename"] for s in data["songs"]}
+    assert files == {"a.psarc", "b.psarc", "c.sloppak", "e.sloppak"}
+
+
+def test_tunings_eb_standard_only(client, seeded):
+    data = _get(client, tunings="Eb Standard")
+    assert {s["filename"] for s in data["songs"]} == {"d.sloppak", "f.psarc"}
+
+
+# ── Combined cross-axis (AND) ───────────────────────────────────────────────
+
+def test_combined_axes(client, seeded):
+    data = _get(client, arrangements_has="Lead", has_lyrics="1", tunings="E Standard")
+    # Lead AND lyrics AND E Standard:
+    # a (Lead, lyrics, E Std) ✓
+    # f (Lead, lyrics, Eb Std) ✗ (wrong tuning)
+    # c is Combo not Lead
+    assert {s["filename"] for s in data["songs"]} == {"a.psarc"}
+
+
+# ── Whitelist sanitization (defense-in-depth) ───────────────────────────────
+
+def test_whitelist_rejects_unknown_arrangement(client, seeded):
+    """Unknown arrangement names are dropped silently (whitelist), so a
+    bogus value is treated as 'no filter' rather than reaching SQL."""
+    full = _get(client)
+    bogus = _get(client, arrangements_has="DROP TABLE songs")
+    # Same row count as no-filter — whitelist stripped the unknown name.
+    assert bogus["total"] == full["total"]
+
+
+# ── Year sort (slopsmith#128) ───────────────────────────────────────────────
+
+def test_year_sort_desc_newest_first(client, seeded):
+    data = _get(client, sort="year-desc")
+    files = [s["filename"] for s in data["songs"]]
+    # Years: c=2020, d=2018, f=2015, a=2010, b=2005, e=''.
+    # Empty year goes to the bottom for both directions.
+    assert files == ["c.sloppak", "d.sloppak", "f.psarc", "a.psarc", "b.psarc", "e.sloppak"]
+
+
+def test_year_sort_asc_oldest_first(client, seeded):
+    data = _get(client, sort="year")
+    files = [s["filename"] for s in data["songs"]]
+    # Empty year still bottom — only the dated rows reverse.
+    assert files == ["b.psarc", "a.psarc", "f.psarc", "d.sloppak", "c.sloppak", "e.sloppak"]
+
+
+# ── Tuning sort by pitch distance (slopsmith#22) ────────────────────────────
+
+def test_tuning_sort_by_pitch_distance(client, seeded):
+    """Tuning sort previously alphabetized (Drop C, Drop D, E Standard).
+    Now it's musical-distance from E Standard via ABS(sort_key) ASC,
+    so E Standard (|0|) leads, then Drop D (|-2|), then Eb Standard
+    (|-6|). See slopsmith#22."""
+    data = _get(client, sort="tuning")
+    # Group by tuning name, preserving order; assert the first
+    # appearance of each tuning matches the expected musical-distance
+    # ordering. (Within a tuning group, songs sort by row order.)
+    seen_order = []
+    for s in data["songs"]:
+        tn = s.get("tuning_name")
+        if tn and tn not in seen_order:
+            seen_order.append(tn)
+    assert seen_order == ["E Standard", "Drop D", "Eb Standard"]
+
+
+# ── /api/library/tuning-names endpoint ──────────────────────────────────────
+
+def test_tuning_names_endpoint(client, seeded):
+    data = client.get("/api/library/tuning-names").json()
+    names = [t["name"] for t in data["tunings"]]
+    # ABS(sort_key) ascending puts E Standard first, then Drop D
+    # (|-2|), then Eb Standard (|-6|).
+    assert names == ["E Standard", "Drop D", "Eb Standard"]
+    counts = {t["name"]: t["count"] for t in data["tunings"]}
+    assert counts["E Standard"] == 2
+    assert counts["Drop D"] == 2
+    assert counts["Eb Standard"] == 2
+
+
+# ── Stats endpoint mirrors filtered totals ──────────────────────────────────
+
+def test_stats_reflects_filters(client, seeded):
+    full = client.get("/api/library/stats").json()
+    filtered = client.get("/api/library/stats", params={"has_lyrics": "1"}).json()
+    assert full["total_songs"] == 6
+    assert filtered["total_songs"] == 3
+    assert filtered["total_artists"] == 3
+
+
+# ── Empty values are no-ops ─────────────────────────────────────────────────
+
+def test_empty_values_are_no_ops(client, seeded):
+    full = _get(client)
+    same = _get(client, arrangements_has="", arrangements_lacks=",,",
+                stems_has="", tunings="", has_lyrics="")
+    assert full["total"] == same["total"]

--- a/tests/test_library_filters.py
+++ b/tests/test_library_filters.py
@@ -224,6 +224,20 @@ def test_year_sort_asc_oldest_first(client, seeded):
     assert files == ["b.psarc", "a.psarc", "f.psarc", "d.sloppak", "c.sloppak", "e.sloppak"]
 
 
+def test_compound_sort_with_legacy_dir_desc_doesnt_error(client, seeded):
+    """Regression for Copilot finding on PR #134: `sort=year&dir=desc`
+    used to produce invalid SQL (`CAST(year AS INTEGER) ASC DESC`)
+    because the global dir-append toggle didn't notice that the
+    compound year sort already encoded direction. Now the append is
+    suppressed when the sort clause already contains ASC or DESC."""
+    r = client.get("/api/library", params={"sort": "year", "dir": "desc"})
+    assert r.status_code == 200
+    # Order matches plain `sort=year` (legacy dir is ignored on
+    # already-directional clauses). The point is no 500 from invalid SQL.
+    files = [s["filename"] for s in r.json()["songs"]]
+    assert files == ["b.psarc", "a.psarc", "f.psarc", "d.sloppak", "c.sloppak", "e.sloppak"]
+
+
 # ── Tuning sort by pitch distance (slopsmith#22) ────────────────────────────
 
 def test_tuning_sort_by_pitch_distance(client, seeded):


### PR DESCRIPTION
Bundles four related library-browsing issues that share enough plumbing to ship as one PR.

Closes #129. Closes #69. Closes #128. Closes #22.

## Summary

| Issue | What it asked | What this delivers |
|---|---|---|
| #129 | Filter library by parts present / missing | Tri-state filter axes for arrangements (Lead/Rhythm/Bass/Combo), stems (drums/bass/vocals/guitar/piano/other), and lyrics |
| #69  | Filter songs by tuning | Multi-select tuning checklist populated from the live library |
| #128 | Sort library by year | Two new options: "Year (newest)" and "Year (oldest)" |
| #22  | Tuning sort is alphabetical, should be musically logical | Tuning sort rewritten to order by distance from E Standard |

## UX

Default library view adds **one small "Filters" button** next to the format/sort row. Nothing else visible until the user opts in. When filters are active, an active-count badge appears on the button and a single dismissible-chip row appears below the controls so the drawer doesn't have to be open to see state.

Inside the drawer:
- **Arrangements** — tri-state pills for Lead, Rhythm, Bass, Combo. One click cycles `any → require → exclude → any`.
- **Stems** — tri-state pills for Drums, Bass, Vocals, Guitar, Piano, Other. Section dimmed when format = PSARC (no stems exist there).
- **Lyrics** — single tri-state pill, same cycle.
- **Tuning** — collapsible checkbox list populated from `/api/library/tuning-names`, ordered by musical distance from E Standard.
- **Clear all** link.

Multi-select within an axis is OR (Lead + Rhythm = "has Lead OR Rhythm"). Cross-axis is AND (must satisfy every active axis). Filter state persists in `localStorage` so reloads keep the picked set.

## Schema

Three new columns on `songs` via idempotent `ALTER TABLE` (matches the existing migration pattern):

- `stem_ids` (TEXT) — JSON list of sloppak stem ids the manifest declares.
- `tuning_name` (TEXT) — denormalized canonical name. Indexed.
- `tuning_sort_key` (INT) — sum of per-string semitone offsets. Signed; 0 = E Standard. Indexed.

Existing rows have `NULL stem_ids` until rescanned; lazy backfill via the periodic rescan, immediate via **Settings → Full Rescan**. CHANGELOG includes a migration note advising users to run Full Rescan if filters look empty post-upgrade.

## Atomicity / safety

- A shared `_build_where()` helper is consulted by `query_page`, `query_artists`, and `query_stats` so the grid, tree view, and letter-bar counts stay synchronized under any filter set.
- Arrangement / stem inputs are whitelisted against known sets before binding — defense in depth even though parameters are properly bound. A bogus `arrangements_has=DROP TABLE` is silently dropped.
- Tuning input is capped at 32 entries to prevent a hostile caller from blowing out the parameter list.
- Empty `stem_ids` (PSARCs) and `NULL stem_ids` (legacy rows pre-migration) correctly *exclude* the row from `stems_has` (no proof of presence) and *include* it in `stems_lacks` (no proof of absence either, but matches user intent — "show me songs that don't have drum stems"). Documented in tests.

## API additions

On `/api/library`, `/api/library/artists`, `/api/library/stats`:

```
arrangements_has=Lead,Rhythm
arrangements_lacks=Bass
stems_has=drums,vocals
stems_lacks=piano
has_lyrics=1                 # 0 to exclude, absent = any
tunings=E%20Standard,Drop%20D
sort=year-desc               # also: year, tuning (now musical-distance order)
```

And a new endpoint:

```
GET /api/library/tuning-names
→ {"tunings": [{"name": "E Standard", "sort_key": 0, "count": 412}, ...]}
```

Ordered by `ABS(sort_key)` ASC so musically-close tunings appear together.

## Tuning sort rewrite (#22)

Was: `ORDER BY tuning COLLATE NOCASE` — alphabetical, mixes unrelated tunings.

Now: `ORDER BY ABS(tuning_sort_key), tuning_sort_key DESC, tuning_name COLLATE NOCASE`.

`tuning_sort_key` is the sum of per-string offsets (signed). E Standard = 0, Drop D = -2, Eb Standard = -6, Drop D♭ = -8, D Standard = -12. ABS ascending puts E Standard first, then ±2 (Drop D / F Standard), then ±6 (Eb Standard / F# Standard), and so on. Within a magnitude tier, signed DESC puts down-tuned before up-tuned, matching how Rocksmith groups them. Final tiebreak is alphabetical so order is fully deterministic.

## Files changed

- `server.py` — schema migration, `_build_where`, query updates, three handler signature updates, `/api/library/tuning-names` endpoint, new sort variants
- `lib/sloppak.py` — emit `stem_ids` from `extract_meta`
- `static/index.html` — Filters button, drawer markup, year sort options, chip row
- `static/app.js` — filter state, drawer JS, query-string builder, localStorage persist, tuning-names fetch
- `static/style.css` — drawer + tri-state pill styles, chip row styles
- `tests/test_library_filters.py` — 19 new test cases
- `CHANGELOG.md` — Unreleased entry + migration note

## Test plan

- [x] `pytest tests/test_library_filters.py -v` — 19 passing. Full suite: 249 passing (no regressions).
- [x] Settings → Full Rescan repopulates the new columns.
- [x] Filters button opens drawer; pills cycle `any → require → exclude → any`.
- [x] Active-filter chip row appears below the sort row when filters are set; clicking `×` removes the filter and updates state.
- [x] Tuning list populated from real library, ordered E Standard first.
- [x] Sort by "Year (newest)" / "Tuning" works as expected.
- [x] Filter state persists across hard reloads via `localStorage`.
- [x] Stems pills dim when format = PSARC.
- [x] Tree view + letter-bar counts mirror grid totals under active filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)