### PR TITLE
fix: bundled plugins always win over user-installed copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Section Map](https://github.com/byrongamatos/slopsmith-plugin-sectionmap) | Color-coded song structure minimap with clickable navigation | `git clone ...slopsmith-plugin-sectionmap.git section_map` |
 | [RS1 Extractor](https://github.com/byrongamatos/slopsmith-plugin-rs1extract) | Extract RS1 compatibility songs into individual CDLCs | `git clone ...slopsmith-plugin-rs1extract.git rs1_extract` |
 | [Base Game Extractor](https://github.com/byrongamatos/slopsmith-plugin-discextract) | Extract on-disc base game songs from songs.psarc into individual CDLCs | `git clone ...slopsmith-plugin-discextract.git disc_extract` |
-| [3D Highway](https://github.com/byrongamatos/slopsmith-plugin-3dhighway) | Three.js 3D perspective highway view as an alternative to the 2D canvas | `git clone ...slopsmith-plugin-3dhighway.git 3dhighway` |
 | [Arrangement Editor](https://github.com/byrongamatos/slopsmith-plugin-editor) | DAW-like visual editor for creating and editing CDLC note charts | `git clone ...slopsmith-plugin-editor.git editor` |
 | [Profile Import](https://github.com/byrongamatos/slopsmith-plugin-profileimport) | Import play counts, favorites, and scores from Rocksmith profiles | `git clone ...slopsmith-plugin-profileimport.git profileimport` |
 | [MIDI Capo](https://github.com/masc0t/slopsmith-plugin-midi-capo) | MIDI capo control for real-time transposition | `git clone ...slopsmith-plugin-midi-capo.git midi_capo` |

--- a/docs/diagnostics-bundle-spec.md
+++ b/docs/diagnostics-bundle-spec.md
@@ -186,10 +186,18 @@ entry explaining why.
 ```
 
 `orphans` covers plugin directories that contain a `plugin.json` but are
-NOT in `LOADED_PLUGINS` (failed to load — usually requirements install
-failure or manifest error). A plugin appearing only in `orphans` is the
-single best diagnostic signal for "user installed plugin X but it's not
-working".
+NOT in `LOADED_PLUGINS`. Two sub-cases:
+
+- **Failed-to-load** (no `evicted` field): the plugin id is not loaded at
+  all — usually requirements install failure or manifest error. A plugin
+  appearing only in `orphans` without `evicted` is the single best
+  diagnostic signal for "user installed plugin X but it's not working".
+- **Evicted/superseded** (`"evicted": true`): the plugin id IS loaded, but
+  from a *different* directory. Typical cause: bundled-wins logic discarded
+  an old user-installed clone in favour of the in-tree copy. Also covers
+  bundled plugin directories whose routes failed and whose server fell back
+  to a user copy (the bundled dir then has a different path from the loaded
+  entry). Check the server startup log for the specific failure reason.
 
 ### `logs.server.v1` — `logs/server.log.meta.json`
 

--- a/docs/diagnostics-bundle-spec.md
+++ b/docs/diagnostics-bundle-spec.md
@@ -179,7 +179,8 @@ entry explaining why.
       "name": "Broken Plugin",
       "version": "0.1.0",
       "loaded": false,
-      "dir": "broken"
+      "dir": "broken",
+      "path": "/home/user/.config/slopsmith/plugins/broken"
     }
   ]
 }
@@ -198,6 +199,13 @@ NOT in `LOADED_PLUGINS`. Two sub-cases:
   bundled plugin directories whose routes failed and whose server fell back
   to a user copy (the bundled dir then has a different path from the loaded
   entry). Check the server startup log for the specific failure reason.
+
+`dir` is the bare directory name. `path` is the full resolved absolute path
+to the orphan directory — the key disambiguator when the bundled copy and a
+user-installed copy share the same directory name (e.g. both `highway_3d`).
+In a redacted bundle `path` has home-dir and config-dir prefixes replaced
+with placeholder tokens (e.g. `<HOME>/...`, `<CONFIG_DIR>/...`) so
+filesystem paths and usernames do not leak.
 
 ### `logs.server.v1` — `logs/server.log.meta.json`
 

--- a/lib/diagnostics_bundle.py
+++ b/lib/diagnostics_bundle.py
@@ -403,7 +403,7 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
     loaded_ids: set[str] = set()
     # Map plugin_id → resolved directory path for the loaded copy,
     # used below to distinguish the canonical dir from stale clones.
-    loaded_dir_by_id: dict[str, "Path"] = {}
+    loaded_dir_by_id: dict[str, Path] = {}
     plugins_out: list[dict] = []
     for p in loaded_plugins:
         manifest = p.get("_manifest") or {}

--- a/lib/diagnostics_bundle.py
+++ b/lib/diagnostics_bundle.py
@@ -485,6 +485,12 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
                     "type": manifest.get("type"),
                     "loaded": False,
                     "dir": child.name,
+                    # Full resolved path for disambiguation: when the bundled
+                    # and user-installed copies share the same directory name
+                    # (e.g. both are named "highway_3d"), `dir` alone is
+                    # ambiguous.  `path` lets maintainers identify which root
+                    # the evicted copy came from without inspecting server logs.
+                    "path": str(child_key),
                 }
                 # Flag directories that share an id with a loaded plugin
                 # (bundled-wins evicted them) vs. true orphans (failed to load).

--- a/lib/diagnostics_bundle.py
+++ b/lib/diagnostics_bundle.py
@@ -395,8 +395,15 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
     *plugins_root* accepts a single Path, a list of Paths (to cover both
     the built-in ``plugins/`` directory and ``SLOPSMITH_PLUGINS_DIR``), or
     None to skip orphan detection entirely.
+
+    Stale/evicted copies — directories with the same plugin id as a loaded
+    plugin but a different on-disk path — are included in ``orphans`` with
+    ``"evicted": True`` so support staff can see them in the bundle.
     """
     loaded_ids: set[str] = set()
+    # Map plugin_id → resolved directory path for the loaded copy,
+    # used below to distinguish the canonical dir from stale clones.
+    loaded_dir_by_id: dict[str, "Path"] = {}
     plugins_out: list[dict] = []
     for p in loaded_plugins:
         manifest = p.get("_manifest") or {}
@@ -423,6 +430,8 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
         plugins_out.append(entry)
         if entry["id"]:
             loaded_ids.add(entry["id"])
+            if isinstance(plugin_dir, Path):
+                loaded_dir_by_id[entry["id"]] = plugin_dir.resolve()
 
     # Walk plugin root directories to catch orphans (manifest exists but
     # plugin failed to load — common when requirements.txt installs
@@ -452,7 +461,13 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
                     manifest = {}
                 pid = manifest.get("id") or child.name
                 if pid in loaded_ids:
-                    continue
+                    # Skip only if this IS the loaded plugin's directory.
+                    # A different directory with the same id is a stale/evicted
+                    # copy — still report it so the diagnostics bundle surfaces it.
+                    loaded_dir = loaded_dir_by_id.get(pid)
+                    if loaded_dir is not None and loaded_dir == child_key:
+                        continue
+                    # Falls through to report as an evicted orphan.
                 orphan = {
                     "id": pid,
                     "name": manifest.get("name", pid),
@@ -461,6 +476,10 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
                     "loaded": False,
                     "dir": child.name,
                 }
+                # Flag directories that share an id with a loaded plugin
+                # (bundled-wins evicted them) vs. true orphans (failed to load).
+                if pid in loaded_ids:
+                    orphan["evicted"] = True
                 git = _git_info(child)
                 if git is not None:
                     orphan["git"] = git

--- a/lib/diagnostics_bundle.py
+++ b/lib/diagnostics_bundle.py
@@ -396,9 +396,19 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
     the built-in ``plugins/`` directory and ``SLOPSMITH_PLUGINS_DIR``), or
     None to skip orphan detection entirely.
 
-    Stale/evicted copies — directories with the same plugin id as a loaded
-    plugin but a different on-disk path — are included in ``orphans`` with
-    ``"evicted": True`` so support staff can see them in the bundle.
+    Plugin directories not in ``LOADED_PLUGINS`` appear in ``orphans``.
+    Two sub-cases are distinguished:
+
+    * **Stale/evicted copies**: same plugin id as a loaded plugin but a
+      different on-disk path (e.g. an old user clone of a bundled plugin).
+      These receive ``"evicted": True``. This also covers bundled plugin
+      directories whose routes failed and whose server fell back to a
+      user copy — the bundled dir is then the non-loaded directory and
+      appears here too. Check the server startup log for the specific
+      failure reason in that case.
+    * **Failed-to-load orphans**: directories whose plugin id is not in
+      ``LOADED_PLUGINS`` at all (requirements install failure, manifest
+      error, etc.). These appear without ``"evicted"`` set.
     """
     loaded_ids: set[str] = set()
     # Map plugin_id → resolved directory path for the loaded copy,

--- a/lib/diagnostics_bundle.py
+++ b/lib/diagnostics_bundle.py
@@ -386,7 +386,7 @@ def _sanitize_remote_url(url: str) -> str:
     return sanitized
 
 
-def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path] | None" = None) -> dict:
+def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path] | None" = None, redactor=None) -> dict:
     """Build `system.plugins.v1`. Captures every loaded plugin with
     git/manifest info, AND every directory under each plugins root that
     contains a `plugin.json` so orphan / failed-to-load plugins still
@@ -490,7 +490,12 @@ def _system_plugins(loaded_plugins: list[dict], plugins_root: "Path | list[Path]
                     # (e.g. both are named "highway_3d"), `dir` alone is
                     # ambiguous.  `path` lets maintainers identify which root
                     # the evicted copy came from without inspecting server logs.
-                    "path": str(child_key),
+                    # When redaction is active, the path passes through the
+                    # text redactor so home-dir / config-dir prefixes are
+                    # replaced with their placeholder tokens — preventing
+                    # filesystem paths and usernames from leaking in a
+                    # supposedly redacted bundle.
+                    "path": redactor.redact_text(str(child_key)) if redactor is not None else str(child_key),
                 }
                 # Flag directories that share an id with a loaded plugin
                 # (bundled-wins evicted them) vs. true orphans (failed to load).
@@ -1000,7 +1005,7 @@ def _assemble_files_and_notes(
         files["system/version.json"] = ver_payload
         env_payload = _safe_json_dumps(_system_env(redactor=redactor)).encode("utf-8")
         files["system/env.json"] = env_payload
-        plugins_data = _system_plugins(loaded_plugins, plugins_root=plugins_root)
+        plugins_data = _system_plugins(loaded_plugins, plugins_root=plugins_root, redactor=redactor)
         files["system/plugins.json"] = _safe_json_dumps(plugins_data).encode("utf-8")
         # Plugin loading is async and takes a few seconds on cold
         # boot. If the bundle was captured during that window, every

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -557,6 +557,11 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # instead of a generic "skipping duplicate" line. Mirrors loaded_ids
     # in lifetime; both are local to this discovery pass.
     loaded_specs_by_id: dict[str, tuple] = {}
+    # Maps plugin_id → evicted user spec (plugin_id, plugin_dir, manifest).
+    # Populated when a bundled plugin evicts a user-installed copy. Used as
+    # a fallback: if the bundled copy later fails to load its routes, the
+    # user copy is restored so the server remains functional.
+    _pending_evictions: dict[str, tuple] = {}
 
     def _is_bundled(pdir: Path, mf: dict) -> bool:
         """Return True iff pdir is the real in-tree bundled core plugin.
@@ -621,15 +626,10 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 # for empty strings).
                 continue
             if plugin_id in loaded_ids:
-                # Quiet shadowing: when a user-installed copy beats a
-                # bundled copy (or vice versa), the duplicate-skip is
-                # the override path users explicitly want — phrase the
-                # log so it's obvious which copy is active and why,
-                # rather than the generic "Skipping duplicate".
-                # `loaded_specs_by_id` records the kept copy; this
-                # branch is the discarded one. Slopsmith#160 uses this
-                # for the plugin-list UI marker that shows a banner
-                # when a bundled plugin has been overridden.
+                # Duplicate id — pick a winner. Bundled plugins always win.
+                # `loaded_specs_by_id` records the already-seen copy; this
+                # is the new candidate. Use specific log messages so it's
+                # obvious which copy wins and why.
                 kept = loaded_specs_by_id.get(plugin_id)
                 # Bundled-ness requires ALL THREE: the in-tree PLUGINS_DIR
                 # location, the manifest's ``"bundled": true`` flag, AND
@@ -643,6 +643,11 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     # or cloned directly into plugins/). Bundled always wins —
                     # evict the user copy and fall through to register the
                     # bundled version instead.
+                    #
+                    # Store the evicted spec as a potential fallback: if the
+                    # bundled copy later fails to load its routes, the server
+                    # restores this user copy so it keeps working.
+                    _pending_evictions[plugin_id] = kept
                     log.warning(
                         "User-installed copy of bundled plugin %r at %s ignored; "
                         "using bundled version at %s.",
@@ -696,6 +701,9 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # plugins are loaded, so concurrent readers never see a partially
     # populated LOADED_PLUGINS.
     _loaded_batch: list = []
+    # Track plugin_ids whose routes.setup() raised an exception, so we
+    # can fall back to evicted user copies for those plugin_ids below.
+    _route_failed_ids: set[str] = set()
 
     for idx, (plugin_id, plugin_dir, manifest) in enumerate(plugin_load_specs):
         _emit_progress(
@@ -792,6 +800,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     log.info("Loaded routes for plugin %r", plugin_id)
             except Exception as e:
                 log.exception("Failed to load routes for plugin %r", plugin_id)
+                _route_failed_ids.add(plugin_id)
                 _emit_progress(
                     "plugin-error",
                     f"Failed loading routes for '{plugin_id}'",
@@ -843,6 +852,74 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             loaded=idx + 1,
             total=len(plugin_load_specs),
         )
+
+    # If any bundled plugin failed to load its routes AND it evicted a
+    # user-installed copy during discovery, fall back to that user copy so
+    # the server remains functional. A bad bundled release should never
+    # leave the plugin completely broken when a working user copy exists.
+    for evicted_id, evicted_spec in _pending_evictions.items():
+        if evicted_id not in _route_failed_ids:
+            continue
+        _ev_id, ev_dir, ev_manifest = evicted_spec
+        log.warning(
+            "Bundled plugin %r failed to load routes; "
+            "falling back to user-installed copy at %s.",
+            evicted_id, ev_dir,
+        )
+        # Remove the broken bundled entry from the batch.
+        _loaded_batch[:] = [e for e in _loaded_batch if e["id"] != evicted_id]
+        # Ensure the fallback directory is on sys.path.
+        ev_dir_str = str(ev_dir)
+        if ev_dir_str not in sys.path:
+            sys.path.insert(0, ev_dir_str)
+        ev_context = dict(context)
+        ev_context["load_sibling"] = (
+            lambda name, _pid=evicted_id, _pdir=ev_dir:
+                _load_plugin_sibling(_pid, _pdir, name)
+        )
+        ev_context["log"] = logging.getLogger(f"slopsmith.plugin.{evicted_id}")
+        # Re-load the fallback's routes using the same module-name slot so
+        # it naturally replaces the previously-failed bundled module.
+        ev_routes_file = ev_manifest.get("routes")
+        if ev_routes_file:
+            try:
+                ev_module_name = f"plugin_{_safe_plugin_id_for_module_name(evicted_id)}_routes"
+                ev_spec = importlib.util.spec_from_file_location(
+                    ev_module_name, str(ev_dir / ev_routes_file))
+                ev_routes_module = importlib.util.module_from_spec(ev_spec)
+                sys.modules[ev_module_name] = ev_routes_module
+                ev_spec.loader.exec_module(ev_routes_module)
+                if hasattr(ev_routes_module, "setup"):
+                    if route_setup_fn is not None:
+                        _fn = lambda rm=ev_routes_module, ctx=ev_context: rm.setup(app, ctx)
+                        _fn._plugin_id = evicted_id
+                        route_setup_fn(_fn)
+                    else:
+                        ev_routes_module.setup(app, ev_context)
+                log.info("Loaded routes for fallback copy of plugin %r", evicted_id)
+            except Exception:
+                log.exception(
+                    "Fallback user-installed copy of %r also failed to load routes; "
+                    "plugin unavailable.", evicted_id,
+                )
+        _loaded_batch.append({
+            "id": evicted_id,
+            "name": ev_manifest.get("name", evicted_id),
+            "nav": ev_manifest.get("nav"),
+            "type": ev_manifest.get("type"),
+            "bundled": False,  # user copy, not bundled
+            "has_screen": bool(ev_manifest.get("screen")),
+            "has_script": bool(ev_manifest.get("script")),
+            "has_settings": bool(ev_manifest.get("settings")),
+            "has_tour": _is_valid_tour_manifest(ev_manifest.get("tour")),
+            "_export_paths": _normalize_export_paths(ev_manifest.get("settings"), evicted_id),
+            "_diagnostics_paths": _normalize_diagnostics_paths(ev_manifest.get("diagnostics"), evicted_id),
+            "_diagnostics_callable_spec": _parse_diagnostics_callable(ev_manifest.get("diagnostics"), evicted_id),
+            "_load_sibling": ev_context["load_sibling"],
+            "_dir": ev_dir,
+            "_manifest": ev_manifest,
+        })
+        log.info("Registered fallback user copy of plugin %r (%s)", evicted_id, ev_manifest.get("name", ""))
 
     # Publish all plugins atomically so concurrent readers never observe
     # a partially-populated list during the loading window.  We clear

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -919,7 +919,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             except Exception:
                 log.exception(
                     "Fallback user-installed copy of %r also failed to load routes; "
-                    "plugin will not be registered.", evicted_id,
+                    "plugin unavailable (not registered).", evicted_id,
                 )
                 fallback_routes_ok = False
         if fallback_routes_ok:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1010,13 +1010,12 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         # the main load loop ran, so _install_requirements was never called
         # for it. A user copy that depends on extra packages would otherwise
         # fail with an import error even when those packages can be installed.
-        if not _install_requirements(ev_dir, evicted_id):
-            log.warning(
-                "Fallback user-installed copy of %r: requirements installation "
-                "failed; plugin unavailable (not registered). The original "
-                "bundled-failure error remains in startup-status.", evicted_id,
-            )
-            continue
+        # Mirror the main load-loop contract: _install_requirements returning
+        # False is *non-fatal* (read-only filesystem, optional dep, etc.) —
+        # the main loop emits a plugin-error and continues loading. Treating
+        # it as fatal here would break the fallback for those same tolerated
+        # cases and leave the bundled-failure error unresolved.
+        _install_requirements(ev_dir, evicted_id)
         # Purge any sibling modules the failed bundled copy may have loaded.
         # They are cached under the same namespace as what the fallback would use.
         # The parent package is `plugin_{safe_id}`, sibling modules are

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -955,11 +955,19 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         # resolve bundled helper code that is still cached in sys.modules.
         _safe_eid = _safe_plugin_id_for_module_name(evicted_id)
         _parent_pkg = f"plugin_{_safe_eid}"
+        # The routes module is registered under exactly `{_parent_pkg}_routes`
+        # (underscore, not dot — it is NOT a sub-package of _parent_pkg).
+        # Using startswith(f"{_parent_pkg}_") would also purge route/sibling
+        # modules for other plugins whose ids share the same prefix — e.g.,
+        # "plugin_a_routes" would be deleted when evicting plugin "a" because
+        # "plugin_a_routes".startswith("plugin_a_") is True, which would also
+        # incorrectly match "plugin_a_5f_b_routes" (routes for plugin "a_b").
+        # Match the routes entry exactly instead.
         _stale_sibling_keys = [
             k for k in list(sys.modules)
             if k == _parent_pkg
             or k.startswith(f"{_parent_pkg}.")
-            or k.startswith(f"{_parent_pkg}_")
+            or k == f"{_parent_pkg}_routes"
         ]
         for _k in _stale_sibling_keys:
             del sys.modules[_k]
@@ -1014,6 +1022,11 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "nav": ev_manifest.get("nav"),
                 "type": ev_manifest.get("type"),
                 "bundled": False,  # user copy, not bundled
+                # Marks this entry as an emergency user-copy fallback: the
+                # bundled routes failed, so the evicted user-installed copy
+                # was loaded instead.  Surfaced in /api/plugins and the
+                # settings UI so users know the bundled build is broken.
+                "fallback": True,
                 "has_screen": bool(ev_manifest.get("screen")),
                 "has_script": bool(ev_manifest.get("script")),
                 "has_settings": bool(ev_manifest.get("settings")),
@@ -1119,6 +1132,12 @@ def register_plugin_api(app: FastAPI):
                 # render a "Bundled" badge (lock icon) next to the
                 # plugin name in the settings collapsible.
                 "bundled": p.get("bundled", False),
+                # `fallback` is True only for user-installed copies that
+                # are active because the bundled plugin's routes failed.
+                # Surfaced in /api/plugins so the settings UI can show
+                # a warning badge, letting users know the bundled build
+                # is broken and they are running an older user copy.
+                "fallback": p.get("fallback", False),
                 "has_screen": p["has_screen"],
                 "has_script": p["has_script"],
                 "has_settings": p["has_settings"],

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -673,7 +673,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     )
                     continue
                 else:
-                    log.warning("Skipping duplicate plugin %r from %s", plugin_id, plugins_base_dir)
+                    log.warning("Skipping duplicate plugin %r at %s", plugin_id, plugin_dir)
                     continue
             loaded_ids.add(plugin_id)
             plugin_load_specs.append((plugin_id, plugin_dir, manifest))

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -570,6 +570,13 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # a fallback: if the bundled copy later fails to load its routes, the
     # user copy is restored so the server remains functional.
     _pending_evictions: dict[str, tuple] = {}
+    # Maps plugin_id → set of sys.modules keys that were NEW during the
+    # failed bundled route load. Bundled routes may import helpers under
+    # bare names (e.g. `import helper`); these survive the namespaced
+    # _parent_pkg cleanup and would resolve to bundled code if the fallback
+    # plugin also uses bare imports. Purging them gives the fallback a
+    # clean import slate (Thread 1, review-4226783807).
+    _pending_eviction_stale_modules: dict[str, set] = {}
 
     def _is_bundled(pdir: Path, mf: dict) -> bool:
         """Return True iff pdir is the real in-tree bundled core plugin.
@@ -789,6 +796,11 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             # setup() registered any handlers before raising. FastAPI has
             # no route-removal API, so partial registration is permanent.
             _routes_before = len(getattr(app, "routes", []))
+            # Snapshot sys.modules to track bare-import modules the plugin
+            # adds during its route load. Stored on failure so the fallback
+            # block can purge them and get a clean import slate (Thread 1,
+            # review-4226783807).
+            _sysmod_before_routes = set(sys.modules)
             try:
                 # Escape `.` in plugin_id the same way load_sibling
                 # does. Without it, a plugin id like
@@ -829,6 +841,13 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                         "Plugin %r registered %d route(s) before its setup() raised; "
                         "these handlers cannot be removed and may conflict with any fallback.",
                         plugin_id, _routes_after - _routes_before,
+                    )
+                # Record bare-import modules added during the failed load so
+                # the fallback block can purge them (Thread 1, review-4226783807).
+                # Only store when a fallback user copy is available; no-op otherwise.
+                if plugin_id in _pending_evictions:
+                    _pending_eviction_stale_modules[plugin_id] = (
+                        set(sys.modules) - _sysmod_before_routes
                     )
                 _emit_progress(
                     "plugin-error",
@@ -944,11 +963,21 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         ]
         for _k in _stale_sibling_keys:
             del sys.modules[_k]
+        # Also purge bare-import modules the failed bundled copy may have added
+        # to sys.modules. These are NOT covered by the namespaced purge above;
+        # a bundled plugin that does `import helper` (bare import via sys.path)
+        # would otherwise leave a stale `helper` module in sys.modules that
+        # the fallback copy could accidentally resolve instead of its own file.
+        for _k in _pending_eviction_stale_modules.get(evicted_id, set()):
+            sys.modules.pop(_k, None)
         # Re-load the fallback's routes using the same module-name slot so
         # it naturally replaces the previously-failed bundled module.
         ev_routes_file = ev_manifest.get("routes")
         fallback_routes_ok = True
         if ev_routes_file:
+            # Capture route count before fallback setup() to detect partial
+            # registration — same permanent-mount limitation as the main loop.
+            _fallback_routes_before = len(getattr(app, "routes", []))
             try:
                 ev_module_name = f"plugin_{_safe_plugin_id_for_module_name(evicted_id)}_routes"
                 ev_spec = importlib.util.spec_from_file_location(
@@ -969,6 +998,14 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     "Fallback user-installed copy of %r also failed to load routes; "
                     "plugin unavailable (not registered).", evicted_id,
                 )
+                # Warn on partial registration in the fallback path too.
+                _fallback_routes_after = len(getattr(app, "routes", []))
+                if _fallback_routes_after > _fallback_routes_before:
+                    log.warning(
+                        "Fallback copy of %r registered %d route(s) before its setup() raised; "
+                        "these handlers cannot be removed.",
+                        evicted_id, _fallback_routes_after - _fallback_routes_before,
+                    )
                 fallback_routes_ok = False
         if fallback_routes_ok:
             _loaded_batch.append({

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1010,7 +1010,13 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         # the main load loop ran, so _install_requirements was never called
         # for it. A user copy that depends on extra packages would otherwise
         # fail with an import error even when those packages can be installed.
-        _install_requirements(ev_dir, evicted_id)
+        if not _install_requirements(ev_dir, evicted_id):
+            log.warning(
+                "Fallback user-installed copy of %r: requirements installation "
+                "failed; plugin unavailable (not registered). The original "
+                "bundled-failure error remains in startup-status.", evicted_id,
+            )
+            continue
         # Purge any sibling modules the failed bundled copy may have loaded.
         # They are cached under the same namespace as what the fallback would use.
         # The parent package is `plugin_{safe_id}`, sibling modules are

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -671,6 +671,12 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 elif kept_is_bundled:
                     # A non-bundled (user) copy encountered after an already-kept
                     # bundled copy. Bundled always wins — discard the user copy.
+                    # Store as a potential fallback: if the bundled copy later
+                    # fails to load its routes, the server restores this user copy
+                    # so it keeps working. Only the first user copy encountered is
+                    # kept as the fallback (subsequent duplicates are dropped).
+                    if plugin_id not in _pending_evictions:
+                        _pending_evictions[plugin_id] = (plugin_id, plugin_dir, manifest)
                     log.warning(
                         "User-installed copy of bundled plugin %r at %s ignored; "
                         "using bundled version at %s.",
@@ -857,6 +863,13 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # user-installed copy during discovery, fall back to that user copy so
     # the server remains functional. A bad bundled release should never
     # leave the plugin completely broken when a working user copy exists.
+    #
+    # NOTE: Routes that the broken bundled setup() may have partially
+    # registered before raising cannot be un-registered (FastAPI has no
+    # route-removal API). In practice setup() usually fails before
+    # registering any handlers (import error, missing config), so partial
+    # registration is rare. This is an accepted limitation; the primary
+    # mitigation is thorough testing of bundled releases.
     for evicted_id, evicted_spec in _pending_evictions.items():
         if evicted_id not in _route_failed_ids:
             continue
@@ -878,9 +891,15 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 _load_plugin_sibling(_pid, _pdir, name)
         )
         ev_context["log"] = logging.getLogger(f"slopsmith.plugin.{evicted_id}")
+        # Install the fallback copy's requirements. It was evicted before
+        # the main load loop ran, so _install_requirements was never called
+        # for it. A user copy that depends on extra packages would otherwise
+        # fail with an import error even when those packages can be installed.
+        _install_requirements(ev_dir, evicted_id)
         # Re-load the fallback's routes using the same module-name slot so
         # it naturally replaces the previously-failed bundled module.
         ev_routes_file = ev_manifest.get("routes")
+        fallback_routes_ok = True
         if ev_routes_file:
             try:
                 ev_module_name = f"plugin_{_safe_plugin_id_for_module_name(evicted_id)}_routes"
@@ -900,26 +919,28 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             except Exception:
                 log.exception(
                     "Fallback user-installed copy of %r also failed to load routes; "
-                    "plugin unavailable.", evicted_id,
+                    "plugin will not be registered.", evicted_id,
                 )
-        _loaded_batch.append({
-            "id": evicted_id,
-            "name": ev_manifest.get("name", evicted_id),
-            "nav": ev_manifest.get("nav"),
-            "type": ev_manifest.get("type"),
-            "bundled": False,  # user copy, not bundled
-            "has_screen": bool(ev_manifest.get("screen")),
-            "has_script": bool(ev_manifest.get("script")),
-            "has_settings": bool(ev_manifest.get("settings")),
-            "has_tour": _is_valid_tour_manifest(ev_manifest.get("tour")),
-            "_export_paths": _normalize_export_paths(ev_manifest.get("settings"), evicted_id),
-            "_diagnostics_paths": _normalize_diagnostics_paths(ev_manifest.get("diagnostics"), evicted_id),
-            "_diagnostics_callable_spec": _parse_diagnostics_callable(ev_manifest.get("diagnostics"), evicted_id),
-            "_load_sibling": ev_context["load_sibling"],
-            "_dir": ev_dir,
-            "_manifest": ev_manifest,
-        })
-        log.info("Registered fallback user copy of plugin %r (%s)", evicted_id, ev_manifest.get("name", ""))
+                fallback_routes_ok = False
+        if fallback_routes_ok:
+            _loaded_batch.append({
+                "id": evicted_id,
+                "name": ev_manifest.get("name", evicted_id),
+                "nav": ev_manifest.get("nav"),
+                "type": ev_manifest.get("type"),
+                "bundled": False,  # user copy, not bundled
+                "has_screen": bool(ev_manifest.get("screen")),
+                "has_script": bool(ev_manifest.get("script")),
+                "has_settings": bool(ev_manifest.get("settings")),
+                "has_tour": _is_valid_tour_manifest(ev_manifest.get("tour")),
+                "_export_paths": _normalize_export_paths(ev_manifest.get("settings"), evicted_id),
+                "_diagnostics_paths": _normalize_diagnostics_paths(ev_manifest.get("diagnostics"), evicted_id),
+                "_diagnostics_callable_spec": _parse_diagnostics_callable(ev_manifest.get("diagnostics"), evicted_id),
+                "_load_sibling": ev_context["load_sibling"],
+                "_dir": ev_dir,
+                "_manifest": ev_manifest,
+            })
+            log.info("Registered fallback user copy of plugin %r (%s)", evicted_id, ev_manifest.get("name", ""))
 
     # Publish all plugins atomically so concurrent readers never observe
     # a partially-populated list during the loading window.  We clear

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1027,6 +1027,8 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "plugin-error",
                 f"Failed to install requirements for fallback copy of '{evicted_id}'",
                 plugin_id=evicted_id,
+                loaded=len(_loaded_batch),
+                total=len(plugin_load_specs),
                 error="Requirements installation failed for fallback copy; check server logs",
             )
         # Purge any sibling modules the failed bundled copy may have loaded.
@@ -1100,6 +1102,8 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     "plugin-error",
                     f"Fallback copy of plugin '{evicted_id}' also failed to load routes",
                     plugin_id=evicted_id,
+                    loaded=len(_loaded_batch),
+                    total=len(plugin_load_specs),
                     error=(
                         f"Both bundled and user-installed copies of '{evicted_id}' "
                         "failed to load routes; plugin unavailable — check server logs"
@@ -1144,13 +1148,16 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             # the bundled failure even though the plugin is now active via the
             # fallback copy. Uses clear_error=True so the server handler
             # replaces the stale error with null rather than ignoring it.
+            # Only send clear_error when req install also succeeded; if req
+            # failed we emitted a plugin-error above and must not clear it —
+            # the fallback copy is active but degraded (missing dependencies).
             _emit_progress(
                 "plugin-registered",
                 f"Registered fallback copy of plugin '{evicted_id}'",
                 plugin_id=evicted_id,
                 loaded=len(_loaded_batch),
                 total=len(plugin_load_specs),
-                clear_error=True,
+                clear_error=ev_req_ok,
             )
 
     # Publish all plugins atomically so concurrent readers never observe

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -509,7 +509,8 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     """
 
     def _emit_progress(phase: str, message: str, plugin_id: str = "", loaded: int = 0,
-                       total: int = 0, error: str | None = None):
+                       total: int = 0, error: str | None = None,
+                       clear_error: bool = False):
         if not progress_cb:
             return
         try:
@@ -520,12 +521,19 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "loaded": loaded,
                 "total": total,
             }
-            # Omit the error key when there is no error so that downstream
-            # consumers using "status.error = event.error" don't accidentally
-            # clear a previously-reported plugin error on the next non-error
-            # progress event.
+            # Include the error key only when meaningful:
+            # - A non-null error string sets/updates the error field.
+            # - clear_error=True sends an explicit null to clear a
+            #   previously-reported error (e.g. bundled failure cleared
+            #   by a successful user-copy fallback). Downstream handlers
+            #   must check `"error" in event`, not `event.get("error") is
+            #   not None`, to receive the clear signal.
+            # - No error kwarg → key is omitted; downstream preserves
+            #   any previously-reported error across non-error events.
             if error is not None:
                 event["error"] = error
+            elif clear_error:
+                event["error"] = None
             progress_cb(event)
         except Exception:
             # Progress reporting must never break plugin startup.
@@ -777,6 +785,10 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 loaded=idx,
                 total=len(plugin_load_specs),
             )
+            # Capture the current route count so we can detect whether
+            # setup() registered any handlers before raising. FastAPI has
+            # no route-removal API, so partial registration is permanent.
+            _routes_before = len(getattr(app, "routes", []))
             try:
                 # Escape `.` in plugin_id the same way load_sibling
                 # does. Without it, a plugin id like
@@ -807,6 +819,17 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             except Exception as e:
                 log.exception("Failed to load routes for plugin %r", plugin_id)
                 _route_failed_ids.add(plugin_id)
+                # Detect partial route registration: if setup() mounted any
+                # handlers before raising, those routes stay permanently (no
+                # FastAPI deregistration API). Warn loudly so maintainers can
+                # identify conflicting endpoints in the server log.
+                _routes_after = len(getattr(app, "routes", []))
+                if _routes_after > _routes_before:
+                    log.warning(
+                        "Plugin %r registered %d route(s) before its setup() raised; "
+                        "these handlers cannot be removed and may conflict with any fallback.",
+                        plugin_id, _routes_after - _routes_before,
+                    )
                 _emit_progress(
                     "plugin-error",
                     f"Failed loading routes for '{plugin_id}'",
@@ -864,12 +887,20 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # the server remains functional. A bad bundled release should never
     # leave the plugin completely broken when a working user copy exists.
     #
-    # NOTE: Routes that the broken bundled setup() may have partially
-    # registered before raising cannot be un-registered (FastAPI has no
-    # route-removal API). In practice setup() usually fails before
-    # registering any handlers (import error, missing config), so partial
-    # registration is rare. This is an accepted limitation; the primary
-    # mitigation is thorough testing of bundled releases.
+    # NOTE on partial-registration: if the bundled setup() managed to register
+    # some FastAPI routes before raising, those handlers stay permanently (no
+    # route-removal API). The partial-registration warning above names the
+    # count; the fallback copy's routes then mount alongside them, so duplicate
+    # or conflicting endpoints are possible. This is an accepted limitation;
+    # the primary mitigation is thorough testing of bundled releases.
+    #
+    # NOTE on timeout race: in async mode the bundled setup() runs on the
+    # event-loop thread via route_setup_fn. If it times out (>60 s), the
+    # load_plugins() thread raises TimeoutError and proceeds to activate the
+    # fallback, but the original setup() may still be running concurrently
+    # and can register additional routes after the fallback is already active.
+    # This race is also accepted as a very-unlikely edge case; prefer async-
+    # safe and idempotent setup() implementations in bundled plugins.
     for evicted_id, evicted_spec in _pending_evictions.items():
         if evicted_id not in _route_failed_ids:
             continue
@@ -896,6 +927,23 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         # for it. A user copy that depends on extra packages would otherwise
         # fail with an import error even when those packages can be installed.
         _install_requirements(ev_dir, evicted_id)
+        # Purge any sibling modules the failed bundled copy may have loaded.
+        # They are cached under the same namespace as what the fallback would use.
+        # The parent package is `plugin_{safe_id}`, sibling modules are
+        # `plugin_{safe_id}.{name}` (from load_sibling), and the routes module is
+        # `plugin_{safe_id}_routes` (note the underscore). Clearing all three
+        # patterns ensures the fallback gets a clean slate and doesn't accidentally
+        # resolve bundled helper code that is still cached in sys.modules.
+        _safe_eid = _safe_plugin_id_for_module_name(evicted_id)
+        _parent_pkg = f"plugin_{_safe_eid}"
+        _stale_sibling_keys = [
+            k for k in list(sys.modules)
+            if k == _parent_pkg
+            or k.startswith(f"{_parent_pkg}.")
+            or k.startswith(f"{_parent_pkg}_")
+        ]
+        for _k in _stale_sibling_keys:
+            del sys.modules[_k]
         # Re-load the fallback's routes using the same module-name slot so
         # it naturally replaces the previously-failed bundled module.
         ev_routes_file = ev_manifest.get("routes")
@@ -941,6 +989,20 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "_manifest": ev_manifest,
             })
             log.info("Registered fallback user copy of plugin %r (%s)", evicted_id, ev_manifest.get("name", ""))
+            # Emit a compensating progress event to clear the bundled-failure
+            # error from startup-status. Without this, the final
+            # `plugins-complete` status would still carry the error text from
+            # the bundled failure even though the plugin is now active via the
+            # fallback copy. Uses clear_error=True so the server handler
+            # replaces the stale error with null rather than ignoring it.
+            _emit_progress(
+                "plugin-registered",
+                f"Registered fallback copy of plugin '{evicted_id}'",
+                plugin_id=evicted_id,
+                loaded=len(_loaded_batch),
+                total=len(plugin_load_specs),
+                clear_error=True,
+            )
 
     # Publish all plugins atomically so concurrent readers never observe
     # a partially-populated list during the loading window.  We clear
@@ -953,8 +1015,8 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
 
     _emit_progress(
         "plugins-complete",
-        f"Loaded {len(plugin_load_specs)} plugin(s)",
-        loaded=len(plugin_load_specs),
+        f"Loaded {len(_loaded_batch)} plugin(s)",
+        loaded=len(_loaded_batch),
         total=len(plugin_load_specs),
     )
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1017,10 +1017,18 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         # fail with an import error even when those packages can be installed.
         # Mirror the main load-loop contract: _install_requirements returning
         # False is *non-fatal* (read-only filesystem, optional dep, etc.) —
-        # the main loop emits a plugin-error and continues loading. Treating
-        # it as fatal here would break the fallback for those same tolerated
-        # cases and leave the bundled-failure error unresolved.
-        _install_requirements(ev_dir, evicted_id)
+        # we emit a plugin-error and continue loading, exactly as the main
+        # loop does. Treating it as fatal here would break the fallback for
+        # those same tolerated cases and leave the bundled-failure error
+        # unresolved.
+        ev_req_ok = _install_requirements(ev_dir, evicted_id)
+        if not ev_req_ok:
+            _emit_progress(
+                "plugin-error",
+                f"Failed to install requirements for fallback copy of '{evicted_id}'",
+                plugin_id=evicted_id,
+                error="Requirements installation failed for fallback copy; check server logs",
+            )
         # Purge any sibling modules the failed bundled copy may have loaded.
         # They are cached under the same namespace as what the fallback would use.
         # The parent package is `plugin_{safe_id}`, sibling modules are
@@ -1082,6 +1090,20 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 log.exception(
                     "Fallback user-installed copy of %r also failed to load routes; "
                     "plugin unavailable (not registered).", evicted_id,
+                )
+                # Emit a plugin-error so startup-status reflects the
+                # fallback's failure as the root cause, not the earlier
+                # bundled-copy error. Without this the status stays on the
+                # stale bundled error even though that's no longer the
+                # active failure.
+                _emit_progress(
+                    "plugin-error",
+                    f"Fallback copy of plugin '{evicted_id}' also failed to load routes",
+                    plugin_id=evicted_id,
+                    error=(
+                        f"Both bundled and user-installed copies of '{evicted_id}' "
+                        "failed to load routes; plugin unavailable — check server logs"
+                    ),
                 )
                 # Warn on partial registration in the fallback path too.
                 _fallback_routes_after = len(getattr(app, "routes", []))

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -811,7 +811,6 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             # role; plugin is still loaded and scripts run, it just
             # doesn't show up in role-specific UIs. See slopsmith#36.
             "type": manifest.get("type"),
-            "overrides_bundled": bool(manifest.get("__overrides_bundled")),
             # Uses the same _is_bundled() helper as the duplicate-skip path.
             # See the helper's docstring for the three-part check that prevents
             # user-installed plugins (cloned into plugins/ or carrying a forged
@@ -923,12 +922,6 @@ def register_plugin_api(app: FastAPI):
                 # render a "Bundled" badge (lock icon) next to the
                 # plugin name in the settings collapsible.
                 "bundled": p.get("bundled", False),
-                # True when this user-installed copy is shadowing a
-                # bundled copy of the same id. Surfaced via the API so
-                # the plugin-list UI can render an "Overriding bundled
-                # core plugin" badge — visible signal of the active
-                # override matching the warning in the server log.
-                "overrides_bundled": p.get("overrides_bundled", False),
                 "has_screen": p["has_screen"],
                 "has_script": p["has_script"],
                 "has_settings": p["has_settings"],

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -869,8 +869,15 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 if plugin_id in _pending_evictions:
                     _plugin_dir_prefix = str(plugin_dir) + os.sep
                     _stale = set()
-                    for _k in set(sys.modules) - _sysmod_before_routes:
-                        _mod = sys.modules.get(_k)
+                    # Scan ALL cached modules (not only those newly added since
+                    # the snapshot) for any whose __file__ lives inside this
+                    # plugin's directory.  A previous load_plugins() call (test
+                    # reload, dev restart) may have left same-named helpers from
+                    # the bundled copy in sys.modules before this run's
+                    # snapshot was taken; diffing against the snapshot alone
+                    # would miss those and let the fallback copy resolve the
+                    # old bundled code on repeated loads.
+                    for _k, _mod in list(sys.modules.items()):
                         _mf = getattr(_mod, "__file__", None)
                         if _mf and str(_mf).startswith(_plugin_dir_prefix):
                             _stale.add(_k)
@@ -982,10 +989,17 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             len(_loaded_batch),
         )
         _loaded_batch[:] = [e for e in _loaded_batch if e["id"] != evicted_id]
-        # Ensure the fallback directory is on sys.path.
+        # Ensure the fallback directory is at the FRONT of sys.path so
+        # its modules take priority over any bundled copy still present.
+        # Simply inserting when absent is not enough: on repeated
+        # load_plugins() calls (tests, dev reloads) the user-copy dir may
+        # already be in sys.path but behind the bundled dir from an earlier
+        # run, letting bare imports in the fallback still resolve bundled
+        # files. Always remove-then-reinsert to guarantee front-of-path.
         ev_dir_str = str(ev_dir)
-        if ev_dir_str not in sys.path:
-            sys.path.insert(0, ev_dir_str)
+        if ev_dir_str in sys.path:
+            sys.path.remove(ev_dir_str)
+        sys.path.insert(0, ev_dir_str)
         ev_context = dict(context)
         ev_context["load_sibling"] = (
             lambda name, _pid=evicted_id, _pdir=ev_dir:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -725,6 +725,12 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # Track plugin_ids whose routes.setup() raised an exception, so we
     # can fall back to evicted user copies for those plugin_ids below.
     _route_failed_ids: set[str] = set()
+    # Track plugin_ids whose bundled setup() timed out while already
+    # running (mid-flight). For those, activating the fallback is unsafe
+    # because the original setup() may still be mutating the router
+    # concurrently — fallback routes would mount on top of partial bundled
+    # routes, producing duplicate or conflicting endpoints.
+    _route_mid_flight_ids: set[str] = set()
 
     for idx, (plugin_id, plugin_dir, manifest) in enumerate(plugin_load_specs):
         _emit_progress(
@@ -831,6 +837,12 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             except Exception as e:
                 log.exception("Failed to load routes for plugin %r", plugin_id)
                 _route_failed_ids.add(plugin_id)
+                # If this was a mid-flight timeout, mark the plugin so the
+                # fallback block skips it — the original setup() may still be
+                # running and registering routes concurrently; mounting a
+                # fallback on top would produce duplicate/conflicting endpoints.
+                if getattr(e, "setup_mid_flight", False):
+                    _route_mid_flight_ids.add(plugin_id)
                 # Detect partial route registration: if setup() mounted any
                 # handlers before raising, those routes stay permanently (no
                 # FastAPI deregistration API). Warn loudly so maintainers can
@@ -842,13 +854,30 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                         "these handlers cannot be removed and may conflict with any fallback.",
                         plugin_id, _routes_after - _routes_before,
                     )
-                # Record bare-import modules added during the failed load so
-                # the fallback block can purge them (Thread 1, review-4226783807).
-                # Only store when a fallback user copy is available; no-op otherwise.
+                # Compute bare-import modules added during the failed load.
+                # IMPORTANT: Filter strictly to modules whose __file__ lives
+                # inside this plugin's directory — the naive set-diff would
+                # capture every module imported by any concurrent thread
+                # (metadata scan, stdlib lazy imports, etc.) between the
+                # snapshot and the failure, causing the fallback block to
+                # delete unrelated entries from sys.modules.
+                # Purge them NOW (not deferred) so subsequent plugins in the
+                # main loop don't accidentally resolve this plugin's helpers
+                # when they do bare `import helper`.  The fallback block's
+                # per-key pop() is a harmless no-op when the keys are already
+                # absent.
                 if plugin_id in _pending_evictions:
-                    _pending_eviction_stale_modules[plugin_id] = (
-                        set(sys.modules) - _sysmod_before_routes
-                    )
+                    _plugin_dir_str = str(plugin_dir) + os.sep
+                    _stale = set()
+                    for _k in set(sys.modules) - _sysmod_before_routes:
+                        _mod = sys.modules.get(_k)
+                        _mf = getattr(_mod, "__file__", None)
+                        if _mf and str(_mf).startswith(_plugin_dir_str):
+                            _stale.add(_k)
+                    _pending_eviction_stale_modules[plugin_id] = _stale
+                    # Purge immediately to prevent module leakage into later plugins.
+                    for _k in _stale:
+                        sys.modules.pop(_k, None)
                 _emit_progress(
                     "plugin-error",
                     f"Failed loading routes for '{plugin_id}'",
@@ -914,14 +943,29 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # the primary mitigation is thorough testing of bundled releases.
     #
     # NOTE on timeout race: in async mode the bundled setup() runs on the
-    # event-loop thread via route_setup_fn. If it times out (>60 s), the
-    # load_plugins() thread raises TimeoutError and proceeds to activate the
-    # fallback, but the original setup() may still be running concurrently
-    # and can register additional routes after the fallback is already active.
-    # This race is also accepted as a very-unlikely edge case; prefer async-
-    # safe and idempotent setup() implementations in bundled plugins.
+    # event-loop thread via route_setup_fn. If it times out (>60 s) while
+    # setup() has ALREADY STARTED executing, `_route_mid_flight_ids` is set
+    # for that plugin and the fallback is skipped — the original setup() may
+    # still be mutating the router concurrently and mounting a second set of
+    # routes on top would produce duplicate/conflicting endpoints. The
+    # mid-flight case is detected by the `setup_mid_flight` attribute on the
+    # TimeoutError re-raised by _route_setup_on_main (server.py).
+    # If the timeout fires BEFORE _do() has started, the _cancelled flag
+    # in _route_setup_on_main prevents the queued callback from executing,
+    # making the fallback safe in that case.
     for evicted_id, evicted_spec in _pending_evictions.items():
         if evicted_id not in _route_failed_ids:
+            continue
+        if evicted_id in _route_mid_flight_ids:
+            log.warning(
+                "Skipping fallback for %r: bundled setup() timed out while already "
+                "executing; the router may have partial routes from the bundled copy. "
+                "Restart the server to recover.",
+                evicted_id,
+            )
+            # Remove the broken bundled entry too — its routes are in an
+            # unknown state and it should not appear in /api/plugins.
+            _loaded_batch[:] = [e for e in _loaded_batch if e["id"] != evicted_id]
             continue
         _ev_id, ev_dir, ev_manifest = evicted_spec
         log.warning(
@@ -929,7 +973,14 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             "falling back to user-installed copy at %s.",
             evicted_id, ev_dir,
         )
-        # Remove the broken bundled entry from the batch.
+        # Remove the broken bundled entry from the batch, recording its
+        # original position so the fallback is inserted there instead of
+        # being appended at the end (appending would change the order of
+        # plugins in /api/plugins and the frontend playSong wrapper chain).
+        _bundled_orig_idx = next(
+            (i for i, e in enumerate(_loaded_batch) if e["id"] == evicted_id),
+            len(_loaded_batch),
+        )
         _loaded_batch[:] = [e for e in _loaded_batch if e["id"] != evicted_id]
         # Ensure the fallback directory is on sys.path.
         ev_dir_str = str(ev_dir)
@@ -1014,7 +1065,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     )
                 fallback_routes_ok = False
         if fallback_routes_ok:
-            _loaded_batch.append({
+            _loaded_batch.insert(_bundled_orig_idx, {
                 "id": evicted_id,
                 "name": ev_manifest.get("name", evicted_id),
                 "nav": ev_manifest.get("nav"),

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -668,12 +668,22 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                         "using bundled version at %s.",
                         plugin_id, kept[1] if kept else "(unknown)", plugin_dir,
                     )
-                    plugin_load_specs[:] = [
-                        s for s in plugin_load_specs if s[0] != plugin_id
-                    ]
-                    loaded_ids.discard(plugin_id)
-                    loaded_specs_by_id.pop(plugin_id, None)
-                    # No `continue` — fall through to register the bundled copy.
+                    # Replace the user copy's slot in-place so the bundled
+                    # copy inherits the same discovery position.  Removing and
+                    # re-appending would shift the bundled entry to the end of
+                    # plugin_load_specs, changing /api/plugins order and the
+                    # frontend playSong wrapper chain.
+                    _user_slot = next(
+                        (i for i, s in enumerate(plugin_load_specs) if s[0] == plugin_id),
+                        None,
+                    )
+                    _bundled_spec = (plugin_id, plugin_dir, manifest)
+                    if _user_slot is not None:
+                        plugin_load_specs[_user_slot] = _bundled_spec
+                    else:
+                        plugin_load_specs.append(_bundled_spec)
+                    loaded_specs_by_id[plugin_id] = _bundled_spec
+                    continue  # loaded_ids already contains plugin_id
                 elif this_is_bundled and kept_is_bundled:
                     # Two bundled plugins share an id — shouldn't happen in a
                     # well-maintained tree, but emit a clear warning so it
@@ -802,11 +812,6 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             # setup() registered any handlers before raising. FastAPI has
             # no route-removal API, so partial registration is permanent.
             _routes_before = len(getattr(app, "routes", []))
-            # Snapshot sys.modules to track bare-import modules the plugin
-            # adds during its route load. Stored on failure so the fallback
-            # block can purge them and get a clean import slate (Thread 1,
-            # review-4226783807).
-            _sysmod_before_routes = set(sys.modules)
             try:
                 # Escape `.` in plugin_id the same way load_sibling
                 # does. Without it, a plugin id like
@@ -1049,7 +1054,11 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         # Re-load the fallback's routes using the same module-name slot so
         # it naturally replaces the previously-failed bundled module.
         ev_routes_file = ev_manifest.get("routes")
-        fallback_routes_ok = True
+        # If the user copy has no routes file it cannot restore the bundled
+        # plugin's backend endpoints (the route failure is the very reason we
+        # are in this fallback path). Treat that as a failed recovery so the
+        # bundled-failure error is NOT cleared from startup-status.
+        fallback_routes_ok = bool(ev_routes_file)
         if ev_routes_file:
             # Capture route count before fallback setup() to detect partial
             # registration — same permanent-mount limitation as the main loop.

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -891,7 +891,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 ev_spec.loader.exec_module(ev_routes_module)
                 if hasattr(ev_routes_module, "setup"):
                     if route_setup_fn is not None:
-                        _fn = lambda rm=ev_routes_module, ctx=ev_context: rm.setup(app, ctx)
+                        _fn = lambda rm=ev_routes_module, ctx=ev_context, a=app: rm.setup(a, ctx)
                         _fn._plugin_id = evicted_id
                         route_setup_fn(_fn)
                     else:

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -867,12 +867,12 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 # per-key pop() is a harmless no-op when the keys are already
                 # absent.
                 if plugin_id in _pending_evictions:
-                    _plugin_dir_str = str(plugin_dir) + os.sep
+                    _plugin_dir_prefix = str(plugin_dir) + os.sep
                     _stale = set()
                     for _k in set(sys.modules) - _sysmod_before_routes:
                         _mod = sys.modules.get(_k)
                         _mf = getattr(_mod, "__file__", None)
-                        if _mf and str(_mf).startswith(_plugin_dir_str):
+                        if _mf and str(_mf).startswith(_plugin_dir_prefix):
                             _stale.add(_k)
                     _pending_eviction_stale_modules[plugin_id] = _stale
                     # Purge immediately to prevent module leakage into later plugins.

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -957,12 +957,10 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         _parent_pkg = f"plugin_{_safe_eid}"
         # The routes module is registered under exactly `{_parent_pkg}_routes`
         # (underscore, not dot — it is NOT a sub-package of _parent_pkg).
-        # Using startswith(f"{_parent_pkg}_") would also purge route/sibling
-        # modules for other plugins whose ids share the same prefix — e.g.,
-        # "plugin_a_routes" would be deleted when evicting plugin "a" because
-        # "plugin_a_routes".startswith("plugin_a_") is True, which would also
-        # incorrectly match "plugin_a_5f_b_routes" (routes for plugin "a_b").
-        # Match the routes entry exactly instead.
+        # Using startswith(f"{_parent_pkg}_") would incorrectly match
+        # "plugin_a_5f_b_routes" (routes for plugin "a_b") when evicting
+        # plugin "a", because "plugin_a_5f_b_routes".startswith("plugin_a_")
+        # is True. Match the routes entry exactly instead.
         _stale_sibling_keys = [
             k for k in list(sys.modules)
             if k == _parent_pkg

--- a/plugins/highway_3d/README.md
+++ b/plugins/highway_3d/README.md
@@ -21,7 +21,7 @@ A 3D note highway visualization for [Slopsmith](https://github.com/byrongamatos/
 
 3D Highway ships **bundled** with Slopsmith — no separate installation needed. Pick **3D Highway** from the visualization picker in the player.
 
-If you want to run a customised fork, place your modified copy in a directory pointed to by the `SLOPSMITH_PLUGINS_DIR` environment variable and restart the server — the loader scans that directory first and prefers your copy over the bundled one.
+> **Note:** The bundled version always takes precedence over any user-installed copy with the same plugin ID. If you have an old `slopsmith-plugin-3dhighway` clone on disk (from before 3D Highway was promoted to core), it will be ignored at startup — a warning in the server log names the path of the discarded copy. You can safely delete the stale clone.
 
 ## Settings
 

--- a/plugins/highway_3d/README.md
+++ b/plugins/highway_3d/README.md
@@ -21,7 +21,9 @@ A 3D note highway visualization for [Slopsmith](https://github.com/byrongamatos/
 
 3D Highway ships **bundled** with Slopsmith — no separate installation needed. Pick **3D Highway** from the visualization picker in the player.
 
-> **Note:** The bundled version always takes precedence over any user-installed copy with the same plugin ID. If you have an old `slopsmith-plugin-3dhighway` clone on disk (from before 3D Highway was promoted to core), it will be ignored at startup — a warning in the server log names the path of the discarded copy. You can safely delete the stale clone.
+> **Note:** The bundled version is preferred over any user-installed copy with the same plugin ID. If you have an old `slopsmith-plugin-3dhighway` clone on disk (from before 3D Highway was promoted to core), it will be ignored at startup — a warning in the server log names the path of the discarded copy. You can safely delete the stale clone.
+>
+> **Fallback:** In the unlikely event that the bundled copy fails to load its routes (e.g., a broken bundled release), Slopsmith will automatically fall back to your user-installed copy and show a yellow "Fallback" badge in the Settings panel. Check the server startup log for the root cause in that case.
 
 ## Settings
 

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -158,7 +158,6 @@
 
     const DOTS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24];
     const DDOTS = new Set([12, 24]);
-    const INLAY_LABEL_FRETS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24]; // matches DOTS so labels sit over their physical inlay spheres
 
     const FRET_COOLDOWN = 0.5; // seconds a lane fret stays active after last note
 
@@ -1413,7 +1412,7 @@
         // place — without this the layer stays at its built-in opacity
         // until the next palette change rebuilds buildBoard().
         let stringLineGlows = [];
-        // Fret inlay number label sprites (one per INLAY_LABEL_FRETS entry).
+        // Fret inlay number label sprites (one per DOTS entry).
         // Retained so update() can rescale them live when _textSizeMul changes.
         let _inlayLabels = [];
         // Cloned SpriteMaterials for the inlay labels — disposed on rebuild and
@@ -2860,7 +2859,7 @@
             for (const m of _inlayMats) m.dispose();
             _inlayMats = [];
             _inlayLabels = [];
-            for (const f of INLAY_LABEL_FRETS) {
+            for (const f of DOTS) {
                 const mat = txtMat(f, '#7abfcc', false, 'fretRow').clone();
                 mat.depthWrite = false;
                 mat.opacity = 0.55;

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -1413,6 +1413,9 @@
         // place — without this the layer stays at its built-in opacity
         // until the next palette change rebuilds buildBoard().
         let stringLineGlows = [];
+        // Fret inlay number label sprites (one per INLAY_LABEL_FRETS entry).
+        // Retained so update() can rescale them live when _textSizeMul changes.
+        let _inlayLabels = [];
         // Scratch Color used by _applyVibrancy() to avoid allocating a
         // fresh THREE.Color each time the user drags a slider.
         // Allocated lazily once Three.js is loaded inside initScene().
@@ -2842,15 +2845,20 @@
                 }
             }
 
-            // Fret inlay number labels — static sprites at inlay positions
+            // Fret inlay number labels — sprites at inlay positions.
+            // Scale uses (0.5 + textSize) directly — _textSizeMul is stale
+            // here (only refreshed at the top of update()); update() will
+            // keep scaling in sync from the first frame onward via _inlayLabels.
+            _inlayLabels = [];
             for (const f of INLAY_LABEL_FRETS) {
                 const lbl = new T.Sprite(txtMat(f, '#7abfcc', false, 'fretRow'));
                 lbl.material.opacity = 0.55;
-                const scale = 3.8 * _textSizeMul;
+                const scale = 3.8 * (0.5 + textSize);
                 lbl.scale.set(scale * K, scale * K, 1);
                 lbl.position.set(fretMid(f), my, K);
-                lbl.renderOrder = 100;
+                lbl.renderOrder = -1;
                 fretG.add(lbl);
+                _inlayLabels.push(lbl);
             }
         }
 
@@ -2884,6 +2892,13 @@
             // textSize ∈ [0,1]; _textSizeMul ∈ [0.5, 1.5] with 0.5 ↦ 1.0×
             // so default behaviour matches what the renderer did pre-slider.
             _textSizeMul = 0.5 + textSize;
+            // Rescale inlay labels to track the live text-size slider.
+            // buildBoard() sets an initial scale using (0.5 + textSize) but
+            // _textSizeMul is only authoritative from here onward.
+            for (const lbl of _inlayLabels) {
+                const s = 3.8 * _textSizeMul * K;
+                lbl.scale.set(s, s, 1);
+            }
             pNote.reset(); pSus.reset(); pSusOutline.reset(); pTechArrow.reset(); pTapChevron.reset(); pLbl.reset();
             pBeat.reset(); pSec.reset();
             if (projMeshArr) for (const m of projMeshArr) m.visible = false;

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -158,7 +158,7 @@
 
     const DOTS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24];
     const DDOTS = new Set([12, 24]);
-    const INLAY_LABEL_FRETS = [3, 5, 7, 9, 12, 15, 17, 19, 22, 24];
+    const INLAY_LABEL_FRETS = [3, 5, 7, 9, 12, 15, 17, 19, 22, 24]; // 22 not 21: intentional display choice
 
     const FRET_COOLDOWN = 0.5; // seconds a lane fret stays active after last note
 

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -158,7 +158,7 @@
 
     const DOTS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24];
     const DDOTS = new Set([12, 24]);
-    const INLAY_LABEL_FRETS = [3, 5, 7, 9, 12, 15, 17, 19, 22, 24]; // 22 not 21: intentional display choice
+    const INLAY_LABEL_FRETS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24]; // matches DOTS so labels sit over their physical inlay spheres
 
     const FRET_COOLDOWN = 0.5; // seconds a lane fret stays active after last note
 
@@ -1416,6 +1416,9 @@
         // Fret inlay number label sprites (one per INLAY_LABEL_FRETS entry).
         // Retained so update() can rescale them live when _textSizeMul changes.
         let _inlayLabels = [];
+        // Cloned SpriteMaterials for the inlay labels — disposed on rebuild and
+        // destroy() to prevent GPU leaks across palette changes or panel reuse.
+        let _inlayMats = [];
         // Scratch Color used by _applyVibrancy() to avoid allocating a
         // fresh THREE.Color each time the user drags a slider.
         // Allocated lazily once Three.js is loaded inside initScene().
@@ -2845,20 +2848,29 @@
                 }
             }
 
-            // Fret inlay number labels — sprites at inlay positions.
-            // Scale uses (0.5 + textSize) directly — _textSizeMul is stale
-            // here (only refreshed at the top of update()); update() will
-            // keep scaling in sync from the first frame onward via _inlayLabels.
+            // Fret inlay number labels — sprites sitting just behind the hit line
+            // (Z = -K) so camera-distance sorting in the transparent pass puts
+            // them before notes at Z = 0, letting notes paint on top.
+            // Materials are cloned from the txtMat cache with depthWrite:false so
+            // the sprites don't write stale depth values that would clip incoming
+            // notes (which arrive from large negative Z). Clones are tracked in
+            // _inlayMats for explicit disposal on rebuild and destroy().
+            // Scale uses (0.5 + textSize) directly — _textSizeMul is stale here
+            // (only refreshed at the top of update()); update() rescales live.
+            for (const m of _inlayMats) m.dispose();
+            _inlayMats = [];
             _inlayLabels = [];
             for (const f of INLAY_LABEL_FRETS) {
-                const lbl = new T.Sprite(txtMat(f, '#7abfcc', false, 'fretRow'));
-                lbl.material.opacity = 0.55;
+                const mat = txtMat(f, '#7abfcc', false, 'fretRow').clone();
+                mat.depthWrite = false;
+                mat.opacity = 0.55;
+                const lbl = new T.Sprite(mat);
                 const scale = 3.8 * (0.5 + textSize);
                 lbl.scale.set(scale * K, scale * K, 1);
-                lbl.position.set(fretMid(f), my, K);
-                lbl.renderOrder = -1;
+                lbl.position.set(fretMid(f), my, -K);
                 fretG.add(lbl);
                 _inlayLabels.push(lbl);
+                _inlayMats.push(mat);
             }
         }
 
@@ -4072,6 +4084,7 @@
             scene = cam = noteG = beatG = lblG = fretG = null;
             ambLight = dirLight = null;
             mStr = []; mGlow = []; mSus = []; mProj = []; mProjGlow = []; mWhiteOutline = mSusOutline = null; mHitOutline = mMissOutline = null; stringLines = []; stringLineGlows = [];
+            for (const m of _inlayMats) m?.dispose?.(); _inlayMats = []; _inlayLabels = [];
             // mTechArrow / mTapChevron are owned by pooled meshes attached
             // to noteG; the scene.traverse() dispose pass above already
             // frees them once any pool factory has instantiated a mesh.

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -158,6 +158,7 @@
 
     const DOTS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24];
     const DDOTS = new Set([12, 24]);
+    const INLAY_LABEL_FRETS = [3, 5, 7, 9, 12, 15, 17, 19, 22, 24];
 
     const FRET_COOLDOWN = 0.5; // seconds a lane fret stays active after last note
 
@@ -2839,6 +2840,17 @@
                 } else {
                     const d = new T.Mesh(dg, dm); d.position.set(cx, my, 0); fretG.add(d);
                 }
+            }
+
+            // Fret inlay number labels — static sprites at inlay positions
+            for (const f of INLAY_LABEL_FRETS) {
+                const lbl = new T.Sprite(txtMat(f, '#7abfcc', false, 'fretRow'));
+                lbl.material.opacity = 0.55;
+                const scale = 3.8 * _textSizeMul;
+                lbl.scale.set(scale * K, scale * K, 1);
+                lbl.position.set(fretMid(f), my, K);
+                lbl.renderOrder = 100;
+                fretG.add(lbl);
             }
         }
 

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -158,6 +158,7 @@
 
     const DOTS = [3, 5, 7, 9, 12, 15, 17, 19, 21, 24];
     const DDOTS = new Set([12, 24]);
+    const INLAY_LABEL_FRETS = [3, 5, 7, 9, 12, 15, 17, 19, 22, 24]; // 22 not 21: intentional display choice
 
     const FRET_COOLDOWN = 0.5; // seconds a lane fret stays active after last note
 
@@ -1412,6 +1413,12 @@
         // place — without this the layer stays at its built-in opacity
         // until the next palette change rebuilds buildBoard().
         let stringLineGlows = [];
+        // Fret inlay number label sprites (one per INLAY_LABEL_FRETS entry).
+        // Retained so update() can rescale them live when _textSizeMul changes.
+        let _inlayLabels = [];
+        // Cloned SpriteMaterials for the inlay labels — disposed on rebuild and
+        // destroy() to prevent GPU leaks across palette changes or panel reuse.
+        let _inlayMats = [];
         // Scratch Color used by _applyVibrancy() to avoid allocating a
         // fresh THREE.Color each time the user drags a slider.
         // Allocated lazily once Three.js is loaded inside initScene().
@@ -2840,6 +2847,31 @@
                     const d = new T.Mesh(dg, dm); d.position.set(cx, my, 0); fretG.add(d);
                 }
             }
+
+            // Fret inlay number labels — sprites sitting just behind the hit line
+            // (Z = -K) so camera-distance sorting in the transparent pass puts
+            // them before notes at Z = 0, letting notes paint on top.
+            // Materials are cloned from the txtMat cache with depthWrite:false so
+            // the sprites don't write stale depth values that would clip incoming
+            // notes (which arrive from large negative Z). Clones are tracked in
+            // _inlayMats for explicit disposal on rebuild and destroy().
+            // Scale uses (0.5 + textSize) directly — _textSizeMul is stale here
+            // (only refreshed at the top of update()); update() rescales live.
+            for (const m of _inlayMats) m.dispose();
+            _inlayMats = [];
+            _inlayLabels = [];
+            for (const f of INLAY_LABEL_FRETS) {
+                const mat = txtMat(f, '#7abfcc', false, 'fretRow').clone();
+                mat.depthWrite = false;
+                mat.opacity = 0.55;
+                const lbl = new T.Sprite(mat);
+                const scale = 3.8 * (0.5 + textSize);
+                lbl.scale.set(scale * K, scale * K, 1);
+                lbl.position.set(fretMid(f), my, -K);
+                fretG.add(lbl);
+                _inlayLabels.push(lbl);
+                _inlayMats.push(mat);
+            }
         }
 
         /* ── String glow (called each frame) ────────────────────────────── */
@@ -2872,6 +2904,13 @@
             // textSize ∈ [0,1]; _textSizeMul ∈ [0.5, 1.5] with 0.5 ↦ 1.0×
             // so default behaviour matches what the renderer did pre-slider.
             _textSizeMul = 0.5 + textSize;
+            // Rescale inlay labels to track the live text-size slider.
+            // buildBoard() sets an initial scale using (0.5 + textSize) but
+            // _textSizeMul is only authoritative from here onward.
+            for (const lbl of _inlayLabels) {
+                const s = 3.8 * _textSizeMul * K;
+                lbl.scale.set(s, s, 1);
+            }
             pNote.reset(); pSus.reset(); pSusOutline.reset(); pTechArrow.reset(); pTapChevron.reset(); pLbl.reset();
             pBeat.reset(); pSec.reset();
             if (projMeshArr) for (const m of projMeshArr) m.visible = false;
@@ -4045,6 +4084,7 @@
             scene = cam = noteG = beatG = lblG = fretG = null;
             ambLight = dirLight = null;
             mStr = []; mGlow = []; mSus = []; mProj = []; mProjGlow = []; mWhiteOutline = mSusOutline = null; mHitOutline = mMissOutline = null; stringLines = []; stringLineGlows = [];
+            for (const m of _inlayMats) m?.dispose?.(); _inlayMats = []; _inlayLabels = [];
             // mTechArrow / mTapChevron are owned by pooled meshes attached
             // to noteG; the scene.traverse() dispose pass above already
             // frees them once any pool factory has instantiated a mesh.

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -1412,12 +1412,6 @@
         // place — without this the layer stays at its built-in opacity
         // until the next palette change rebuilds buildBoard().
         let stringLineGlows = [];
-        // Fret inlay number label sprites (one per DOTS entry).
-        // Retained so update() can rescale them live when _textSizeMul changes.
-        let _inlayLabels = [];
-        // Cloned SpriteMaterials for the inlay labels — disposed on rebuild and
-        // destroy() to prevent GPU leaks across palette changes or panel reuse.
-        let _inlayMats = [];
         // Scratch Color used by _applyVibrancy() to avoid allocating a
         // fresh THREE.Color each time the user drags a slider.
         // Allocated lazily once Three.js is loaded inside initScene().
@@ -2846,31 +2840,6 @@
                     const d = new T.Mesh(dg, dm); d.position.set(cx, my, 0); fretG.add(d);
                 }
             }
-
-            // Fret inlay number labels — sprites sitting just behind the hit line
-            // (Z = -K) so camera-distance sorting in the transparent pass puts
-            // them before notes at Z = 0, letting notes paint on top.
-            // Materials are cloned from the txtMat cache with depthWrite:false so
-            // the sprites don't write stale depth values that would clip incoming
-            // notes (which arrive from large negative Z). Clones are tracked in
-            // _inlayMats for explicit disposal on rebuild and destroy().
-            // Scale uses (0.5 + textSize) directly — _textSizeMul is stale here
-            // (only refreshed at the top of update()); update() rescales live.
-            for (const m of _inlayMats) m.dispose();
-            _inlayMats = [];
-            _inlayLabels = [];
-            for (const f of DOTS) {
-                const mat = txtMat(f, '#7abfcc', false, 'fretRow').clone();
-                mat.depthWrite = false;
-                mat.opacity = 0.55;
-                const lbl = new T.Sprite(mat);
-                const scale = 3.8 * (0.5 + textSize);
-                lbl.scale.set(scale * K, scale * K, 1);
-                lbl.position.set(fretMid(f), my, -K);
-                fretG.add(lbl);
-                _inlayLabels.push(lbl);
-                _inlayMats.push(mat);
-            }
         }
 
         /* ── String glow (called each frame) ────────────────────────────── */
@@ -2903,13 +2872,6 @@
             // textSize ∈ [0,1]; _textSizeMul ∈ [0.5, 1.5] with 0.5 ↦ 1.0×
             // so default behaviour matches what the renderer did pre-slider.
             _textSizeMul = 0.5 + textSize;
-            // Rescale inlay labels to track the live text-size slider.
-            // buildBoard() sets an initial scale using (0.5 + textSize) but
-            // _textSizeMul is only authoritative from here onward.
-            for (const lbl of _inlayLabels) {
-                const s = 3.8 * _textSizeMul * K;
-                lbl.scale.set(s, s, 1);
-            }
             pNote.reset(); pSus.reset(); pSusOutline.reset(); pTechArrow.reset(); pTapChevron.reset(); pLbl.reset();
             pBeat.reset(); pSec.reset();
             if (projMeshArr) for (const m of projMeshArr) m.visible = false;
@@ -4083,7 +4045,6 @@
             scene = cam = noteG = beatG = lblG = fretG = null;
             ambLight = dirLight = null;
             mStr = []; mGlow = []; mSus = []; mProj = []; mProjGlow = []; mWhiteOutline = mSusOutline = null; mHitOutline = mMissOutline = null; stringLines = []; stringLineGlows = [];
-            for (const m of _inlayMats) m?.dispose?.(); _inlayMats = []; _inlayLabels = [];
             // mTechArrow / mTapChevron are owned by pooled meshes attached
             // to noteG; the scene.traverse() dispose pass above already
             // frees them once any pool factory has instantiated a mesh.

--- a/server.py
+++ b/server.py
@@ -1067,7 +1067,7 @@ async def startup_events():
             # an error later in startup and the current error source doesn't
             # match the plugin that is now recovering, we leave the error
             # field untouched — the other plugin's failure must not be hidden.
-            _last_error_plugin_id: list = [""]  # mutable box for closure
+            _last_error = {"plugin_id": ""}  # mutable box for closure
 
             def _on_progress(event: dict):
                 total = int(event.get("total") or 0)
@@ -1099,9 +1099,9 @@ async def startup_events():
                 if "error" in event:
                     err_val = event["error"]
                     if err_val is not None:
-                        _last_error_plugin_id[0] = plugin_id
+                        _last_error["plugin_id"] = plugin_id
                         update["error"] = err_val
-                    elif not plugin_id or plugin_id == _last_error_plugin_id[0]:
+                    elif not plugin_id or plugin_id == _last_error["plugin_id"]:
                         # clear_error for the same plugin (or unscoped) — apply.
                         update["error"] = None
                     # else: clear from a different plugin — leave status alone.

--- a/server.py
+++ b/server.py
@@ -1061,6 +1061,14 @@ async def startup_events():
 
     def _load_plugins_background():
         try:
+            # Track which plugin last set a non-null error so that a
+            # `clear_error=True` event from a fallback recovery only clears
+            # the error it actually caused.  If a *different* plugin reported
+            # an error later in startup and the current error source doesn't
+            # match the plugin that is now recovering, we leave the error
+            # field untouched — the other plugin's failure must not be hidden.
+            _last_error_plugin_id: list = [""]  # mutable box for closure
+
             def _on_progress(event: dict):
                 total = int(event.get("total") or 0)
                 loaded = int(event.get("loaded") or 0)
@@ -1081,11 +1089,22 @@ async def startup_events():
                 # - Explicit null (clear_error=True in _emit_progress):
                 #   clear a previously-reported error when, e.g., a bundled
                 #   failure is resolved by a successful user-copy fallback.
+                #   Only applied when the plugin clearing it matches the one
+                #   that last set it — prevents a fallback recovery from
+                #   accidentally hiding an unrelated plugin failure that was
+                #   reported later in startup.
                 # Events that omit the key entirely leave the status unchanged,
                 # preserving any earlier plugin error across the many
                 # non-error progress events that follow normal setup steps.
                 if "error" in event:
-                    update["error"] = event["error"]
+                    err_val = event["error"]
+                    if err_val is not None:
+                        _last_error_plugin_id[0] = plugin_id
+                        update["error"] = err_val
+                    elif not plugin_id or plugin_id == _last_error_plugin_id[0]:
+                        # clear_error for the same plugin (or unscoped) — apply.
+                        update["error"] = None
+                    # else: clear from a different plugin — leave status alone.
                 _set_startup_status(**update)
 
             def _route_setup_on_main(fn):
@@ -1141,7 +1160,14 @@ async def startup_events():
                     fut.result(timeout=60)
                 except concurrent.futures.TimeoutError:
                     _pid = getattr(fn, "_plugin_id", "unknown")
-                    log.warning("route registration for %r timed out after 60 s", _pid)
+                    log.warning(
+                        "route registration for %r timed out after 60 s; "
+                        "if setup() was already executing (mid-flight), any routes "
+                        "it registered before the timeout cannot be removed and may "
+                        "conflict with the user-copy fallback — this is an accepted "
+                        "edge case (Python threads cannot be interrupted mid-execution).",
+                        _pid,
+                    )
                     # Prevent the still-queued _do() from executing if it
                     # hasn't started yet — avoids races with any fallback.
                     _cancelled.set()

--- a/server.py
+++ b/server.py
@@ -1061,13 +1061,20 @@ async def startup_events():
 
     def _load_plugins_background():
         try:
-            # Track which plugin last set a non-null error so that a
-            # `clear_error=True` event from a fallback recovery only clears
-            # the error it actually caused.  If a *different* plugin reported
-            # an error later in startup and the current error source doesn't
-            # match the plugin that is now recovering, we leave the error
-            # field untouched — the other plugin's failure must not be hidden.
-            _last_error = {"plugin_id": ""}  # mutable box for closure
+            # Track all active plugin errors so that a `clear_error=True`
+            # event from a fallback recovery correctly restores any *other*
+            # plugin's still-unresolved failure rather than wiping the error
+            # field entirely.
+            #
+            # Using a single "last error" pointer was insufficient: if plugin A
+            # fails, then plugin B fails and later recovers, the recovery would
+            # overwrite the pointer with B's id — and then B's `error=None`
+            # clears the status to null even though A is still broken.
+            #
+            # With a dict (keyed by plugin_id, insertion-ordered) we can
+            # remove B's entry on recovery and restore the most recent remaining
+            # failure from A, giving an accurate picture of startup health.
+            _active_errors: dict[str, str] = {}  # plugin_id -> error text
 
             def _on_progress(event: dict):
                 total = int(event.get("total") or 0)
@@ -1085,26 +1092,28 @@ async def startup_events():
                 )
                 # Forward the error field only when the event explicitly
                 # carries it.  Two cases:
-                # - Non-null string: set/update the displayed error.
+                # - Non-null string: record this plugin's failure and display it.
                 # - Explicit null (clear_error=True in _emit_progress):
-                #   clear a previously-reported error when, e.g., a bundled
-                #   failure is resolved by a successful user-copy fallback.
-                #   Only applied when the plugin clearing it matches the one
-                #   that last set it — prevents a fallback recovery from
-                #   accidentally hiding an unrelated plugin failure that was
-                #   reported later in startup.
+                #   remove this plugin's failure entry, then restore the most
+                #   recently recorded still-active failure (if any) so
+                #   unresolved failures from other plugins remain visible.
+                #   An unscoped clear (no plugin_id) removes the unscoped
+                #   sentinel and applies the same restore logic.
                 # Events that omit the key entirely leave the status unchanged,
                 # preserving any earlier plugin error across the many
                 # non-error progress events that follow normal setup steps.
                 if "error" in event:
                     err_val = event["error"]
                     if err_val is not None:
-                        _last_error["plugin_id"] = plugin_id
+                        _active_errors[plugin_id] = err_val
                         update["error"] = err_val
-                    elif not plugin_id or plugin_id == _last_error["plugin_id"]:
-                        # clear_error for the same plugin (or unscoped) — apply.
-                        update["error"] = None
-                    # else: clear from a different plugin — leave status alone.
+                    else:
+                        # Clear this plugin's error entry (fallback recovery or
+                        # unscoped clear), then surface the most recently added
+                        # remaining failure, or None if all have been resolved.
+                        _active_errors.pop(plugin_id, None)
+                        remaining = list(_active_errors.values())
+                        update["error"] = remaining[-1] if remaining else None
                 _set_startup_status(**update)
 
             def _route_setup_on_main(fn):
@@ -1132,43 +1141,37 @@ async def startup_events():
                     return
 
                 fut: concurrent.futures.Future = concurrent.futures.Future()
-                # Cancellation flag: set on timeout so the still-queued
-                # _do() callback skips fn() rather than racing with any
-                # fallback copy that load_plugins() activates after the
-                # TimeoutError. If _do() has already started executing when
-                # this flag is set, the check is a no-op — Python threads
-                # cannot be interrupted mid-execution without cooperative
-                # checks at every call site, so partial route registration
-                # inside an already-running fn() remains an accepted edge case.
+                # _state_lock makes the "check _cancelled + set _started"
+                # transition in _do() atomic with the "read _started + set
+                # _cancelled" transition in the timeout handler.  Without this
+                # lock the two threads can interleave:
+                #
+                #   Thread A (_do):   passes check-1, yields to event loop
+                #   Thread B (timeout): reads _started=False → _mid_flight=False
+                #   Thread A (_do):   sets _started, passes check-2 → calls fn()
+                #   Thread B (timeout): sets _cancelled (too late)
+                #   Result: fn() runs AND fallback loads — concurrent mutation.
+                #
+                # With the lock, either _do() commits to running fn() before
+                # the timeout can set _cancelled (in which case _mid_flight=True
+                # and the fallback is skipped), or the timeout wins (sets
+                # _cancelled=True and reads _started=False → _mid_flight=False,
+                # then _do() sees _cancelled inside the lock and bails out).
+                _state_lock = threading.Lock()
                 _cancelled = threading.Event()
-                # Tracks whether _do() has passed the cancellation guard and
-                # started calling fn(). Used on timeout to decide whether a
-                # fallback is safe: if _started is not set, _cancelled will
-                # prevent fn() from running (safe to fallback); if _started
-                # is set, fn() is mid-flight and activating a fallback would
-                # race with it (fallback skipped — caller checks
-                # `e.setup_mid_flight` on the re-raised TimeoutError).
                 _started = threading.Event()
 
                 def _do():
-                    if _cancelled.is_set():
-                        # Timeout already fired; skip to prevent a race
-                        # with the user-copy fallback that may have loaded.
-                        if not fut.done():
-                            fut.set_result(None)
-                        return
-                    _started.set()
-                    # Double-check cancellation: if the timeout fired in the
-                    # window between the first check and _started.set(), the
-                    # timeout handler may have seen _started as not-yet-set
-                    # and allowed a fallback to proceed. Re-checking here
-                    # prevents fn() from racing with that fallback.
-                    # The timeout handler will see _started.is_set() == True
-                    # and log mid-flight=True, but since fn() won't run, the
-                    # fallback is in fact safe — the conservative warning is
-                    # acceptable and avoids the actual race.
-                    if _cancelled.is_set():
-                        return
+                    with _state_lock:
+                        if _cancelled.is_set():
+                            # Timeout already fired before we started; bail
+                            # to prevent a race with any fallback that may
+                            # have been activated by load_plugins().
+                            if not fut.done():
+                                fut.set_result(None)
+                            return
+                        _started.set()
+                    # Past the lock — committed to running fn().
                     try:
                         fn()
                         fut.set_result(None)
@@ -1180,7 +1183,12 @@ async def startup_events():
                     fut.result(timeout=60)
                 except concurrent.futures.TimeoutError as _te:
                     _pid = getattr(fn, "_plugin_id", "unknown")
-                    _mid_flight = _started.is_set()
+                    # Read _started and set _cancelled atomically so _do()
+                    # can't slip through the lock and start fn() between the
+                    # two operations.
+                    with _state_lock:
+                        _mid_flight = _started.is_set()
+                        _cancelled.set()
                     if _mid_flight:
                         log.warning(
                             "route registration for %r timed out after 60 s and "
@@ -1204,7 +1212,7 @@ async def startup_events():
                         )
                     # Prevent the still-queued _do() from executing if it
                     # hasn't started yet — avoids races with any fallback.
-                    _cancelled.set()
+                    # Note: _cancelled was already set inside _state_lock above.
 
                     def _log_deferred(f: concurrent.futures.Future):
                         try:

--- a/server.py
+++ b/server.py
@@ -1158,6 +1158,17 @@ async def startup_events():
                             fut.set_result(None)
                         return
                     _started.set()
+                    # Double-check cancellation: if the timeout fired in the
+                    # window between the first check and _started.set(), the
+                    # timeout handler may have seen _started as not-yet-set
+                    # and allowed a fallback to proceed. Re-checking here
+                    # prevents fn() from racing with that fallback.
+                    # The timeout handler will see _started.is_set() == True
+                    # and log mid-flight=True, but since fn() won't run, the
+                    # fallback is in fact safe — the conservative warning is
+                    # acceptable and avoids the actual race.
+                    if _cancelled.is_set():
+                        return
                     try:
                         fn()
                         fut.set_result(None)

--- a/server.py
+++ b/server.py
@@ -1075,13 +1075,16 @@ async def startup_events():
                     loaded=loaded,
                     total=total,
                 )
-                # Only forward the error field when the event carries a real
-                # (non-null) error string.  This preserves any previously
-                # reported plugin error across the many subsequent non-error
-                # progress events that follow — without this guard the final
-                # `complete` status would almost always show `error: null`
-                # even when a plugin failed requirements or route setup.
-                if event.get("error") is not None:
+                # Forward the error field only when the event explicitly
+                # carries it.  Two cases:
+                # - Non-null string: set/update the displayed error.
+                # - Explicit null (clear_error=True in _emit_progress):
+                #   clear a previously-reported error when, e.g., a bundled
+                #   failure is resolved by a successful user-copy fallback.
+                # Events that omit the key entirely leave the status unchanged,
+                # preserving any earlier plugin error across the many
+                # non-error progress events that follow normal setup steps.
+                if "error" in event:
                     update["error"] = event["error"]
                 _set_startup_status(**update)
 

--- a/server.py
+++ b/server.py
@@ -1105,6 +1105,14 @@ async def startup_events():
                 if "error" in event:
                     err_val = event["error"]
                     if err_val is not None:
+                        # Pop then re-insert so the key moves to the end of
+                        # insertion order even when this plugin already has an
+                        # entry.  A plugin can emit more than one error during a
+                        # single load (requirements + routes), and dict.update()
+                        # on an existing key does NOT move it to the end, so
+                        # remaining[-1] could return a stale earlier message
+                        # after another plugin clears its own error.
+                        _active_errors.pop(plugin_id, None)
                         _active_errors[plugin_id] = err_val
                         update["error"] = err_val
                     else:

--- a/server.py
+++ b/server.py
@@ -1116,8 +1116,11 @@ async def startup_events():
                 # Cancellation flag: set on timeout so the still-queued
                 # _do() callback skips fn() rather than racing with any
                 # fallback copy that load_plugins() activates after the
-                # TimeoutError. If _do() has already started executing,
-                # this won't interrupt it mid-setup (inherent limitation).
+                # TimeoutError. If _do() has already started executing when
+                # this flag is set, the check is a no-op — Python threads
+                # cannot be interrupted mid-execution without cooperative
+                # checks at every call site, so partial route registration
+                # inside an already-running fn() remains an accepted edge case.
                 _cancelled = threading.Event()
 
                 def _do():

--- a/server.py
+++ b/server.py
@@ -1113,8 +1113,20 @@ async def startup_events():
                     return
 
                 fut: concurrent.futures.Future = concurrent.futures.Future()
+                # Cancellation flag: set on timeout so the still-queued
+                # _do() callback skips fn() rather than racing with any
+                # fallback copy that load_plugins() activates after the
+                # TimeoutError. If _do() has already started executing,
+                # this won't interrupt it mid-setup (inherent limitation).
+                _cancelled = threading.Event()
 
                 def _do():
+                    if _cancelled.is_set():
+                        # Timeout already fired; skip to prevent a race
+                        # with the user-copy fallback that may have loaded.
+                        if not fut.done():
+                            fut.set_result(None)
+                        return
                     try:
                         fn()
                         fut.set_result(None)
@@ -1127,6 +1139,9 @@ async def startup_events():
                 except concurrent.futures.TimeoutError:
                     _pid = getattr(fn, "_plugin_id", "unknown")
                     log.warning("route registration for %r timed out after 60 s", _pid)
+                    # Prevent the still-queued _do() from executing if it
+                    # hasn't started yet — avoids races with any fallback.
+                    _cancelled.set()
 
                     def _log_deferred(f: concurrent.futures.Future):
                         try:

--- a/server.py
+++ b/server.py
@@ -1141,6 +1141,14 @@ async def startup_events():
                 # checks at every call site, so partial route registration
                 # inside an already-running fn() remains an accepted edge case.
                 _cancelled = threading.Event()
+                # Tracks whether _do() has passed the cancellation guard and
+                # started calling fn(). Used on timeout to decide whether a
+                # fallback is safe: if _started is not set, _cancelled will
+                # prevent fn() from running (safe to fallback); if _started
+                # is set, fn() is mid-flight and activating a fallback would
+                # race with it (fallback skipped — caller checks
+                # `e.setup_mid_flight` on the re-raised TimeoutError).
+                _started = threading.Event()
 
                 def _do():
                     if _cancelled.is_set():
@@ -1149,6 +1157,7 @@ async def startup_events():
                         if not fut.done():
                             fut.set_result(None)
                         return
+                    _started.set()
                     try:
                         fn()
                         fut.set_result(None)
@@ -1158,16 +1167,30 @@ async def startup_events():
                 loop.call_soon_threadsafe(_do)
                 try:
                     fut.result(timeout=60)
-                except concurrent.futures.TimeoutError:
+                except concurrent.futures.TimeoutError as _te:
                     _pid = getattr(fn, "_plugin_id", "unknown")
-                    log.warning(
-                        "route registration for %r timed out after 60 s; "
-                        "if setup() was already executing (mid-flight), any routes "
-                        "it registered before the timeout cannot be removed and may "
-                        "conflict with the user-copy fallback — this is an accepted "
-                        "edge case (Python threads cannot be interrupted mid-execution).",
-                        _pid,
-                    )
+                    _mid_flight = _started.is_set()
+                    if _mid_flight:
+                        log.warning(
+                            "route registration for %r timed out after 60 s and "
+                            "setup() was already mid-flight; any routes registered "
+                            "before the timeout cannot be removed. The user-copy "
+                            "fallback will NOT be activated to prevent concurrent "
+                            "router mutation (Python threads cannot be interrupted "
+                            "mid-execution). Restart the server to recover.",
+                            _pid,
+                        )
+                        # Signal to load_plugins() that fallback is unsafe
+                        # for this plugin — the original setup() is still
+                        # running and may add more routes concurrently.
+                        _te.setup_mid_flight = True
+                    else:
+                        log.warning(
+                            "route registration for %r timed out after 60 s; "
+                            "setup() had not started yet, so it has been cancelled "
+                            "and the user-copy fallback (if any) can proceed safely.",
+                            _pid,
+                        )
                     # Prevent the still-queued _do() from executing if it
                     # hasn't started yet — avoids races with any fallback.
                     _cancelled.set()

--- a/static/app.js
+++ b/static/app.js
@@ -3989,6 +3989,26 @@ async function loadPlugins() {
                     `;
                     labelWrap.appendChild(badge);
                 }
+                // "Fallback" warning badge: the bundled copy failed to load its
+                // routes, so the server fell back to this older user-installed
+                // copy.  Warn users so they know the bundled build is broken and
+                // can check the server startup log for the root cause.
+                if (plugin.fallback) {
+                    const fallbackDesc = 'The bundled copy of this plugin failed to start. This is a fallback from your user-installed copy. Check the server startup log for details.';
+                    const fbBadge = document.createElement('span');
+                    fbBadge.className = 'inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-yellow-400/40 bg-yellow-500/10 text-yellow-300';
+                    fbBadge.title = fallbackDesc;
+                    fbBadge.setAttribute('aria-label', 'Fallback — ' + fallbackDesc);
+                    fbBadge.setAttribute('role', 'img');
+                    fbBadge.innerHTML = `
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                  d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                        </svg>
+                        Fallback
+                    `;
+                    labelWrap.appendChild(fbBadge);
+                }
                 summary.appendChild(labelWrap);
                 // Chevron icon — built via setAttributeNS so the SVG sits in
                 // the SVG namespace and renders correctly. Plugin label is

--- a/static/app.js
+++ b/static/app.js
@@ -3988,28 +3988,6 @@ async function loadPlugins() {
                         Bundled
                     `;
                     labelWrap.appendChild(badge);
-                } else if (plugin.overrides_bundled) {
-                    // User-installed copy is shadowing a bundled core
-                    // version of this plugin (slopsmith#160). Surface
-                    // the override so users understand why a "bundled"
-                    // marker isn't visible — and so they can decide
-                    // whether to remove the user copy and let the
-                    // bundled version take over. Mirrors the warning
-                    // line the plugin loader writes at startup.
-                    const overrideDesc = 'A user-installed copy of this plugin is shadowing the bundled core version. Check the server startup log for the exact path, remove the user copy and restart to use the bundled build instead.';
-                    const badge = document.createElement('span');
-                    badge.className = 'inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-amber-400/30 bg-amber-500/10 text-amber-300';
-                    badge.title = overrideDesc;
-                    badge.setAttribute('aria-label', 'Overrides bundled — ' + overrideDesc);
-                    badge.setAttribute('role', 'img');
-                    badge.innerHTML = `
-                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                  d="M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z"/>
-                        </svg>
-                        Overrides bundled
-                    `;
-                    labelWrap.appendChild(badge);
                 }
                 summary.appendChild(labelWrap);
                 // Chevron icon — built via setAttributeNS so the SVG sits in
@@ -4058,33 +4036,6 @@ async function loadPlugins() {
                     newScript.textContent = oldScript.textContent;
                     oldScript.parentNode.replaceChild(newScript, oldScript);
                 });
-                // Overrides-bundled notice — injected after settings HTML so
-                // it isn't wiped by innerHTML. Rendered as visible text so
-                // all users (including touch and keyboard-only) see the
-                // explanation without needing a hover tooltip.
-                if (plugin.overrides_bundled) {
-                    const notice = document.createElement('div');
-                    notice.className = 'flex items-start gap-2 rounded p-3 text-xs bg-amber-500/10 border border-amber-400/30 text-amber-300';
-                    notice.setAttribute('role', 'status');
-                    const noticeSvgNS = 'http://www.w3.org/2000/svg';
-                    const noticeSvg = document.createElementNS(noticeSvgNS, 'svg');
-                    noticeSvg.setAttribute('class', 'w-4 h-4 shrink-0 mt-0.5');
-                    noticeSvg.setAttribute('fill', 'none');
-                    noticeSvg.setAttribute('stroke', 'currentColor');
-                    noticeSvg.setAttribute('viewBox', '0 0 24 24');
-                    noticeSvg.setAttribute('aria-hidden', 'true');
-                    const noticePath = document.createElementNS(noticeSvgNS, 'path');
-                    noticePath.setAttribute('stroke-linecap', 'round');
-                    noticePath.setAttribute('stroke-linejoin', 'round');
-                    noticePath.setAttribute('stroke-width', '2');
-                    noticePath.setAttribute('d', 'M12 9v2m0 4h.01M5.07 19h13.86c1.54 0 2.5-1.67 1.73-3L13.73 4c-.77-1.33-2.69-1.33-3.46 0L3.34 16c-.77 1.33.19 3 1.73 3z');
-                    noticeSvg.appendChild(noticePath);
-                    const noticeText = document.createElement('span');
-                    noticeText.textContent = 'A user-installed copy of this plugin is shadowing the bundled core version. Check the server startup log for the exact path; remove the user copy and restart to use the bundled build instead.';
-                    notice.appendChild(noticeSvg);
-                    notice.appendChild(noticeText);
-                    body.insertBefore(notice, body.firstChild);
-                }
             }
 
             // Load plugin JS

--- a/static/app.js
+++ b/static/app.js
@@ -3962,7 +3962,12 @@ async function loadPlugins() {
                 const summary = document.createElement('summary');
                 // .plugin-settings-summary class hides the browser's native
                 // disclosure triangle (see style.css) so only our chevron shows.
-                summary.className = 'plugin-settings-summary cursor-pointer select-none px-4 py-3 text-sm font-medium text-gray-300 hover:bg-dark-700/70 transition flex items-center justify-between';
+                // flex-col allows the fallback explanation note to appear below
+                // the name/badges row when plugin.fallback is set.
+                summary.className = 'plugin-settings-summary cursor-pointer select-none px-4 py-3 text-sm font-medium text-gray-300 hover:bg-dark-700/70 transition flex flex-col';
+                // Inner row: plugin name/badges (left) + chevron (right).
+                const headerRow = document.createElement('span');
+                headerRow.className = 'flex items-center justify-between';
                 const labelWrap = document.createElement('span');
                 labelWrap.className = 'flex items-center gap-2';
                 const labelSpan = document.createElement('span');
@@ -3997,24 +4002,14 @@ async function loadPlugins() {
                     const fbBadge = document.createElement('span');
                     fbBadge.className = 'inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-yellow-400/40 bg-yellow-500/10 text-yellow-300';
                     fbBadge.setAttribute('aria-hidden', 'true');
-                    fbBadge.innerHTML = `
-                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                  d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
-                        </svg>
-                        Fallback
-                    `;
+                    fbBadge.innerHTML = '<svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/></svg> Fallback';
                     labelWrap.appendChild(fbBadge);
-                    // Visible explanation below the badge — accessible to all
-                    // users including those on touch devices or using keyboards
-                    // (browser tooltips are hover-only, so title/aria-label alone
-                    // is not sufficient).
-                    const fbNote = document.createElement('p');
-                    fbNote.className = 'text-xs text-yellow-300/80 mt-0.5';
-                    fbNote.textContent = 'The bundled version failed to start. This user-installed copy is serving as a fallback. Check the server startup log for details.';
-                    labelWrap.appendChild(fbNote);
                 }
-                summary.appendChild(labelWrap);
+                // Assemble inner header row: [name/badges (left)] [chevron (right)].
+                // Both are placed in headerRow so the fallback note (if any)
+                // can sit below the entire row as a second flex-col child of
+                // summary, rather than being squeezed inline beside the chevron.
+                headerRow.appendChild(labelWrap);
                 // Chevron icon — built via setAttributeNS so the SVG sits in
                 // the SVG namespace and renders correctly. Plugin label is
                 // appended as text above so manifest values can't inject HTML.
@@ -4024,13 +4019,25 @@ async function loadPlugins() {
                 svg.setAttribute('fill', 'none');
                 svg.setAttribute('stroke', 'currentColor');
                 svg.setAttribute('viewBox', '0 0 24 24');
-                const path = document.createElementNS(svgNS, 'path');
-                path.setAttribute('stroke-linecap', 'round');
-                path.setAttribute('stroke-linejoin', 'round');
-                path.setAttribute('stroke-width', '2');
-                path.setAttribute('d', 'M19 9l-7 7-7-7');
-                svg.appendChild(path);
-                summary.appendChild(svg);
+                const svgPath = document.createElementNS(svgNS, 'path');
+                svgPath.setAttribute('stroke-linecap', 'round');
+                svgPath.setAttribute('stroke-linejoin', 'round');
+                svgPath.setAttribute('stroke-width', '2');
+                svgPath.setAttribute('d', 'M19 9l-7 7-7-7');
+                svg.appendChild(svgPath);
+                headerRow.appendChild(svg);
+                summary.appendChild(headerRow);
+                // Fallback explanation note: a visible <p> below the header row,
+                // accessible to touch/keyboard users (browser tooltip via title/
+                // aria-label alone is hover-only and insufficient). Appended to
+                // summary (not labelWrap) so it renders as the second child in
+                // summary's flex-col layout, appearing below the name+badges row.
+                if (plugin.fallback) {
+                    const fbNote = document.createElement('p');
+                    fbNote.className = 'text-xs text-yellow-300/80 mt-1';
+                    fbNote.textContent = 'The bundled version failed to start. This user-installed copy is serving as a fallback. Check the server startup log for details.';
+                    summary.appendChild(fbNote);
+                }
                 details.appendChild(summary);
 
                 const body = document.createElement('div');

--- a/static/app.js
+++ b/static/app.js
@@ -4036,34 +4036,7 @@ async function loadPlugins() {
                     newScript.textContent = oldScript.textContent;
                     oldScript.parentNode.replaceChild(newScript, oldScript);
                 });
-                // Bundled-plugin notice — injected after settings HTML so
-                // it isn't wiped by innerHTML. Bundled plugins always win
-                // over any user-installed copy with the same id; if your
-                // modifications to this plugin are not taking effect, check
-                // the server startup log for a warning naming the ignored copy.
-                if (plugin.bundled) {
-                    const notice = document.createElement('div');
-                    notice.className = 'flex items-start gap-2 rounded p-3 text-xs bg-purple-500/10 border border-purple-400/30 text-purple-300 mt-4';
-                    notice.setAttribute('role', 'note');
-                    const noticeSvgNS = 'http://www.w3.org/2000/svg';
-                    const noticeSvg = document.createElementNS(noticeSvgNS, 'svg');
-                    noticeSvg.setAttribute('class', 'w-4 h-4 shrink-0 mt-0.5');
-                    noticeSvg.setAttribute('fill', 'none');
-                    noticeSvg.setAttribute('stroke', 'currentColor');
-                    noticeSvg.setAttribute('viewBox', '0 0 24 24');
-                    noticeSvg.setAttribute('aria-hidden', 'true');
-                    const noticePath = document.createElementNS(noticeSvgNS, 'path');
-                    noticePath.setAttribute('stroke-linecap', 'round');
-                    noticePath.setAttribute('stroke-linejoin', 'round');
-                    noticePath.setAttribute('stroke-width', '2');
-                    noticePath.setAttribute('d', 'M12 11c1.657 0 3-1.343 3-3V6a3 3 0 10-6 0v2c0 1.657 1.343 3 3 3zM6 11h12a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2v-6a2 2 0 012-2z');
-                    noticeSvg.appendChild(noticePath);
-                    const noticeText = document.createElement('span');
-                    noticeText.textContent = 'This plugin is bundled with Slopsmith. Any user-installed copy with the same plugin ID is automatically overridden by this bundled version. Check the server startup log if your modifications are not taking effect.';
-                    notice.appendChild(noticeSvg);
-                    notice.appendChild(noticeText);
-                    body.appendChild(notice);
-                }
+
             }
 
             // Load plugin JS

--- a/static/app.js
+++ b/static/app.js
@@ -4036,6 +4036,34 @@ async function loadPlugins() {
                     newScript.textContent = oldScript.textContent;
                     oldScript.parentNode.replaceChild(newScript, oldScript);
                 });
+                // Bundled-plugin notice — injected after settings HTML so
+                // it isn't wiped by innerHTML. Bundled plugins always win
+                // over any user-installed copy with the same id; if your
+                // modifications to this plugin are not taking effect, check
+                // the server startup log for a warning naming the ignored copy.
+                if (plugin.bundled) {
+                    const notice = document.createElement('div');
+                    notice.className = 'flex items-start gap-2 rounded p-3 text-xs bg-purple-500/10 border border-purple-400/30 text-purple-300 mt-4';
+                    notice.setAttribute('role', 'note');
+                    const noticeSvgNS = 'http://www.w3.org/2000/svg';
+                    const noticeSvg = document.createElementNS(noticeSvgNS, 'svg');
+                    noticeSvg.setAttribute('class', 'w-4 h-4 shrink-0 mt-0.5');
+                    noticeSvg.setAttribute('fill', 'none');
+                    noticeSvg.setAttribute('stroke', 'currentColor');
+                    noticeSvg.setAttribute('viewBox', '0 0 24 24');
+                    noticeSvg.setAttribute('aria-hidden', 'true');
+                    const noticePath = document.createElementNS(noticeSvgNS, 'path');
+                    noticePath.setAttribute('stroke-linecap', 'round');
+                    noticePath.setAttribute('stroke-linejoin', 'round');
+                    noticePath.setAttribute('stroke-width', '2');
+                    noticePath.setAttribute('d', 'M12 11c1.657 0 3-1.343 3-3V6a3 3 0 10-6 0v2c0 1.657 1.343 3 3 3zM6 11h12a2 2 0 012 2v6a2 2 0 01-2 2H6a2 2 0 01-2-2v-6a2 2 0 012-2z');
+                    noticeSvg.appendChild(noticePath);
+                    const noticeText = document.createElement('span');
+                    noticeText.textContent = 'This plugin is bundled with Slopsmith. Any user-installed copy with the same plugin ID is automatically overridden by this bundled version. Check the server startup log if your modifications are not taking effect.';
+                    notice.appendChild(noticeSvg);
+                    notice.appendChild(noticeText);
+                    body.appendChild(notice);
+                }
             }
 
             // Load plugin JS

--- a/static/app.js
+++ b/static/app.js
@@ -3994,7 +3994,7 @@ async function loadPlugins() {
                 // copy.  Warn users so they know the bundled build is broken and
                 // can check the server startup log for the root cause.
                 if (plugin.fallback) {
-                    const fallbackDesc = 'The bundled copy of this plugin failed to start. This is a fallback from your user-installed copy. Check the server startup log for details.';
+                    const fallbackDesc = 'This user-installed copy is serving as a fallback because the bundled version failed to start. Check the server startup log for details.';
                     const fbBadge = document.createElement('span');
                     fbBadge.className = 'inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-yellow-400/40 bg-yellow-500/10 text-yellow-300';
                     fbBadge.title = fallbackDesc;

--- a/static/app.js
+++ b/static/app.js
@@ -3994,12 +3994,9 @@ async function loadPlugins() {
                 // copy.  Warn users so they know the bundled build is broken and
                 // can check the server startup log for the root cause.
                 if (plugin.fallback) {
-                    const fallbackDesc = 'This user-installed copy is serving as a fallback because the bundled version failed to start. Check the server startup log for details.';
                     const fbBadge = document.createElement('span');
                     fbBadge.className = 'inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded border border-yellow-400/40 bg-yellow-500/10 text-yellow-300';
-                    fbBadge.title = fallbackDesc;
-                    fbBadge.setAttribute('aria-label', 'Fallback — ' + fallbackDesc);
-                    fbBadge.setAttribute('role', 'img');
+                    fbBadge.setAttribute('aria-hidden', 'true');
                     fbBadge.innerHTML = `
                         <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -4008,6 +4005,14 @@ async function loadPlugins() {
                         Fallback
                     `;
                     labelWrap.appendChild(fbBadge);
+                    // Visible explanation below the badge — accessible to all
+                    // users including those on touch devices or using keyboards
+                    // (browser tooltips are hover-only, so title/aria-label alone
+                    // is not sufficient).
+                    const fbNote = document.createElement('p');
+                    fbNote.className = 'text-xs text-yellow-300/80 mt-0.5';
+                    fbNote.textContent = 'The bundled version failed to start. This older user-installed copy is serving as a fallback. Check the server startup log for details.';
+                    labelWrap.appendChild(fbNote);
                 }
                 summary.appendChild(labelWrap);
                 // Chevron icon — built via setAttributeNS so the SVG sits in

--- a/static/app.js
+++ b/static/app.js
@@ -4011,7 +4011,7 @@ async function loadPlugins() {
                     // is not sufficient).
                     const fbNote = document.createElement('p');
                     fbNote.className = 'text-xs text-yellow-300/80 mt-0.5';
-                    fbNote.textContent = 'The bundled version failed to start. This older user-installed copy is serving as a fallback. Check the server startup log for details.';
+                    fbNote.textContent = 'The bundled version failed to start. This user-installed copy is serving as a fallback. Check the server startup log for details.';
                     labelWrap.appendChild(fbNote);
                 }
                 summary.appendChild(labelWrap);

--- a/static/app.js
+++ b/static/app.js
@@ -4033,8 +4033,8 @@ async function loadPlugins() {
                 // summary (not labelWrap) so it renders as the second child in
                 // summary's flex-col layout, appearing below the name+badges row.
                 if (plugin.fallback) {
-                    const fbNote = document.createElement('p');
-                    fbNote.className = 'text-xs text-yellow-300/80 mt-1';
+                    const fbNote = document.createElement('span');
+                    fbNote.className = 'block text-xs text-yellow-300/80 mt-1';
                     fbNote.textContent = 'The bundled version failed to start. This user-installed copy is serving as a fallback. Check the server startup log for details.';
                     summary.appendChild(fbNote);
                 }

--- a/tests/test_diagnostics_bundle.py
+++ b/tests/test_diagnostics_bundle.py
@@ -563,6 +563,9 @@ def test_system_plugins_evicted_stale_copy_appears_in_orphans(tmp_path):
     assert len(evicted) == 1
     assert evicted[0]["dir"] == "3dhighway"
     assert evicted[0].get("evicted") is True
+    # The `path` field must contain the full resolved path so maintainers can
+    # tell which root the evicted copy came from even when dir names match.
+    assert evicted[0].get("path") == str(stale_dir.resolve())
     # The canonical loaded copy must NOT appear in orphans.
     loaded_ids = {p["id"] for p in result["plugins"]}
     assert "highway_3d" in loaded_ids

--- a/tests/test_diagnostics_bundle.py
+++ b/tests/test_diagnostics_bundle.py
@@ -571,6 +571,62 @@ def test_system_plugins_evicted_stale_copy_appears_in_orphans(tmp_path):
     assert "highway_3d" in loaded_ids
 
 
+def test_system_plugins_orphan_path_redacted_when_redactor_provided(tmp_path):
+    """Orphan `path` must pass through the redactor when one is provided.
+
+    The full resolved path of an evicted copy (e.g.
+    ``/home/user/.config/slopsmith/plugins/highway_3d``) contains the user's
+    home directory.  Without redaction that leaks in a supposedly-sanitised
+    bundle.  When a Redactor is passed to _system_plugins, home-dir prefixes
+    in `path` must be replaced with the ``<HOME>`` placeholder.
+    """
+    from diagnostics_redact import Redactor
+
+    home = tmp_path / "home" / "user"
+    home.mkdir(parents=True)
+    plugins_dir = home / "plugins"
+    plugins_dir.mkdir()
+
+    stale_dir = plugins_dir / "highway_3d"
+    stale_dir.mkdir()
+    (stale_dir / "plugin.json").write_text('{"id":"highway_3d","name":"3D Highway (user)"}')
+
+    # Simulate that the canonical copy was loaded from somewhere else.
+    other_dir = tmp_path / "bundled" / "highway_3d"
+    other_dir.mkdir(parents=True)
+    loaded_plugins = [{"id": "highway_3d", "name": "3D Highway", "_dir": other_dir, "_manifest": {}}]
+
+    redactor = Redactor(home_dir=home)
+    result = db._system_plugins(loaded_plugins, plugins_root=plugins_dir, redactor=redactor)
+
+    evicted = [o for o in result["orphans"] if o["id"] == "highway_3d"]
+    assert len(evicted) == 1
+    path_val = evicted[0]["path"]
+    # The raw home-dir path must not appear.
+    assert str(home) not in path_val
+    # The placeholder must be present.
+    assert "<HOME>" in path_val
+
+
+def test_system_plugins_orphan_path_not_redacted_when_no_redactor(tmp_path):
+    """Without a redactor the `path` field is the raw resolved path (no change)."""
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+    stale_dir = plugins_dir / "old_plugin"
+    stale_dir.mkdir()
+    (stale_dir / "plugin.json").write_text('{"id":"my_plugin","name":"My Plugin"}')
+
+    loaded_plugins = [{"id": "my_plugin", "name": "My Plugin",
+                       "_dir": tmp_path / "canonical", "_manifest": {}}]
+
+    result = db._system_plugins(loaded_plugins, plugins_root=plugins_dir)
+
+    evicted = [o for o in result["orphans"] if o["id"] == "my_plugin"]
+    assert len(evicted) == 1
+    # Raw path — no <HOME> or <CONFIG_DIR> replacement.
+    assert str(stale_dir.resolve()) == evicted[0]["path"]
+
+
 def test_git_remote_token_stripped():
     """Embedded credentials in git remote URLs must be stripped from system/plugins.json."""
     # Simulate a plugin with a git remote that embeds a token.

--- a/tests/test_diagnostics_bundle.py
+++ b/tests/test_diagnostics_bundle.py
@@ -529,6 +529,45 @@ def test_system_plugins_multi_root_scans_all(tmp_path):
     assert "pluginB" in orphan_ids
 
 
+def test_system_plugins_evicted_stale_copy_appears_in_orphans(tmp_path):
+    """A stale/evicted copy (same plugin id, different directory) appears
+    in the orphans list with ``evicted: True`` so it's visible in diagnostics.
+
+    Previously, _system_plugins silently skipped any directory whose manifest
+    id matched a loaded plugin, which meant evicted stale copies were invisible
+    in exported bundles.
+    """
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+
+    # Stale in-tree clone: same manifest id, different directory name.
+    stale_dir = plugins_dir / "3dhighway"
+    stale_dir.mkdir()
+    (stale_dir / "plugin.json").write_text('{"id":"highway_3d","name":"3D Highway (stale)"}')
+
+    # The real bundled copy is loaded from a different dir.
+    bundled_dir = plugins_dir / "highway_3d"
+    bundled_dir.mkdir()
+
+    loaded_plugins = [{
+        "id": "highway_3d",
+        "name": "3D Highway",
+        "_dir": bundled_dir,
+        "_manifest": {},
+    }]
+
+    result = db._system_plugins(loaded_plugins, plugins_root=plugins_dir)
+
+    # The stale clone must appear as an orphan with evicted=True.
+    evicted = [o for o in result["orphans"] if o["id"] == "highway_3d"]
+    assert len(evicted) == 1
+    assert evicted[0]["dir"] == "3dhighway"
+    assert evicted[0].get("evicted") is True
+    # The canonical loaded copy must NOT appear in orphans.
+    loaded_ids = {p["id"] for p in result["plugins"]}
+    assert "highway_3d" in loaded_ids
+
+
 def test_git_remote_token_stripped():
     """Embedded credentials in git remote URLs must be stripped from system/plugins.json."""
     # Simulate a plugin with a git remote that embeds a token.

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -13,6 +13,7 @@ existing colliding plugins are visible.
 """
 
 import contextlib
+import concurrent.futures
 import importlib
 import json
 import logging
@@ -1751,7 +1752,7 @@ def test_fallback_skipped_when_setup_was_mid_flight_on_timeout(
     # Inject a route_setup_fn that simulates a mid-flight timeout by raising
     # a TimeoutError with setup_mid_flight=True.
     def _mid_flight_timeout_setup_fn(fn):
-        e = __import__("concurrent.futures", fromlist=["TimeoutError"]).TimeoutError()
+        e = concurrent.futures.TimeoutError()
         e.setup_mid_flight = True
         raise e
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1255,33 +1255,25 @@ def test_bundled_flag_requires_both_in_tree_directory_and_manifest_field(
 
     # In-tree plugin with "bundled": true AND dir name == id → bundled=True.
     assert by_id["real_core"]["bundled"] is True
-    assert by_id["real_core"]["overrides_bundled"] is False
 
     # In-tree plugin without "bundled" field → bundled=False (user clone in plugins/).
     assert by_id["user_in_tree"]["bundled"] is False
-    assert by_id["user_in_tree"]["overrides_bundled"] is False
 
     # In-tree plugin with "bundled": true but dir name ≠ id → bundled=False.
     # (verbatim copy under a different folder; dir name "other_name" ≠ id "real_core_copy")
     assert by_id["real_core_copy"]["bundled"] is False
-    assert by_id["real_core_copy"]["overrides_bundled"] is False
 
     # Plugin from user dir with "bundled": true → bundled=False (manifest field alone insufficient).
     assert by_id["fake_bundled"]["bundled"] is False
-    assert by_id["fake_bundled"]["overrides_bundled"] is False
 
 
 
-def test_bundled_and_overrides_bundled_returned_by_api(tmp_path, reset_plugin_state):
-    """GET /api/plugins must include ``bundled`` and ``overrides_bundled``
-    boolean fields for each plugin.
+def test_bundled_returned_by_api(tmp_path, reset_plugin_state):
+    """GET /api/plugins must include a ``bundled`` boolean field for each plugin.
 
-    - A plugin loaded from a manifest with ``"bundled": true`` must surface
-      ``bundled: true, overrides_bundled: false``.
-    - A user copy that shadows a bundled plugin must surface
-      ``bundled: false, overrides_bundled: true``.
-    - A plain user plugin with no bundled interaction must surface
-      ``bundled: false, overrides_bundled: false``.
+    - A plugin loaded from a manifest with ``"bundled": true`` (in-tree, dir name
+      matches id) must surface ``bundled: true``.
+    - A plain user plugin must surface ``bundled: false``.
     """
     plugins_mod = reset_plugin_state
 
@@ -1295,23 +1287,6 @@ def test_bundled_and_overrides_bundled_returned_by_api(tmp_path, reset_plugin_st
         "nav": None,
         "type": None,
         "bundled": True,
-        "overrides_bundled": False,
-        "has_screen": False,
-        "has_script": False,
-        "has_settings": False,
-        "has_tour": False,
-        "_dir": plugin_dir,
-        "_manifest": {},
-    })
-
-    # User copy overriding a bundled plugin.
-    plugins_mod.LOADED_PLUGINS.append({
-        "id": "highway_3d",
-        "name": "3D Highway (user)",
-        "nav": None,
-        "type": None,
-        "bundled": False,
-        "overrides_bundled": True,
         "has_screen": False,
         "has_script": False,
         "has_settings": False,
@@ -1327,7 +1302,6 @@ def test_bundled_and_overrides_bundled_returned_by_api(tmp_path, reset_plugin_st
         "nav": None,
         "type": None,
         "bundled": False,
-        "overrides_bundled": False,
         "has_screen": False,
         "has_script": False,
         "has_settings": False,
@@ -1343,13 +1317,10 @@ def test_bundled_and_overrides_bundled_returned_by_api(tmp_path, reset_plugin_st
         ids = {p["id"]: p for p in r.json()}
 
         assert ids["core_viz"]["bundled"] is True
-        assert ids["core_viz"]["overrides_bundled"] is False
-
-        assert ids["highway_3d"]["bundled"] is False
-        assert ids["highway_3d"]["overrides_bundled"] is True
+        assert "overrides_bundled" not in ids["core_viz"]
 
         assert ids["my_plugin"]["bundled"] is False
-        assert ids["my_plugin"]["overrides_bundled"] is False
+        assert "overrides_bundled" not in ids["my_plugin"]
     finally:
         client.close()
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -894,10 +894,11 @@ def test_bundled_plugin_always_wins_over_slopsmith_plugins_dir_copy(
     # Exactly one highway_3d entry registered.
     hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert len(hw3d_entries) == 1
-    # The loader emits a warning about the ignored user copy.
+    # The loader emits a warning about the ignored user copy, naming its path.
     assert (
         "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
         and "ignored" in caplog.text
+        and str(user_dir / "highway_3d") in caplog.text
     )
 
 
@@ -949,10 +950,11 @@ def test_bundled_plugin_wins_over_user_copy_and_logs_warning(
     assert str(kept["_dir"]) == str(plugin_dir)
     assert kept.get("bundled") is True
 
-    # The loader must emit the specific warning about the ignored user copy.
+    # The loader must emit the specific warning about the ignored user copy, naming its path.
     assert (
         "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
         and "ignored" in caplog.text
+        and str(user_plugin_dir) in caplog.text
     )
 
 
@@ -1005,10 +1007,11 @@ def test_bundled_plugin_wins_over_verbatim_user_copy(
     assert str(kept["_dir"]) == str(plugin_dir)
     assert kept.get("bundled") is True
 
-    # The loader emits the warning about the ignored user copy.
+    # The loader emits the warning about the ignored user copy, naming its path.
     assert (
         "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
         and "ignored" in caplog.text
+        and str(user_plugin_dir) in caplog.text
     )
 
 
@@ -1067,10 +1070,11 @@ def test_bundled_plugin_wins_over_copy_in_same_plugins_dir(
     # Bundled flag set on the kept copy.
     assert kept.get("bundled") is True
 
-    # The loader emits the specific warning about the ignored user copy.
+    # The loader emits the specific warning about the ignored user copy, naming its path.
     assert (
         "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
         and "ignored" in caplog.text
+        and str(user_plugin_dir) in caplog.text
     )
 
 
@@ -1124,10 +1128,11 @@ def test_bundled_plugin_wins_over_copy_in_same_plugins_dir_bundled_sorts_first(
     # Bundled flag set on the kept copy.
     assert kept.get("bundled") is True
 
-    # The loader emits the specific warning about the ignored user copy.
+    # The loader emits the specific warning about the ignored user copy, naming its path.
     assert (
         "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
         and "ignored" in caplog.text
+        and str(user_plugin_dir) in caplog.text
     )
 
 
@@ -1186,10 +1191,11 @@ def test_bundled_plugin_wins_over_verbatim_copy_in_same_plugins_dir(
     # Bundled flag set on the kept copy.
     assert kept.get("bundled") is True
 
-    # Warning about the ignored user copy must be emitted.
+    # Warning about the ignored user copy must be emitted, naming its path.
     assert (
         "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
         and "ignored" in caplog.text
+        and str(user_plugin_dir) in caplog.text
     )
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1449,6 +1449,215 @@ def test_plugin_absent_when_both_routes_fail(
     assert "also failed to load routes" in caplog.text
 
 
+def test_partial_route_registration_warning(
+    tmp_path, reset_plugin_state, monkeypatch, caplog
+):
+    """When bundled setup() registers routes before raising, a specific
+    warning should name the count so maintainers can identify the partial
+    registration in the server log (Thread 1, review-4226318201).
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    # Routes that register one endpoint before raising.
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n"
+        "    app.routes.append('stub')\n"
+        "    raise RuntimeError('partial fail')\n"
+    )
+
+    fake_app = type("FakeApp", (), {"routes": []})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        with capture_logger(caplog, "slopsmith.plugins", level=logging.WARNING):
+            plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    assert "registered 1 route" in caplog.text
+    assert "cannot be removed" in caplog.text
+
+
+def test_sibling_module_cache_purged_before_fallback(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """Sibling modules from the failed bundled copy are purged from sys.modules
+    before the fallback copy's routes are loaded, so the fallback gets a clean
+    slate and doesn't accidentally resolve to bundled helper code
+    (Thread 2, review-4226318201).
+    """
+    import sys
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    # Bundled helper reports 'bundled'; bundled routes load it via load_sibling
+    # then fail — this caches the bundled helper in sys.modules.
+    (bundled_plugin_dir / "helper.py").write_text("ORIGIN = 'bundled'\n")
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n"
+        "    ctx['load_sibling']('helper')  # caches bundled helper\n"
+        "    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    # User copy has its own helper with a different ORIGIN; routes use load_sibling.
+    (user_plugin_dir / "helper.py").write_text("ORIGIN = 'user'\n")
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n"
+        "    helper = ctx['load_sibling']('helper')\n"
+        "    app.state.helper_origin = helper.ORIGIN\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # The fallback routes ran and resolved the user copy's helper, not bundled's.
+    hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert len(hw3d_entries) == 1
+    assert getattr(fake_app.state, "helper_origin", None) == "user"
+
+
+def test_fallback_success_clears_error_in_progress_events(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """When fallback succeeds, the progress event should carry explicit
+    error=None (clear_error=True) so downstream startup-status handlers can
+    clear the bundled-failure error text (Thread 3, review-4226318201).
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    pass\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    events = []
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {}, progress_cb=events.append)
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # After fallback success, a "plugin-registered" event with explicit
+    # "error": None should clear the bundled-failure error in the handler.
+    registered_clear_events = [
+        e for e in events
+        if e.get("phase") == "plugin-registered"
+        and e.get("plugin_id") == "highway_3d"
+        and "error" in e
+        and e["error"] is None
+    ]
+    assert registered_clear_events, (
+        "Expected a plugin-registered event with explicit error=None after fallback success"
+    )
+
+
+def test_plugins_complete_loaded_count_when_both_routes_fail(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """When both bundled and fallback routes fail, plugins-complete must
+    report loaded = actual registered count, not len(plugin_load_specs)
+    (Thread 4, review-4226318201).
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    # One healthy plugin + one that will fail completely.
+    healthy_plugin_dir = bundled_dir / "healthy"
+    healthy_plugin_dir.mkdir()
+    (healthy_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "healthy", "name": "Healthy Plugin", "bundled": True})
+    )
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('user also broken')\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    events = []
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {}, progress_cb=events.append)
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    complete = next(e for e in events if e["phase"] == "plugins-complete")
+    # "healthy" loaded OK, "highway_3d" failed completely → actual loaded == 1
+    assert complete["loaded"] == 1, (
+        f"plugins-complete loaded should be 1 (only healthy), got {complete['loaded']}"
+    )
+    # total still reflects how many specs were discovered
+    assert complete["total"] == 2
+
+
+
 def test_bundled_flag_requires_both_in_tree_directory_and_manifest_field(
     tmp_path, reset_plugin_state, monkeypatch
 ):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -838,7 +838,7 @@ def test_per_plugin_context_does_not_leak_load_sibling_across_plugins(tmp_path, 
 
 # ── SLOPSMITH_PLUGINS_DIR precedence over bundled in-tree plugins ────────────
 
-def test_slopsmith_plugins_dir_takes_precedence_over_bundled(
+def test_bundled_plugin_always_wins_over_slopsmith_plugins_dir_copy(
     tmp_path, reset_plugin_state, monkeypatch, caplog
 ):
     """Bundled plugins always win over user-installed copies in SLOPSMITH_PLUGINS_DIR.

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1661,16 +1661,21 @@ def test_plugins_complete_loaded_count_when_both_routes_fail(
 def test_fallback_preserves_plugin_order(
     tmp_path, reset_plugin_state, monkeypatch
 ):
-    """When a fallback user copy replaces a broken bundled plugin, it must be
-    inserted at the bundled plugin's original position in LOADED_PLUGINS —
-    not appended at the end — so that /api/plugins order and the frontend
-    playSong wrapper chain are unchanged (Thread 3, review-4227201020).
+    """When a bundled copy evicts a user-installed copy and then fails to load
+    its routes, the fallback (user copy) must occupy the SAME slot the user
+    copy had at discovery time — not the position the bundled copy would have
+    been appended at (Thread 1, review-4227852922; Thread 3, review-4227201020).
 
     Layout:
-      bundled: alpha (healthy), highway_3d (broken), omega (healthy)
-      user dir: highway_3d (working fallback)
+      user dir: highway_3d (working fallback, has routes)
+      bundled:  alpha (healthy), highway_3d (broken routes), omega (healthy)
 
-    Expected order after fallback: [alpha, highway_3d (fallback), omega]
+    Scan order: user dir first, then bundled.  user/highway_3d lands at slot 0.
+    When bundled/highway_3d is scanned it replaces the user copy IN-PLACE at
+    slot 0 (review-4227852922 fix).  After route failure the fallback is
+    inserted back at slot 0.
+
+    Expected order after fallback: [highway_3d (fallback), alpha, omega]
     """
     plugins = reset_plugin_state
 
@@ -1692,6 +1697,56 @@ def test_fallback_preserves_plugin_order(
     user_dir.mkdir()
     user_hw = user_dir / "highway_3d"
     user_hw.mkdir()
+    # User copy must have a routes file; without one fallback_routes_ok is
+    # False and the entry is never added to LOADED_PLUGINS (review-4227852922).
+    (user_hw / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_hw / "routes.py").write_text("def setup(app, ctx): pass\n")
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    ids = [p["id"] for p in plugins.LOADED_PLUGINS]
+    assert ids == ["highway_3d", "alpha", "omega"], (
+        f"Fallback entry must occupy the user copy's original discovery slot, got order: {ids}"
+    )
+    # The entry at position 0 (user copy's original slot) is the fallback.
+    assert plugins.LOADED_PLUGINS[0].get("fallback") is True
+
+
+def test_fallback_not_registered_when_user_copy_has_no_routes(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """If the evicted user copy has no routes entry it cannot restore the
+    bundled plugin's backend endpoints.  The fallback must be treated as
+    unsuccessful (fallback_routes_ok=False) so the plugin is absent from
+    LOADED_PLUGINS and the bundled-failure error stays in startup-status.
+    (Thread 2, review-4227852922)
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bd = bundled_dir / "highway_3d"
+    bd.mkdir()
+    (bd / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bd / "routes.py").write_text("def setup(app, ctx):\n    raise RuntimeError('broken')\n")
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_hw = user_dir / "highway_3d"
+    user_hw.mkdir()
+    # No routes in user copy — cannot restore bundled endpoints.
     (user_hw / "plugin.json").write_text(
         json.dumps({"id": "highway_3d", "name": "3D Highway (user)"})
     )
@@ -1707,11 +1762,9 @@ def test_fallback_preserves_plugin_order(
         plugins.PLUGINS_DIR = saved_dir
 
     ids = [p["id"] for p in plugins.LOADED_PLUGINS]
-    assert ids == ["alpha", "highway_3d", "omega"], (
-        f"Fallback entry must occupy the bundled plugin's original position, got order: {ids}"
+    assert "highway_3d" not in ids, (
+        "Plugin with no-routes user copy must NOT appear in LOADED_PLUGINS"
     )
-    # The entry at position 1 is the fallback copy.
-    assert plugins.LOADED_PLUGINS[1].get("fallback") is True
 
 
 def test_fallback_skipped_when_setup_was_mid_flight_on_timeout(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1961,6 +1961,31 @@ def test_fallback_proceeds_when_install_requirements_returns_false(
         f"events were: {events}"
     )
 
+    # The req-failure event must include loaded/total so startup-status
+    # progress counters are not zeroed out.
+    # (Thread 2, review-4228421486)
+    for e in req_errors:
+        assert "loaded" in e and "total" in e, (
+            f"plugin-error event for req failure must include loaded/total; got: {e}"
+        )
+
+    # After successful route registration the plugin-registered event must
+    # NOT carry error=None when req install failed; that would wipe the req
+    # error from startup-status, making startup look clean despite degraded
+    # dependencies. (Thread 1, review-4228421486)
+    registered_clear_events = [
+        e for e in events
+        if e.get("phase") == "plugin-registered"
+        and e.get("plugin_id") == "highway_3d"
+        and "error" in e
+        and e["error"] is None
+    ]
+    assert not registered_clear_events, (
+        "plugin-registered must NOT carry error=None when req install failed "
+        "(that would silently wipe the req-failure error from startup-status); "
+        f"events were: {events}"
+    )
+
 
 def test_fallback_routes_failure_emits_plugin_error(
     tmp_path, reset_plugin_state, monkeypatch
@@ -2030,6 +2055,14 @@ def test_fallback_routes_failure_emits_plugin_error(
         "fallback" in e["error"].lower() or "both" in e["error"].lower()
         for e in fallback_errors
     ), f"plugin-error text should reference the fallback failure; got: {[e['error'] for e in fallback_errors]}"
+
+    # The fallback route-error event must include loaded/total so the
+    # startup-status progress counters are not zeroed mid-run.
+    # (Thread 3, review-4228421486)
+    for e in fallback_errors:
+        assert "loaded" in e and "total" in e, (
+            f"plugin-error event for fallback route failure must include loaded/total; got: {e}"
+        )
 
 
 def test_normal_plugins_do_not_have_fallback_field_set(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1657,6 +1657,166 @@ def test_plugins_complete_loaded_count_when_both_routes_fail(
     assert complete["total"] == 2
 
 
+def test_fallback_entry_has_fallback_true_field(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """When a user-copy fallback is activated because bundled routes fail,
+    the registered LOADED_PLUGINS entry must include ``"fallback": True``.
+    The /api/plugins endpoint exposes this field so the settings UI can
+    show a warning badge (Thread 4, review-4226937699).
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text("def setup(app, ctx):\n    pass\n")
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.get("fallback") is True, (
+        "Fallback user copy entry must have fallback=True, got "
+        f"{entry.get('fallback')!r}"
+    )
+    assert entry.get("bundled") is False, (
+        "Fallback user copy must not be marked bundled"
+    )
+
+
+def test_normal_plugins_do_not_have_fallback_field_set(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """Normal (non-fallback) plugins — both bundled and user-installed —
+    must not have ``fallback: True`` set.  Only emergency user-copy
+    fallbacks that replaced a broken bundled plugin carry the flag.
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "my_plugin"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "my_plugin", "name": "My Plugin", "bundled": True})
+    )
+
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "my_plugin"]
+    assert len(entries) == 1
+    assert not entries[0].get("fallback"), (
+        "Normal bundled plugin must not have fallback=True"
+    )
+
+
+def test_sibling_purge_does_not_affect_other_plugin_with_same_prefix(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """The sibling module purge in the fallback block must only remove the
+    exact routes module key for the evicted plugin and its namespaced
+    load_sibling modules.  It must NOT delete modules for other plugins
+    whose namespaced IDs share the same prefix.
+
+    Previously, ``k.startswith(f"{_parent_pkg}_")`` would match
+    ``plugin_a_routes`` when purging plugin ``a``, and would also
+    incorrectly match ``plugin_a_5f_b_routes`` (routes for plugin ``a_b``).
+    The fix replaces the startswith check with an exact key match.
+
+    (Thread 1, review-4226937699)
+    """
+    plugins = reset_plugin_state
+    import sys
+
+    # plugin "a" — bundled, fails routes.
+    # plugin "a_b" — also bundled, healthy.
+    # user copy of "a" — provides the fallback.
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+
+    ba_dir = bundled_dir / "a"
+    ba_dir.mkdir()
+    (ba_dir / "plugin.json").write_text(
+        json.dumps({"id": "a", "name": "Plugin A", "routes": "routes.py", "bundled": True})
+    )
+    (ba_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('a broken')\n"
+    )
+
+    ab_dir = bundled_dir / "a_b"
+    ab_dir.mkdir()
+    # `a_b` routes capture a ref so we can assert they ran from the right module.
+    (ab_dir / "plugin.json").write_text(
+        json.dumps({"id": "a_b", "name": "Plugin A_B", "routes": "routes.py", "bundled": True})
+    )
+    (ab_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    app.state.ab_setup_ran = True\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    ua_dir = user_dir / "a"
+    ua_dir.mkdir()
+    (ua_dir / "plugin.json").write_text(
+        json.dumps({"id": "a", "name": "Plugin A (user)", "routes": "routes.py"})
+    )
+    (ua_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    app.state.a_fallback_ran = True\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # plugin "a_b" routes should have run without being clobbered by
+    # the prefix-based purge.
+    assert getattr(fake_app.state, "ab_setup_ran", False) is True, (
+        "plugin 'a_b' setup() was not called — its module was incorrectly "
+        "purged during the 'a' fallback sibling purge"
+    )
+    # plugin "a" fallback also ran.
+    assert getattr(fake_app.state, "a_fallback_ran", False) is True, (
+        "plugin 'a' fallback setup() did not run"
+    )
+
 
 def test_bundled_flag_requires_both_in_tree_directory_and_manifest_field(
     tmp_path, reset_plugin_state, monkeypatch

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1333,6 +1333,122 @@ def test_fallback_to_user_copy_when_bundled_routes_fail(
     assert str(user_plugin_dir) in caplog.text
 
 
+def test_fallback_when_bundled_sorts_first_and_routes_fail(
+    tmp_path, reset_plugin_state, caplog
+):
+    """Fallback works even when the bundled plugin is discovered BEFORE the user copy.
+
+    Thread 6 regression: the `elif kept_is_bundled:` branch previously
+    discarded the user copy without storing it in `_pending_evictions`, so
+    a bundled plugin discovered first had no fallback available.
+
+    Layout (both in the same plugins_dir, bundled sorts first):
+      plugins/highway_3d/   ← bundled (broken routes)
+      plugins/zzz-highway/  ← user copy (working routes)
+    """
+    plugins = reset_plugin_state
+
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+
+    # Bundled copy — sorts first alphabetically; routes.setup() will raise.
+    bundled_plugin_dir = plugins_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    # User copy — sorts after bundled; working routes.
+    user_plugin_dir = plugins_dir / "zzz-highway"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    app.state.origin = 'user_fallback'\n"
+    )
+
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = plugins_dir
+    try:
+        with capture_logger(caplog, "slopsmith.plugins", level=logging.WARNING):
+            plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # The fallback user copy should be registered.
+    hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert len(hw3d_entries) == 1
+    assert hw3d_entries[0].get("bundled") is False
+    assert str(hw3d_entries[0]["_dir"]) == str(user_plugin_dir)
+
+    # The fallback's routes.setup() should have run.
+    assert getattr(fake_app.state, "origin", None) == "user_fallback"
+
+    # The fallback warning must be logged.
+    assert "falling back to user-installed copy" in caplog.text
+    assert str(user_plugin_dir) in caplog.text
+
+
+def test_both_bundled_and_fallback_routes_fail_plugin_absent(
+    tmp_path, reset_plugin_state, monkeypatch, caplog
+):
+    """When both bundled routes AND fallback routes fail, plugin is absent from LOADED_PLUGINS.
+
+    Thread 5 regression: the old code always appended to _loaded_batch even when
+    the fallback routes also failed, causing the plugin to appear in /api/plugins
+    despite having no working routes — contradicting the 'plugin unavailable' log.
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    # User copy routes also raise.
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('user also broken')\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        with capture_logger(caplog, "slopsmith.plugins", level=logging.WARNING):
+            plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # Plugin must be absent — neither bundled nor user copy registered.
+    hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert len(hw3d_entries) == 0
+
+    # Both failures must be logged.
+    assert "falling back to user-installed copy" in caplog.text
+    assert "also failed to load routes" in caplog.text
+
+
 def test_bundled_flag_requires_both_in_tree_directory_and_manifest_field(
     tmp_path, reset_plugin_state, monkeypatch
 ):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1832,6 +1832,65 @@ def test_fallback_entry_has_fallback_true_field(
     )
 
 
+def test_fallback_proceeds_when_install_requirements_returns_false(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """_install_requirements returning False in the fallback path must be
+    non-fatal — the fallback must still load routes, matching the main loop
+    behaviour which only emits a plugin-error but does not abort.
+
+    Previously the fallback block did ``if not _install_requirements(...): continue``
+    which skipped the user copy entirely, leaving the bundled-failure error in
+    startup-status even when the user copy could have run without those deps.
+    (Thread 1, review-4227643820)
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    app.state.fallback_ran = True\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+    # Simulate _install_requirements failing (read-only filesystem, optional
+    # dep, etc.) — same scenario the main loop tolerates.
+    monkeypatch.setattr(plugins, "_install_requirements", lambda *a, **kw: False)
+
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # Despite requirements failure the fallback routes.setup() must have run.
+    assert getattr(fake_app.state, "fallback_ran", False) is True, (
+        "Fallback routes.setup() must run even when _install_requirements returns False"
+    )
+    entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert entries, "highway_3d must be registered as a fallback"
+    assert entries[0].get("fallback") is True
+
+
 def test_normal_plugins_do_not_have_fallback_field_set(
     tmp_path, reset_plugin_state, monkeypatch
 ):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1962,7 +1962,6 @@ def test_fallback_proceeds_when_install_requirements_returns_false(
     )
 
 
-
 def test_fallback_routes_failure_emits_plugin_error(
     tmp_path, reset_plugin_state, monkeypatch
 ):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1199,6 +1199,83 @@ def test_bundled_plugin_wins_over_verbatim_copy_in_same_plugins_dir(
     )
 
 
+def test_bundled_wins_with_multiple_stale_copies(
+    tmp_path, reset_plugin_state, monkeypatch, caplog
+):
+    """Bundled plugin wins when multiple stale copies exist simultaneously.
+
+    Exercises the exact #181 layout: the user has both an external
+    ``SLOPSMITH_PLUGINS_DIR/highway_3d`` copy AND a stale in-tree clone at
+    ``plugins/3dhighway``, alongside the real bundled ``plugins/highway_3d``.
+
+    Scan order:
+    1. SLOPSMITH_PLUGINS_DIR scanned first → user_dir/highway_3d registered.
+    2. PLUGINS_DIR scanned next (sorted):
+       - ``3dhighway`` sorts before ``highway_3d`` → duplicate, neither is bundled
+         → discarded with a warning naming the specific plugin_dir.
+       - ``highway_3d`` → bundled; evicts the SLOPSMITH_PLUGINS_DIR copy; wins.
+
+    Both stale paths must be named in warning log messages.
+    """
+    plugins = reset_plugin_state
+
+    # Simulate the in-tree (bundled) plugins directory.
+    plugins_dir = tmp_path / "plugins"
+    plugins_dir.mkdir()
+
+    # Stale in-tree clone (different dir name; not bundled because dir ≠ id).
+    stale_intree_dir = plugins_dir / "3dhighway"
+    stale_intree_dir.mkdir()
+    (stale_intree_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (stale clone)"})
+    )
+
+    # Real bundled copy.
+    bundled_plugin_dir = plugins_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "bundled": True})
+    )
+
+    # Simulate a user-installed plugins directory (SLOPSMITH_PLUGINS_DIR).
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)"})
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = plugins_dir
+    try:
+        with capture_logger(caplog, "slopsmith.plugins"):
+            plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # Exactly one entry registered.
+    hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert len(hw3d_entries) == 1
+
+    # The bundled copy must win.
+    kept = hw3d_entries[0]
+    assert str(kept["_dir"]) == str(bundled_plugin_dir)
+    assert kept.get("bundled") is True
+
+    # The stale in-tree clone path must be named in the log.
+    assert str(stale_intree_dir) in caplog.text
+    # The user-installed copy path must be named in the log (bundled-wins warning).
+    assert (
+        "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
+        and "ignored" in caplog.text
+        and str(user_plugin_dir) in caplog.text
+    )
+
+
 def test_bundled_flag_requires_both_in_tree_directory_and_manifest_field(
     tmp_path, reset_plugin_state, monkeypatch
 ):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1657,6 +1657,128 @@ def test_plugins_complete_loaded_count_when_both_routes_fail(
     assert complete["total"] == 2
 
 
+def test_fallback_preserves_plugin_order(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """When a fallback user copy replaces a broken bundled plugin, it must be
+    inserted at the bundled plugin's original position in LOADED_PLUGINS —
+    not appended at the end — so that /api/plugins order and the frontend
+    playSong wrapper chain are unchanged (Thread 3, review-4227201020).
+
+    Layout:
+      bundled: alpha (healthy), highway_3d (broken), omega (healthy)
+      user dir: highway_3d (working fallback)
+
+    Expected order after fallback: [alpha, highway_3d (fallback), omega]
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+
+    for name, content in [
+        ("alpha", {"id": "alpha", "name": "Alpha", "bundled": True}),
+        ("highway_3d", {"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True}),
+        ("omega", {"id": "omega", "name": "Omega", "bundled": True}),
+    ]:
+        d = bundled_dir / name
+        d.mkdir()
+        (d / "plugin.json").write_text(json.dumps(content))
+        if name == "highway_3d":
+            (d / "routes.py").write_text("def setup(app, ctx):\n    raise RuntimeError('broken')\n")
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_hw = user_dir / "highway_3d"
+    user_hw.mkdir()
+    (user_hw / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)"})
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    ids = [p["id"] for p in plugins.LOADED_PLUGINS]
+    assert ids == ["alpha", "highway_3d", "omega"], (
+        f"Fallback entry must occupy the bundled plugin's original position, got order: {ids}"
+    )
+    # The entry at position 1 is the fallback copy.
+    assert plugins.LOADED_PLUGINS[1].get("fallback") is True
+
+
+def test_fallback_skipped_when_setup_was_mid_flight_on_timeout(
+    tmp_path, reset_plugin_state, monkeypatch, caplog
+):
+    """When bundled setup() times out mid-flight (already executing), the loader
+    must NOT activate the user-copy fallback — the original setup() may still be
+    mutating the router concurrently (Thread 4, review-4227201020).
+
+    Simulated by injecting an exception with ``setup_mid_flight=True`` (the
+    attribute _route_setup_on_main attaches when it detects _started is set at
+    timeout).
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text("def setup(app, ctx): pass\n")
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    app.state.fallback_ran = True\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    # Inject a route_setup_fn that simulates a mid-flight timeout by raising
+    # a TimeoutError with setup_mid_flight=True.
+    def _mid_flight_timeout_setup_fn(fn):
+        e = __import__("concurrent.futures", fromlist=["TimeoutError"]).TimeoutError()
+        e.setup_mid_flight = True
+        raise e
+
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        with capture_logger(caplog, "slopsmith.plugins", level=logging.WARNING):
+            plugins.load_plugins(fake_app, {}, route_setup_fn=_mid_flight_timeout_setup_fn)
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # Fallback must NOT have run — original setup() was mid-flight.
+    assert not getattr(fake_app.state, "fallback_ran", False), (
+        "Fallback setup() must not run when bundled setup() was mid-flight at timeout"
+    )
+    # Plugin must be absent from LOADED_PLUGINS (both copies failed).
+    hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert len(hw3d_entries) == 0, (
+        "Plugin must be absent when bundled timed out mid-flight and fallback was skipped"
+    )
+    # Warning about skipping fallback must appear in log.
+    assert "Skipping fallback" in caplog.text or "mid-flight" in caplog.text
+
+
+
 def test_fallback_entry_has_fallback_true_field(
     tmp_path, reset_plugin_state, monkeypatch
 ):
@@ -1949,8 +2071,73 @@ def test_bundled_returned_by_api(tmp_path, reset_plugin_state):
     finally:
         client.close()
 
+def test_fallback_field_is_surfaced_in_api_response(tmp_path, reset_plugin_state):
+    """GET /api/plugins must include a ``fallback`` boolean field for each plugin.
 
-# ── progress_cb tests ─────────────────────────────────────────────────────────
+    - A fallback user-copy entry (bundled routes failed) must surface ``fallback: true``.
+    - A normal plugin must surface ``fallback: false``.
+
+    This ensures the frontend badge rendering is reliable — the badge depends
+    on this field being present in the JSON response from the endpoint, not
+    just in the internal LOADED_PLUGINS list (Thread 6, review-4227201020).
+    """
+    plugins_mod = reset_plugin_state
+
+    plugin_dir = tmp_path / "dummy"
+    plugin_dir.mkdir()
+
+    # Fallback user-copy entry (bundled routes failed, user copy active).
+    plugins_mod.LOADED_PLUGINS.append({
+        "id": "highway_3d",
+        "name": "3D Highway (user fallback)",
+        "nav": None,
+        "type": None,
+        "bundled": False,
+        "fallback": True,
+        "has_screen": False,
+        "has_script": False,
+        "has_settings": False,
+        "has_tour": False,
+        "_dir": plugin_dir,
+        "_manifest": {},
+    })
+
+    # Normal user plugin — must NOT have fallback=true.
+    plugins_mod.LOADED_PLUGINS.append({
+        "id": "normal_plugin",
+        "name": "Normal Plugin",
+        "nav": None,
+        "type": None,
+        "bundled": False,
+        "has_screen": False,
+        "has_script": False,
+        "has_settings": False,
+        "has_tour": False,
+        "_dir": plugin_dir,
+        "_manifest": {},
+    })
+
+    client = _make_api_client(plugins_mod)
+    try:
+        r = client.get("/api/plugins")
+        assert r.status_code == 200
+        ids = {p["id"]: p for p in r.json()}
+
+        # Fallback entry must have fallback=true in the response.
+        assert "fallback" in ids["highway_3d"], (
+            "/api/plugins response must include the 'fallback' key"
+        )
+        assert ids["highway_3d"]["fallback"] is True
+
+        # Normal plugin must have fallback=false in the response.
+        assert "fallback" in ids["normal_plugin"], (
+            "/api/plugins response must include the 'fallback' key for all plugins"
+        )
+        assert ids["normal_plugin"]["fallback"] is False
+    finally:
+        client.close()
+
+
 
 def _run_load_plugins_with_cb(plugins, app, tmp_path, progress_cb, context=None):
     """Like _run_load_plugins but passes a progress_cb spy."""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -841,12 +841,11 @@ def test_per_plugin_context_does_not_leak_load_sibling_across_plugins(tmp_path, 
 def test_slopsmith_plugins_dir_takes_precedence_over_bundled(
     tmp_path, reset_plugin_state, monkeypatch, caplog
 ):
-    """SLOPSMITH_PLUGINS_DIR is scanned before the in-tree PLUGINS_DIR, so a
-    user-installed plugin with the same id shadows the bundled copy.
+    """Bundled plugins always win over user-installed copies in SLOPSMITH_PLUGINS_DIR.
 
-    This is the mechanism that keeps existing standalone highway_3d installs
-    working unchanged after the plugin was bundled into core (PR 1 of 4,
-    slopsmith#160). A regression here would silently break their setup.
+    Even though SLOPSMITH_PLUGINS_DIR is scanned first, a user-installed copy
+    with the same id as a bundled plugin is evicted in favour of the bundled
+    version. The loader emits a warning naming the ignored user copy.
     """
     plugins = reset_plugin_state
 
@@ -890,24 +889,25 @@ def test_slopsmith_plugins_dir_takes_precedence_over_bundled(
     finally:
         plugins.PLUGINS_DIR = saved_dir
 
-    # User copy must win — setup() from user_dir ran, not bundled_dir.
-    assert fake_app.state.origin == "user"
+    # Bundled copy must win — setup() from bundled_dir ran, not user_dir.
+    assert fake_app.state.origin == "bundled"
     # Exactly one highway_3d entry registered.
     hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert len(hw3d_entries) == 1
-    # The loader emits the bundled-override warning.
+    # The loader emits a warning about the ignored user copy.
     assert (
-        "Bundled plugin 'highway_3d'" in caplog.text
-        and "overridden by user-installed copy" in caplog.text
+        "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
+        and "ignored" in caplog.text
     )
 
 
-def test_bundled_plugin_overridden_by_user_copy_logs_warning_and_sets_flag(
+def test_bundled_plugin_wins_over_user_copy_and_logs_warning(
     tmp_path, reset_plugin_state, monkeypatch, caplog
 ):
-    """When a user-installed copy shadows a manifest-bundled plugin the loader
-    emits the specific override warning and stamps ``__overrides_bundled`` on the
-    kept (user) copy so the frontend can render the amber badge.
+    """Bundled plugin wins over a user-installed copy with the same id.
+
+    The loader emits a warning naming the ignored user copy. The kept entry
+    is the bundled version (bundled=True, dir matches plugin id).
     """
     plugins = reset_plugin_state
 
@@ -920,8 +920,7 @@ def test_bundled_plugin_overridden_by_user_copy_logs_warning_and_sets_flag(
         json.dumps({"id": "highway_3d", "name": "3D Highway", "bundled": True})
     )
 
-    # User-installed copy with the same id in a differently-named directory
-    # (confirms the override is keyed on manifest id, not directory name).
+    # User-installed copy with the same id in a differently-named directory.
     user_dir = tmp_path / "user"
     user_dir.mkdir()
     user_plugin_dir = user_dir / "3dhighway"  # different directory name
@@ -945,36 +944,26 @@ def test_bundled_plugin_overridden_by_user_copy_logs_warning_and_sets_flag(
     hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert len(hw3d_entries) == 1
 
-    # The kept copy must be the user copy (user dir scanned first).
+    # The kept copy must be the bundled version.
     kept = hw3d_entries[0]
-    assert str(kept["_dir"]) == str(user_plugin_dir)
+    assert str(kept["_dir"]) == str(plugin_dir)
+    assert kept.get("bundled") is True
 
-    # The override flag must be stamped on the kept (user) copy.
-    assert kept.get("overrides_bundled") is True
-
-    # The bundled field must be False for the user copy.
-    assert kept.get("bundled") is False
-
-    # The loader must emit the specific override warning.
+    # The loader must emit the specific warning about the ignored user copy.
     assert (
-        "Bundled plugin 'highway_3d'" in caplog.text
-        and "overridden by user-installed copy" in caplog.text
+        "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
+        and "ignored" in caplog.text
     )
 
 
-def test_bundled_plugin_overridden_by_verbatim_copy_sets_flag(
+def test_bundled_plugin_wins_over_verbatim_user_copy(
     tmp_path, reset_plugin_state, monkeypatch, caplog
 ):
-    """A user who copies the in-tree bundled plugin verbatim (keeping
-    ``"bundled": true`` in their copy) still triggers the override warning
-    and gets ``overrides_bundled=True`` + ``bundled=False`` on the kept entry.
+    """Bundled plugin wins even when the user copy verbatim-copied ``"bundled": true``.
 
-    The user copy lives in ``SLOPSMITH_PLUGINS_DIR`` (not in-tree PLUGINS_DIR),
-    so the three-part ``_is_bundled()`` check — ``(in-tree directory) AND
-    manifest.get("bundled") AND (dir name == plugin id)`` — correctly
-    identifies the in-tree copy as the real bundled plugin and the user copy
-    as the override, even though the user copy also carries the
-    ``"bundled": true`` manifest field.
+    The three-part ``_is_bundled()`` check — in-tree directory, manifest field,
+    AND dir name == plugin id — correctly identifies the in-tree copy as
+    bundled and ignores the user copy regardless of its manifest contents.
     """
     plugins = reset_plugin_state
 
@@ -1011,57 +1000,48 @@ def test_bundled_plugin_overridden_by_verbatim_copy_sets_flag(
     hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert len(hw3d_entries) == 1
 
-    # The kept copy is the user copy (user dir scanned first).
+    # The kept copy must be the real bundled version.
     kept = hw3d_entries[0]
-    assert str(kept["_dir"]) == str(user_plugin_dir)
+    assert str(kept["_dir"]) == str(plugin_dir)
+    assert kept.get("bundled") is True
 
-    # The override flag must be set even though the user copy also has bundled=true.
-    assert kept.get("overrides_bundled") is True
-
-    # bundled must be False — the kept copy is a user override, not a real
-    # in-tree bundled plugin, regardless of what its manifest claims.
-    assert kept.get("bundled") is False
-
-    # The loader emits the specific override warning.
+    # The loader emits the warning about the ignored user copy.
     assert (
-        "Bundled plugin 'highway_3d'" in caplog.text
-        and "overridden by user-installed copy" in caplog.text
+        "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
+        and "ignored" in caplog.text
     )
 
 
-def test_bundled_plugin_overridden_by_copy_in_same_plugins_dir(
+def test_bundled_plugin_wins_over_copy_in_same_plugins_dir(
     tmp_path, reset_plugin_state, caplog
 ):
-    """A user who clones an override directly into ``plugins/`` (the documented
-    third-party install location) still gets the override warning and
-    ``overrides_bundled=True``.
+    """Bundled plugin wins even when a user fork sorts alphabetically first.
 
     Both plugins live under the same PLUGINS_DIR, so override detection cannot
     use the directory parent alone. The three-part ``_is_bundled()`` check —
     ``(in-tree dir) AND manifest.get("bundled") AND (dir name == plugin id)`` —
-    identifies the bundled copy, and the user copy (no ``"bundled"`` field, or
-    a different directory name) as the override.
+    identifies the bundled copy and discards the user fork.
 
     Layout mirroring the canonical example from the PR description:
       plugins/3dhighway/   ← user-installed fork (no "bundled" field)
       plugins/highway_3d/  ← bundled core (has "bundled": true, dir name == id)
 
-    ``3dhighway`` sorts before ``highway_3d`` alphabetically and is kept;
-    ``highway_3d`` is the duplicate that should fire the override warning.
+    ``3dhighway`` sorts before ``highway_3d`` alphabetically and is registered
+    first; when ``highway_3d`` arrives it evicts the user fork and wins.
     """
     plugins = reset_plugin_state
 
     plugins_dir = tmp_path / "plugins"
     plugins_dir.mkdir()
 
-    # User-installed fork — comes first alphabetically, will be kept.
+    # User-installed fork — comes first alphabetically.
     user_plugin_dir = plugins_dir / "3dhighway"
     user_plugin_dir.mkdir()
     (user_plugin_dir / "plugin.json").write_text(
         json.dumps({"id": "highway_3d", "name": "3D Highway (user fork)"})
     )
 
-    # Bundled core — sorts after "3dhighway", will be the duplicate.
+    # Bundled core — sorts after "3dhighway"; evicts the user fork when encountered.
     bundled_plugin_dir = plugins_dir / "highway_3d"
     bundled_plugin_dir.mkdir()
     (bundled_plugin_dir / "plugin.json").write_text(
@@ -1080,28 +1060,27 @@ def test_bundled_plugin_overridden_by_copy_in_same_plugins_dir(
     hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert len(hw3d_entries) == 1
 
-    # The kept copy must be the user fork (alphabetically first).
+    # The bundled copy must win, regardless of alphabetical order.
     kept = hw3d_entries[0]
-    assert str(kept["_dir"]) == str(user_plugin_dir)
+    assert str(kept["_dir"]) == str(bundled_plugin_dir)
 
-    # Override flag and bundled=False on the kept user copy.
-    assert kept.get("overrides_bundled") is True
-    assert kept.get("bundled") is False
+    # Bundled flag set on the kept copy.
+    assert kept.get("bundled") is True
 
-    # The loader emits the specific override warning.
+    # The loader emits the specific warning about the ignored user copy.
     assert (
-        "Bundled plugin 'highway_3d'" in caplog.text
-        and "overridden by user-installed copy" in caplog.text
+        "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
+        and "ignored" in caplog.text
     )
 
 
-def test_bundled_plugin_overridden_by_copy_in_same_plugins_dir_bundled_sorts_first(
+def test_bundled_plugin_wins_over_copy_in_same_plugins_dir_bundled_sorts_first(
     tmp_path, reset_plugin_state, caplog
 ):
-    """Override detection works even when the bundled directory sorts *before*
-    the user directory (i.e., the bundled copy is encountered first).
+    """Bundled plugin wins when it sorts *before* the user directory.
 
-    The user copy must still win regardless of alphabetical sort order.
+    When the bundled copy is encountered first it is registered; the later
+    user copy is discarded with a warning.
 
     Layout where bundled sorts before user:
       plugins/highway_3d/   ← bundled core (has "bundled": true), sorts first
@@ -1138,39 +1117,36 @@ def test_bundled_plugin_overridden_by_copy_in_same_plugins_dir_bundled_sorts_fir
     hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert len(hw3d_entries) == 1
 
-    # The user copy must win even though the bundled copy sorted first.
+    # The bundled copy must win; user fork is discarded.
     kept = hw3d_entries[0]
-    assert str(kept["_dir"]) == str(user_plugin_dir)
+    assert str(kept["_dir"]) == str(bundled_plugin_dir)
 
-    # Override flag and bundled=False on the kept user copy.
-    assert kept.get("overrides_bundled") is True
-    assert kept.get("bundled") is False
+    # Bundled flag set on the kept copy.
+    assert kept.get("bundled") is True
 
-    # The loader emits the specific override warning.
+    # The loader emits the specific warning about the ignored user copy.
     assert (
-        "Bundled plugin 'highway_3d'" in caplog.text
-        and "overridden by user-installed copy" in caplog.text
+        "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
+        and "ignored" in caplog.text
     )
 
 
-def test_bundled_plugin_overridden_by_verbatim_copy_in_same_plugins_dir(
+def test_bundled_plugin_wins_over_verbatim_copy_in_same_plugins_dir(
     tmp_path, reset_plugin_state, caplog
 ):
-    """A user who copies the bundled plugin *verbatim* (keeping ``"bundled": true``)
-    into ``plugins/`` under a **different directory name** is still correctly
-    identified as a user override, not a second bundled copy.
+    """Bundled plugin wins over a verbatim user copy that carries ``"bundled": true``.
 
     The three-part ``_is_bundled()`` check — in-tree directory, manifest field,
-    AND directory-name-matches-plugin-id — is what distinguishes the real core
-    copy from this verbatim clone.
+    AND directory-name-matches-plugin-id — correctly identifies the real core
+    copy and rejects the verbatim clone (dir name ≠ plugin id).
 
     Layout:
       plugins/highway_3d/   ← bundled core (has "bundled": true, dir name == id)
       plugins/zzz-highway/  ← verbatim user copy (has "bundled": true, dir name ≠ id)
 
     ``highway_3d`` sorts before ``zzz-highway``; the bundled copy is encountered
-    first. When the user copy arrives it matches ``kept_is_bundled`` → the user
-    copy evicts the bundled one and is registered as the active plugin.
+    first. When the user copy arrives it is not truly bundled (dir name mismatch)
+    and is discarded with a warning.
     """
     plugins = reset_plugin_state
 
@@ -1203,18 +1179,17 @@ def test_bundled_plugin_overridden_by_verbatim_copy_in_same_plugins_dir(
     hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert len(hw3d_entries) == 1
 
-    # The user copy (zzz-highway) must win even though it also carries "bundled": true.
+    # The real bundled copy (highway_3d) must win; the verbatim clone is discarded.
     kept = hw3d_entries[0]
-    assert str(kept["_dir"]) == str(user_plugin_dir)
+    assert str(kept["_dir"]) == str(bundled_plugin_dir)
 
-    # override flag set; bundled must be False (dir name "zzz-highway" ≠ "highway_3d").
-    assert kept.get("overrides_bundled") is True
-    assert kept.get("bundled") is False
+    # Bundled flag set on the kept copy.
+    assert kept.get("bundled") is True
 
-    # Override warning must be emitted.
+    # Warning about the ignored user copy must be emitted.
     assert (
-        "Bundled plugin 'highway_3d'" in caplog.text
-        and "overridden by user-installed copy" in caplog.text
+        "User-installed copy of bundled plugin 'highway_3d'" in caplog.text
+        and "ignored" in caplog.text
     )
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1395,7 +1395,7 @@ def test_fallback_when_bundled_sorts_first_and_routes_fail(
     assert str(user_plugin_dir) in caplog.text
 
 
-def test_both_bundled_and_fallback_routes_fail_plugin_absent(
+def test_plugin_absent_when_both_routes_fail(
     tmp_path, reset_plugin_state, monkeypatch, caplog
 ):
     """When both bundled routes AND fallback routes fail, plugin is absent from LOADED_PLUGINS.

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -836,7 +836,7 @@ def test_per_plugin_context_does_not_leak_load_sibling_across_plugins(tmp_path, 
     assert fake_app.state.zzz_origin == "zzz"
 
 
-# ── SLOPSMITH_PLUGINS_DIR precedence over bundled in-tree plugins ────────────
+# ── Bundled plugins always win over user-installed copies ────────────────────
 
 def test_bundled_plugin_always_wins_over_slopsmith_plugins_dir_copy(
     tmp_path, reset_plugin_state, monkeypatch, caplog
@@ -1274,6 +1274,63 @@ def test_bundled_wins_with_multiple_stale_copies(
         and "ignored" in caplog.text
         and str(user_plugin_dir) in caplog.text
     )
+
+
+def test_fallback_to_user_copy_when_bundled_routes_fail(
+    tmp_path, reset_plugin_state, monkeypatch, caplog
+):
+    """If a bundled plugin's routes.setup() raises, the loader falls back to
+    the previously-evicted user-installed copy so the server keeps working.
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    # Bundled copy whose routes.setup() will raise.
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    app.state.origin = 'user_fallback'\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        with capture_logger(caplog, "slopsmith.plugins", level=logging.WARNING):
+            plugins.load_plugins(fake_app, {})
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # The fallback user copy should be registered.
+    hw3d_entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert len(hw3d_entries) == 1
+    assert hw3d_entries[0].get("bundled") is False
+    assert str(hw3d_entries[0]["_dir"]) == str(user_plugin_dir)
+
+    # The fallback's routes.setup() should have run.
+    assert getattr(fake_app.state, "origin", None) == "user_fallback"
+
+    # The fallback warning must be logged.
+    assert "falling back to user-installed copy" in caplog.text
+    assert str(user_plugin_dir) in caplog.text
 
 
 def test_bundled_flag_requires_both_in_tree_directory_and_manifest_field(

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1896,6 +1896,11 @@ def test_fallback_proceeds_when_install_requirements_returns_false(
     which skipped the user copy entirely, leaving the bundled-failure error in
     startup-status even when the user copy could have run without those deps.
     (Thread 1, review-4227643820)
+
+    A plugin-error must also be emitted when requirements fail, mirroring the
+    main loop — without it the later clear_error=True makes startup look healthy
+    even though the running plugin may be missing dependencies.
+    (Thread 2, review-4228077246)
     """
     plugins = reset_plugin_state
 
@@ -1928,10 +1933,11 @@ def test_fallback_proceeds_when_install_requirements_returns_false(
 
     fake_app = type("FakeApp", (), {})()
     fake_app.state = type("State", (), {})()
+    events: list = []
     saved_dir = plugins.PLUGINS_DIR
     plugins.PLUGINS_DIR = bundled_dir
     try:
-        plugins.load_plugins(fake_app, {})
+        plugins.load_plugins(fake_app, {}, progress_cb=events.append)
     finally:
         plugins.PLUGINS_DIR = saved_dir
 
@@ -1942,6 +1948,89 @@ def test_fallback_proceeds_when_install_requirements_returns_false(
     entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
     assert entries, "highway_3d must be registered as a fallback"
     assert entries[0].get("fallback") is True
+
+    # A plugin-error must have been emitted for the fallback requirements failure.
+    req_errors = [
+        e for e in events
+        if e.get("phase") == "plugin-error"
+        and e.get("plugin_id") == "highway_3d"
+        and e.get("error")
+    ]
+    assert req_errors, (
+        "Expected at least one plugin-error event for highway_3d fallback requirements failure; "
+        f"events were: {events}"
+    )
+
+
+
+def test_fallback_routes_failure_emits_plugin_error(
+    tmp_path, reset_plugin_state, monkeypatch
+):
+    """When the fallback user-copy's routes also fail, a plugin-error event
+    must be emitted so startup-status reflects the fallback's failure as the
+    root cause.
+
+    Without this, startup-status is left pointing at the earlier bundled-copy
+    error even though that is no longer the active failure, making it harder
+    for operators to identify the correct root cause.
+    (Thread 1, review-4228077246)
+    """
+    plugins = reset_plugin_state
+
+    bundled_dir = tmp_path / "bundled"
+    bundled_dir.mkdir()
+    bundled_plugin_dir = bundled_dir / "highway_3d"
+    bundled_plugin_dir.mkdir()
+    (bundled_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway", "routes": "routes.py", "bundled": True})
+    )
+    (bundled_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('bundled broken')\n"
+    )
+
+    user_dir = tmp_path / "user"
+    user_dir.mkdir()
+    user_plugin_dir = user_dir / "highway_3d"
+    user_plugin_dir.mkdir()
+    (user_plugin_dir / "plugin.json").write_text(
+        json.dumps({"id": "highway_3d", "name": "3D Highway (user)", "routes": "routes.py"})
+    )
+    (user_plugin_dir / "routes.py").write_text(
+        "def setup(app, ctx):\n    raise RuntimeError('fallback also broken')\n"
+    )
+
+    monkeypatch.setenv("SLOPSMITH_PLUGINS_DIR", str(user_dir))
+
+    fake_app = type("FakeApp", (), {})()
+    events: list = []
+    saved_dir = plugins.PLUGINS_DIR
+    plugins.PLUGINS_DIR = bundled_dir
+    try:
+        plugins.load_plugins(fake_app, {}, progress_cb=events.append)
+    finally:
+        plugins.PLUGINS_DIR = saved_dir
+
+    # The plugin must NOT be registered.
+    entries = [p for p in plugins.LOADED_PLUGINS if p["id"] == "highway_3d"]
+    assert not entries, "highway_3d must not be registered when both copies fail"
+
+    # A plugin-error event must have been emitted for the fallback failure.
+    fallback_errors = [
+        e for e in events
+        if e.get("phase") == "plugin-error"
+        and e.get("plugin_id") == "highway_3d"
+        and e.get("error")
+    ]
+    assert fallback_errors, (
+        "Expected at least one plugin-error event when fallback routes also fail; "
+        f"events were: {events}"
+    )
+    # The error message must mention 'Both' or 'fallback' to distinguish it
+    # from the original bundled-failure error.
+    assert any(
+        "fallback" in e["error"].lower() or "both" in e["error"].lower()
+        for e in fallback_errors
+    ), f"plugin-error text should reference the fallback failure; got: {[e['error'] for e in fallback_errors]}"
 
 
 def test_normal_plugins_do_not_have_fallback_field_set(

--- a/tests/test_startup_status.py
+++ b/tests/test_startup_status.py
@@ -539,7 +539,52 @@ def test_startup_status_latest_error_wins_when_same_plugin_emits_multiple(
     )
 
 
-def test_startup_status_e2e_real_plugin_loader(tmp_path, monkeypatch, isolate_logging):
+def test_startup_status_fallback_req_error_not_cleared_by_route_success(
+    monkeypatch, startup_harness
+):
+    """When a fallback copy's requirements installation fails (non-fatal) but its
+    routes succeed, the plugin-registered event must NOT carry error=None — that
+    would wipe the req-failure from _active_errors and make startup look clean
+    even though the active fallback copy has missing dependencies.
+    (Thread 1, review-4228421486)
+    """
+    server, phases = startup_harness
+
+    _EVENTS = [
+        # Bundled plugin fails its routes.
+        {"phase": "plugin-error", "message": "Bundled routes failed",
+         "plugin_id": "highway_3d", "loaded": 0, "total": 1,
+         "error": "bundled routes failure"},
+        # Fallback req install also fails (non-fatal).
+        {"phase": "plugin-error", "message": "Fallback req failed",
+         "plugin_id": "highway_3d", "loaded": 0, "total": 1,
+         "error": "fallback req failure"},
+        # Fallback routes succeed — plugin-registered WITHOUT clear_error
+        # because req failed.  event must NOT carry "error" key.
+        {"phase": "plugin-registered", "message": "Registered fallback",
+         "plugin_id": "highway_3d", "loaded": 1, "total": 1},
+        {"phase": "plugins-complete", "message": "Loaded 1 plugin(s)",
+         "plugin_id": "", "loaded": 1, "total": 1},
+    ]
+
+    def fake_load_plugins(_app, _context, progress_cb=None, route_setup_fn=None):
+        if progress_cb:
+            for event in _EVENTS:
+                progress_cb(event)
+
+    monkeypatch.setattr(server, "load_plugins", fake_load_plugins)
+    asyncio.run(server.startup_events())
+    final = server._get_startup_status()
+
+    # Startup must still report the req-failure error — the fallback succeeded
+    # in loading routes but its dependencies are degraded.
+    assert final["error"] == "fallback req failure", (
+        f"Expected req-failure error to persist after fallback route success, "
+        f"got {final['error']!r}"
+    )
+
+
+
     """Integration: run startup_events() with the REAL load_plugins against a
     minimal test plugin, using the production background-thread code path.
 

--- a/tests/test_startup_status.py
+++ b/tests/test_startup_status.py
@@ -406,6 +406,46 @@ def test_startup_status_plugin_error_cleared_by_explicit_none_progress(monkeypat
     )
 
 
+def test_startup_status_clear_error_does_not_erase_unrelated_plugin_failure(
+    monkeypatch, startup_harness
+):
+    """When plugin A fails and then plugin B's fallback recovery emits
+    error=None, the error set by plugin A must NOT be cleared.
+
+    This exercises the _last_error_plugin_id tracking added in server.py
+    (Thread 2, review-4226937699).  Without that guard, a fallback clear
+    from any plugin would erase all startup-status errors regardless of
+    source, hiding a broken plugin from the user.
+    """
+    server, phases = startup_harness
+
+    # plugin_a fails; plugin_b's fallback succeeds and emits error=None.
+    # plugin_a's error must survive because the clear came from plugin_b.
+    _EVENTS = [
+        {"phase": "plugin-error", "message": "Failed for plugin_a",
+         "plugin_id": "plugin_a", "loaded": 0, "total": 2,
+         "error": "plugin_a route failure"},
+        # plugin_b's fallback recovery — clears *its own* error, not plugin_a's.
+        {"phase": "plugin-registered", "message": "Registered fallback of plugin_b",
+         "plugin_id": "plugin_b", "loaded": 1, "total": 2, "error": None},
+        {"phase": "plugins-complete", "message": "Loaded 1 plugin(s)",
+         "plugin_id": "", "loaded": 1, "total": 2},
+    ]
+
+    def fake_load_plugins(_app, _context, progress_cb=None, route_setup_fn=None):
+        if progress_cb:
+            for event in _EVENTS:
+                progress_cb(event)
+
+    monkeypatch.setattr(server, "load_plugins", fake_load_plugins)
+    asyncio.run(server.startup_events())
+    final = server._get_startup_status()
+
+    # plugin_a's error must still be present — plugin_b's clear must not erase it.
+    assert final["error"] == "plugin_a route failure", (
+        f"plugin_a error should be preserved after plugin_b's clear, got {final['error']!r}"
+    )
+
 
 def test_startup_status_e2e_real_plugin_loader(tmp_path, monkeypatch, isolate_logging):
     """Integration: run startup_events() with the REAL load_plugins against a

--- a/tests/test_startup_status.py
+++ b/tests/test_startup_status.py
@@ -412,7 +412,7 @@ def test_startup_status_clear_error_does_not_erase_unrelated_plugin_failure(
     """When plugin A fails and then plugin B's fallback recovery emits
     error=None, the error set by plugin A must NOT be cleared.
 
-    This exercises the _last_error_plugin_id tracking added in server.py
+    This exercises the _active_errors dict tracking added in server.py
     (Thread 2, review-4226937699).  Without that guard, a fallback clear
     from any plugin would erase all startup-status errors regardless of
     source, hiding a broken plugin from the user.
@@ -444,6 +444,49 @@ def test_startup_status_clear_error_does_not_erase_unrelated_plugin_failure(
     # plugin_a's error must still be present — plugin_b's clear must not erase it.
     assert final["error"] == "plugin_a route failure", (
         f"plugin_a error should be preserved after plugin_b's clear, got {final['error']!r}"
+    )
+
+
+def test_startup_status_two_plugin_errors_one_clears_other_remains(
+    monkeypatch, startup_harness
+):
+    """When two plugins fail and only one recovers via fallback, the other
+    plugin's error must remain visible in startup-status.
+
+    The _last_error single-pointer approach could not handle this case: once
+    plugin B overwrote the pointer, B's subsequent clear_error would wipe
+    the status to None even though A was still broken.  The _active_errors
+    dict correctly removes B and restores A's failure.
+    """
+    server, phases = startup_harness
+
+    _EVENTS = [
+        # Both plugins fail.
+        {"phase": "plugin-error", "message": "Failed for plugin_a",
+         "plugin_id": "plugin_a", "loaded": 0, "total": 2,
+         "error": "plugin_a route failure"},
+        {"phase": "plugin-error", "message": "Failed for plugin_b",
+         "plugin_id": "plugin_b", "loaded": 0, "total": 2,
+         "error": "plugin_b route failure"},
+        # plugin_b's fallback succeeds and clears its own error.
+        {"phase": "plugin-registered", "message": "Registered fallback of plugin_b",
+         "plugin_id": "plugin_b", "loaded": 1, "total": 2, "error": None},
+        {"phase": "plugins-complete", "message": "Loaded 1 plugin(s)",
+         "plugin_id": "", "loaded": 1, "total": 2},
+    ]
+
+    def fake_load_plugins(_app, _context, progress_cb=None, route_setup_fn=None):
+        if progress_cb:
+            for event in _EVENTS:
+                progress_cb(event)
+
+    monkeypatch.setattr(server, "load_plugins", fake_load_plugins)
+    asyncio.run(server.startup_events())
+    final = server._get_startup_status()
+
+    # plugin_a's error must still be present after plugin_b's recovery.
+    assert final["error"] == "plugin_a route failure", (
+        f"plugin_a error should remain after plugin_b recovery, got {final['error']!r}"
     )
 
 

--- a/tests/test_startup_status.py
+++ b/tests/test_startup_status.py
@@ -340,6 +340,73 @@ def test_startup_status_plugin_error_event_preserved_in_complete(monkeypatch, st
     assert endpoint_data["error"] == _FAKE_PLUGIN_ERROR_TEXT
 
 
+def test_startup_status_plugin_error_cleared_by_explicit_null_progress(monkeypatch, startup_harness):
+    """When a plugin-registered event carries explicit error=None after a
+    preceding plugin-error event, the stale error must be cleared from
+    startup-status. This exercises the ``'error' in event`` path in _on_progress
+    which was added to support the bundled-plugin fallback (Thread 4,
+    review-4226783807).
+
+    A regression that checks ``event.get("error") is not None`` instead of
+    ``"error" in event`` would leave the stale bundled-failure error in the
+    status even though the user-copy fallback succeeded.
+    """
+    server, phases = startup_harness
+
+    # Simulate the exact sequence load_plugins emits during a successful
+    # bundled-failure fallback: plugin-error (bundled broken) followed by
+    # plugin-registered with explicit error=None (fallback OK, clear error).
+    _FAKE_FALLBACK_RECOVERY_EVENTS = [
+        {"phase": "plugins-discovered", "message": "Discovered 1 plugin(s)",
+         "plugin_id": "", "loaded": 0, "total": 1},
+        {"phase": "plugin-start", "message": "Loading plugin 'myplug'",
+         "plugin_id": "myplug", "loaded": 0, "total": 1},
+        {"phase": "plugin-requirements", "message": "Installing requirements for 'myplug' (if needed)",
+         "plugin_id": "myplug", "loaded": 0, "total": 1},
+        {"phase": "plugin-error", "message": "Failed loading routes for 'myplug'",
+         "plugin_id": "myplug", "loaded": 0, "total": 1, "error": "bundled routes broken"},
+        # Fallback success: event explicitly carries error=None to clear the stale error.
+        {"phase": "plugin-registered", "message": "Registered fallback copy of plugin 'myplug'",
+         "plugin_id": "myplug", "loaded": 1, "total": 1, "error": None},
+        {"phase": "plugins-complete", "message": "Loaded 1 plugin(s)",
+         "plugin_id": "", "loaded": 1, "total": 1},
+    ]
+
+    def fake_load_plugins(_app, _context, progress_cb=None, route_setup_fn=None):
+        if progress_cb:
+            for event in _FAKE_FALLBACK_RECOVERY_EVENTS:
+                progress_cb(event)
+
+    monkeypatch.setattr(server, "load_plugins", fake_load_plugins)
+    asyncio.run(server.startup_events())
+    final = server._get_startup_status()
+
+    # The plugin-error event sets error; the plugin-registered with error=None
+    # must clear it. If _on_progress only forwards non-null errors, this fails.
+    assert final["error"] is None, (
+        f"Expected error to be cleared by explicit error=None event, got {final['error']!r}"
+    )
+    assert final["phase"] == "complete"
+    assert final["running"] is False
+
+    # Verify via the HTTP endpoint too — a disconnect between the endpoint
+    # handler and _get_startup_status would silently pass the assertion above.
+    async def _fetch_endpoint_data():
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=server.app), base_url="http://test"
+        ) as ac:
+            r = await ac.get("/api/startup-status")
+            return r.json()
+
+    endpoint_data = asyncio.run(_fetch_endpoint_data())
+    assert endpoint_data["phase"] == "complete"
+    assert endpoint_data["running"] is False
+    assert endpoint_data["error"] is None, (
+        f"HTTP endpoint should also show cleared error, got {endpoint_data['error']!r}"
+    )
+
+
+
 def test_startup_status_e2e_real_plugin_loader(tmp_path, monkeypatch, isolate_logging):
     """Integration: run startup_events() with the REAL load_plugins against a
     minimal test plugin, using the production background-thread code path.

--- a/tests/test_startup_status.py
+++ b/tests/test_startup_status.py
@@ -584,7 +584,7 @@ def test_startup_status_fallback_req_error_not_cleared_by_route_success(
     )
 
 
-
+def test_startup_status_e2e_real_plugin_loader(tmp_path, monkeypatch, isolate_logging):
     """Integration: run startup_events() with the REAL load_plugins against a
     minimal test plugin, using the production background-thread code path.
 

--- a/tests/test_startup_status.py
+++ b/tests/test_startup_status.py
@@ -340,7 +340,7 @@ def test_startup_status_plugin_error_event_preserved_in_complete(monkeypatch, st
     assert endpoint_data["error"] == _FAKE_PLUGIN_ERROR_TEXT
 
 
-def test_startup_status_plugin_error_cleared_by_explicit_null_progress(monkeypatch, startup_harness):
+def test_startup_status_plugin_error_cleared_by_explicit_none_progress(monkeypatch, startup_harness):
     """When a plugin-registered event carries explicit error=None after a
     preceding plugin-error event, the stale error must be cleared from
     startup-status. This exercises the ``'error' in event`` path in _on_progress
@@ -364,7 +364,7 @@ def test_startup_status_plugin_error_cleared_by_explicit_null_progress(monkeypat
         {"phase": "plugin-requirements", "message": "Installing requirements for 'myplug' (if needed)",
          "plugin_id": "myplug", "loaded": 0, "total": 1},
         {"phase": "plugin-error", "message": "Failed loading routes for 'myplug'",
-         "plugin_id": "myplug", "loaded": 0, "total": 1, "error": "bundled routes broken"},
+         "plugin_id": "myplug", "loaded": 0, "total": 1, "error": "Failed to load bundled plugin routes"},
         # Fallback success: event explicitly carries error=None to clear the stale error.
         {"phase": "plugin-registered", "message": "Registered fallback copy of plugin 'myplug'",
          "plugin_id": "myplug", "loaded": 1, "total": 1, "error": None},

--- a/tests/test_startup_status.py
+++ b/tests/test_startup_status.py
@@ -490,6 +490,55 @@ def test_startup_status_two_plugin_errors_one_clears_other_remains(
     )
 
 
+def test_startup_status_latest_error_wins_when_same_plugin_emits_multiple(
+    monkeypatch, startup_harness
+):
+    """When the same plugin emits multiple error events (e.g. requirements
+    failure then routes failure), restoring after another plugin clears must
+    surface the *latest* error from the first plugin, not the first one.
+
+    The dict.update()-in-place approach fails here because assigning a key
+    that already exists does NOT move it to the end of insertion order.
+    The fix (pop + re-insert) guarantees remaining[-1] is always the most
+    recently emitted unresolved failure.
+    (Thread 3, review-4228077246)
+    """
+    server, phases = startup_harness
+
+    _EVENTS = [
+        # plugin_a emits two successive errors.
+        {"phase": "plugin-error", "message": "req failure",
+         "plugin_id": "plugin_a", "loaded": 0, "total": 2,
+         "error": "plugin_a requirements failure"},
+        {"phase": "plugin-error", "message": "routes failure",
+         "plugin_id": "plugin_a", "loaded": 0, "total": 2,
+         "error": "plugin_a routes failure"},
+        # plugin_b fails, then recovers — clears only its own error.
+        {"phase": "plugin-error", "message": "Failed for plugin_b",
+         "plugin_id": "plugin_b", "loaded": 1, "total": 2,
+         "error": "plugin_b route failure"},
+        {"phase": "plugin-registered", "message": "Registered fallback of plugin_b",
+         "plugin_id": "plugin_b", "loaded": 2, "total": 2, "error": None},
+        {"phase": "plugins-complete", "message": "Loaded 1 plugin(s)",
+         "plugin_id": "", "loaded": 1, "total": 2},
+    ]
+
+    def fake_load_plugins(_app, _context, progress_cb=None, route_setup_fn=None):
+        if progress_cb:
+            for event in _EVENTS:
+                progress_cb(event)
+
+    monkeypatch.setattr(server, "load_plugins", fake_load_plugins)
+    asyncio.run(server.startup_events())
+    final = server._get_startup_status()
+
+    # After plugin_b clears its own error, plugin_a's *latest* error (routes
+    # failure) should be surfaced — not the earlier requirements failure.
+    assert final["error"] == "plugin_a routes failure", (
+        f"Expected latest plugin_a error after plugin_b recovery, got {final['error']!r}"
+    )
+
+
 def test_startup_status_e2e_real_plugin_loader(tmp_path, monkeypatch, isolate_logging):
     """Integration: run startup_events() with the REAL load_plugins against a
     minimal test plugin, using the production background-thread code path.


### PR DESCRIPTION
Fixes #181

## Problem

When `highway_3d` was promoted to a bundled core plugin, users with an old `slopsmith-plugin-3dhighway` copy in their user plugins dir (or cloned directly into `plugins/`) saw a shadowing warning in the 3D Highway settings panel. The plugin loader was designed to let user-installed copies win, so the bundled version was silently discarded.

## Changes

**`plugins/__init__.py`**
- Reversed the shadowing preference in `load_plugins()`: when a bundled plugin (marked `"bundled": true`, located in `PLUGINS_DIR`, directory name matches plugin id) conflicts with a user-installed copy, the bundled version now evicts the user copy instead of yielding to it.
- Removed the `__overrides_bundled` flag path — no longer needed since bundled always wins.

## Test plan

- [ ] Start slopsmith with an extra `highway_3d/` in `SLOPSMITH_PLUGINS_DIR` — confirm bundled version loads and no warning appears
- [ ] Start slopsmith with a `3dhighway/` directory (same plugin id, different dir name) in plugins/ — confirm bundled version wins
- [ ] Normal startup with no conflicting copies — confirm all plugins register as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)