### PR TITLE
fix: add Save button next to Demucs Server URL field

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -284,7 +284,7 @@
                                     class="flex-1 bg-dark-700 border border-gray-800 rounded-xl px-4 py-2.5 text-sm text-gray-300 placeholder-gray-600 focus:border-accent/50 outline-none">
                                 <button onclick="saveSettings()" class="bg-accent hover:bg-accent-light px-6 py-2.5 rounded-xl text-sm font-semibold text-white transition">Save</button>
                             </div>
-                            <p class="text-xs text-gray-600 mt-1">Optional. Run <a href="https://github.com/byrongamatos/slopsmith-demucs-server" target="_blank" rel="noopener" class="text-accent hover:text-accent-light underline">slopsmith-demucs-server</a> on your desktop for stem splitting without crashing Docker.</p>
+                            <p class="text-xs text-gray-600 mt-1">Optional. Run <a href="https://github.com/byrongamatos/slopsmith-demucs-server" target="_blank" rel="noopener" class="text-accent hover:text-accent-light underline">slopsmith-demucs-server</a> on a machine with a GPU to offload stem splitting and avoid resource exhaustion on the host running Slopsmith.</p>
                         </div>
                         <div>
                             <label class="text-sm font-medium text-gray-400 mb-2 block">Library</label>

--- a/static/index.html
+++ b/static/index.html
@@ -278,7 +278,7 @@
                             <p class="text-xs text-gray-600 mt-1">Removes duplicate entries when your DLC folder contains both _p.psarc (PC) and _m.psarc (Mac) variants of the same song.</p>
                         </div>
                         <div>
-                            <label class="text-sm font-medium text-gray-400 mb-2 block">Demucs Server (for stem separation)</label>
+                            <label for="demucs-server-url" class="text-sm font-medium text-gray-400 mb-2 block">Demucs Server (for stem separation)</label>
                             <div class="flex gap-3">
                                 <input type="text" id="demucs-server-url" placeholder="http://192.168.1.100:7865"
                                     class="flex-1 bg-dark-700 border border-gray-800 rounded-xl px-4 py-2.5 text-sm text-gray-300 placeholder-gray-600 focus:border-accent/50 outline-none">

--- a/static/index.html
+++ b/static/index.html
@@ -284,7 +284,7 @@
                                     class="flex-1 bg-dark-700 border border-gray-800 rounded-xl px-4 py-2.5 text-sm text-gray-300 placeholder-gray-600 focus:border-accent/50 outline-none">
                                 <button onclick="saveSettings()" class="bg-accent hover:bg-accent-light px-6 py-2.5 rounded-xl text-sm font-semibold text-white transition">Save</button>
                             </div>
-                            <p class="text-xs text-gray-600 mt-1">Optional. Run slopsmith-demucs-server on your desktop for stem splitting without crashing Docker.</p>
+                            <p class="text-xs text-gray-600 mt-1">Optional. Run <a href="https://github.com/byrongamatos/slopsmith-demucs-server" target="_blank" rel="noopener" class="text-accent hover:text-accent-light underline">slopsmith-demucs-server</a> on your desktop for stem splitting without crashing Docker.</p>
                         </div>
                         <div>
                             <label class="text-sm font-medium text-gray-400 mb-2 block">Library</label>

--- a/static/index.html
+++ b/static/index.html
@@ -279,8 +279,11 @@
                         </div>
                         <div>
                             <label class="text-sm font-medium text-gray-400 mb-2 block">Demucs Server (for stem separation)</label>
-                            <input type="text" id="demucs-server-url" placeholder="http://192.168.1.100:7865"
-                                class="w-full bg-dark-700 border border-gray-800 rounded-xl px-4 py-2.5 text-sm text-gray-300 placeholder-gray-600 focus:border-accent/50 outline-none">
+                            <div class="flex gap-3">
+                                <input type="text" id="demucs-server-url" placeholder="http://192.168.1.100:7865"
+                                    class="flex-1 bg-dark-700 border border-gray-800 rounded-xl px-4 py-2.5 text-sm text-gray-300 placeholder-gray-600 focus:border-accent/50 outline-none">
+                                <button onclick="saveSettings()" class="bg-accent hover:bg-accent-light px-6 py-2.5 rounded-xl text-sm font-semibold text-white transition">Save</button>
+                            </div>
                             <p class="text-xs text-gray-600 mt-1">Optional. Run slopsmith-demucs-server on your desktop for stem splitting without crashing Docker.</p>
                         </div>
                         <div>


### PR DESCRIPTION
## Summary
- The settings panel had a single Save button next to the DLC path field, but `saveSettings()` actually persists every setting on the panel (DLC, default arrangement, demucs URL, A/V offset, PSARC platform). Users editing the demucs URL had no obvious way to commit the change.
- Mirror the DLC field layout: input + Save button on the same row. Reuses the existing handler — no new endpoint.

## Test plan
- [x] Hard reload, open Settings, type into Demucs Server URL field, click adjacent Save — value persists across reload
- [x] DLC Save button still works
- [x] Other fields (default arrangement, PSARC platform) still saved by either Save button click

A future PR will add a Test button next to the field once slopsmith-demucs-server gains a /health route (separate issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)