### PR TITLE
feat(3D Highway): toggle for static fret-inlay number labels

### DIFF
--- a/plugins/highway_3d/plugin.json
+++ b/plugins/highway_3d/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "highway_3d",
     "name": "3D Highway",
-    "version": "3.11.0",
+    "version": "3.12.0",
     "type": "visualization",
     "bundled": true,
     "script": "screen.js",

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -396,7 +396,7 @@
         return _bgBandsCache;
     }
 
-    const BG_DEFAULTS = { style: 'particles', intensity: 0.5, reactive: true, palette: 'default', showFretOnNote: false, cameraSmoothing: 0.5, zoomSmoothing: 0.5, tiltSmoothing: 0.5, cameraLockLow: false, cameraLockZoom: 0.5, textSize: 0.5, vibrancy: 0.85, glow: 0.25, customImageDataUrl: '', customImageName: '', customVideoName: '', chordDiagramSize: 0.5, chordDiagramPosition: 'tl', fretColumnMarkerCadence: 4 };
+    const BG_DEFAULTS = { style: 'particles', intensity: 0.5, reactive: true, palette: 'default', showFretOnNote: false, cameraSmoothing: 0.5, zoomSmoothing: 0.5, tiltSmoothing: 0.5, cameraLockLow: false, cameraLockZoom: 0.5, textSize: 0.5, vibrancy: 0.85, glow: 0.25, customImageDataUrl: '', customImageName: '', customVideoName: '', chordDiagramSize: 0.5, chordDiagramPosition: 'tl', fretColumnMarkerCadence: 4, inlayLabelsVisible: true };
     const BG_STYLE_IDS = ['off', 'particles', 'silhouettes', 'lights', 'geometric', 'image', 'video'];
 
     function _bgPanelKey(canvas) {
@@ -434,7 +434,7 @@
     // means (fall back to default rather than silently flipping to
     // false). Add new boolean keys to BG_DEFAULTS and they pick this
     // up via the dispatch below.
-    const _BG_BOOL_KEYS = new Set(['reactive', 'showFretOnNote', 'cameraLockLow']);
+    const _BG_BOOL_KEYS = new Set(['reactive', 'showFretOnNote', 'cameraLockLow', 'inlayLabelsVisible']);
     function _bgCoerceBool(val, fallback) {
         if (val === 'true' || val === '1') return true;
         if (val === 'false' || val === '0') return false;
@@ -520,6 +520,7 @@
     window.h3dBgSetChordDiagramSize     = (v) => _bgWriteGlobal('chordDiagramSize', v);
     window.h3dBgSetChordDiagramPosition = (v) => _bgWriteGlobal('chordDiagramPosition', v);
     window.h3dBgSetFretColumnMarkerCadence = (v) => _bgWriteGlobal('fretColumnMarkerCadence', v);
+    window.h3dBgSetInlayLabelsVisible = (v) => _bgWriteGlobal('inlayLabelsVisible', !!v);
     // Custom image asset for the 'image' bg style (#19). Composite setter:
     // writes both the data URL (the bytes that drive the texture) and the
     // display filename, each emitting a change event. The listener
@@ -1397,6 +1398,7 @@
         let chordDiagramSize     = BG_DEFAULTS.chordDiagramSize;
         let chordDiagramPosition = BG_DEFAULTS.chordDiagramPosition;
         let fretColumnMarkerCadence = BG_DEFAULTS.fretColumnMarkerCadence;
+        let inlayLabelsVisible = BG_DEFAULTS.inlayLabelsVisible;
         let _vibrancyIdleOp = 0.4  + 0.6  * BG_DEFAULTS.vibrancy;
         let _vibrancyProjOp = 0.15 + 0.35 * BG_DEFAULTS.vibrancy;
         // Custom image asset (issue #19). Data URL is the bytes that
@@ -2383,6 +2385,10 @@
             // slider.
             _applyVibrancy();
             _applyGlow();
+            // buildBoard() ran above with the default inlayLabelsVisible,
+            // before _bgLoadSettings populated the user-stored value.
+            // Sync now so first-frame state matches the stored setting.
+            for (const lbl of _inlayLabels) lbl.visible = inlayLabelsVisible;
             bgGroup = new T.Group();
             // Note: renderOrder on a Group is a no-op (Three.js Groups
             // are transforms, not rendered objects, so renderOrder only
@@ -2394,6 +2400,14 @@
             scene.add(bgGroup);
             _bgMountStyle();
             _bgListener = (changedKey) => {
+                if (changedKey === 'inlayLabelsVisible') {
+                    _bgLoadSettings();
+                    // Flip visibility on the already-built sprites; no
+                    // need to rebuild the board (cheaper, preserves the
+                    // shared materials and avoids palette re-apply churn).
+                    for (const lbl of _inlayLabels) lbl.visible = inlayLabelsVisible;
+                    return;
+                }
                 if (changedKey === 'reactive' || changedKey === 'showFretOnNote' ||
                     changedKey === 'cameraSmoothing' || changedKey === 'zoomSmoothing' ||
                     changedKey === 'tiltSmoothing' || changedKey === 'cameraLockLow' ||
@@ -2593,6 +2607,7 @@
             chordDiagramSize     = _bgReadSetting(panelKey, 'chordDiagramSize');
             chordDiagramPosition = _bgReadSetting(panelKey, 'chordDiagramPosition');
             fretColumnMarkerCadence = _bgReadSetting(panelKey, 'fretColumnMarkerCadence');
+            inlayLabelsVisible = _bgReadSetting(panelKey, 'inlayLabelsVisible');
             _vibrancyIdleOp = 0.4  + 0.6  * vibrancy;
             _vibrancyProjOp = 0.15 + 0.35 * vibrancy;
             // Custom image asset is a single GLOBAL slot — bytes are
@@ -2937,6 +2952,7 @@
                 const scale = 5.5 * (0.5 + textSize);
                 lbl.scale.set(scale * K, scale * K, 1);
                 lbl.position.set(fretMid(f), yTop - S_GAP * 0.4, -K);
+                lbl.visible = inlayLabelsVisible;
                 fretG.add(lbl);
                 _inlayLabels.push(lbl);
                 _inlayMats.push(mat);

--- a/plugins/highway_3d/settings.html
+++ b/plugins/highway_3d/settings.html
@@ -398,8 +398,8 @@
         <p class="text-[10px] text-gray-500 mt-1 ml-6">
             Teal numbers (3, 5, 7, 9, 12, 15, 17, 19, 22, 24) painted
             between the strings on the fretboard at the standard inlay
-            positions. Always visible; doesn't scroll. Independent of
-            the rolling fret-column markers above.
+            positions. When visible, they stay fixed (don't scroll).
+            Independent of the rolling fret-column markers above.
         </p>
     </div>
 

--- a/plugins/highway_3d/settings.html
+++ b/plugins/highway_3d/settings.html
@@ -384,6 +384,25 @@
         </p>
     </div>
 
+    <!-- Static inlay fret-number labels on the fretboard.
+         UI is inverted-polarity for clarity: checking the box hides
+         the labels. Storage stays `inlayLabelsVisible` (true=visible)
+         so the renderer reads the natural-direction flag. -->
+    <div class="mt-4">
+        <label class="flex items-center gap-2 text-xs text-gray-300 cursor-pointer">
+            <input type="checkbox" id="h3d-inlay-labels-visible"
+                   onchange="window.h3dBgSetInlayLabelsVisible && window.h3dBgSetInlayLabelsVisible(!this.checked)"
+                   class="accent-accent">
+            Hide static fret-inlay number labels
+        </label>
+        <p class="text-[10px] text-gray-500 mt-1 ml-6">
+            Teal numbers (3, 5, 7, 9, 12, 15, 17, 19, 22, 24) painted
+            between the strings on the fretboard at the standard inlay
+            positions. Always visible; doesn't scroll. Independent of
+            the rolling fret-column markers above.
+        </p>
+    </div>
+
     <!-- Hydrate from localStorage on load. Mirror runtime defaults AND
          coercion rules from screen.js's BG_DEFAULTS / _bgCoerce so first-
          run users see what the renderer actually drew, and any garbage
@@ -392,7 +411,7 @@
          no-selection / NaN state. -->
     <script>
         (function () {
-            const DEFAULTS = { style: 'particles', intensity: 0.5, reactive: true, palette: 'default', showFretOnNote: false, cameraSmoothing: 0.5, zoomSmoothing: 0.5, tiltSmoothing: 0.5, cameraLockLow: false, cameraLockZoom: 0.5, textSize: 0.5, vibrancy: 0.85, glow: 0.25, customImageDataUrl: '', customImageName: '', customVideoName: '', chordDiagramSize: 0.5, chordDiagramPosition: 'tl', fretColumnMarkerCadence: 4 };
+            const DEFAULTS = { style: 'particles', intensity: 0.5, reactive: true, palette: 'default', showFretOnNote: false, cameraSmoothing: 0.5, zoomSmoothing: 0.5, tiltSmoothing: 0.5, cameraLockLow: false, cameraLockZoom: 0.5, textSize: 0.5, vibrancy: 0.85, glow: 0.25, customImageDataUrl: '', customImageName: '', customVideoName: '', chordDiagramSize: 0.5, chordDiagramPosition: 'tl', fretColumnMarkerCadence: 4, inlayLabelsVisible: true };
             const VALID_STYLES = new Set(['off', 'particles', 'silhouettes', 'lights', 'geometric', 'image', 'video']);
             const VALID_PALETTES = new Set(['default', 'neon', 'pastel']);
             const VALID_CHORD_DIAG_POSITIONS = new Set(['tl', 'tr', 'bl', 'br']);
@@ -489,6 +508,7 @@
             let storedChordDiagramSize = null;
             let storedChordDiagramPosition = null;
             let storedFretColumnMarkerCadence = null;
+            let storedInlayLabelsVisible = null;
             try {
                 storedStyle = localStorage.getItem('h3d_bg_style');
                 storedI = localStorage.getItem('h3d_bg_intensity');
@@ -506,6 +526,7 @@
                 storedChordDiagramSize = localStorage.getItem('h3d_bg_chordDiagramSize');
                 storedChordDiagramPosition = localStorage.getItem('h3d_bg_chordDiagramPosition');
                 storedFretColumnMarkerCadence = localStorage.getItem('h3d_bg_fretColumnMarkerCadence');
+                storedInlayLabelsVisible = localStorage.getItem('h3d_bg_inlayLabelsVisible');
                 storedCustomImageDataUrl = localStorage.getItem('h3d_bg_customImageDataUrl');
                 storedCustomImageName = localStorage.getItem('h3d_bg_customImageName');
                 storedCustomVideoName = localStorage.getItem('h3d_bg_customVideoName');
@@ -549,6 +570,7 @@
             const fretColumnMarkerCadence = (storedFretColumnMarkerCadence == null)
                 ? DEFAULTS.fretColumnMarkerCadence
                 : coerceCadence(storedFretColumnMarkerCadence);
+            const inlayLabelsVisible = coerceBool(storedInlayLabelsVisible, DEFAULTS.inlayLabelsVisible);
             const customImageDataUrl = (typeof storedCustomImageDataUrl === 'string') ? storedCustomImageDataUrl : DEFAULTS.customImageDataUrl;
             const customImageName    = (typeof storedCustomImageName === 'string')    ? storedCustomImageName    : DEFAULTS.customImageName;
             const customVideoName    = (typeof storedCustomVideoName === 'string')    ? storedCustomVideoName    : DEFAULTS.customVideoName;
@@ -578,6 +600,7 @@
             const cdslbl= document.getElementById('h3d-chord-diagram-size-label');
             const cdpos = document.getElementById('h3d-chord-diagram-position');
             const fcmc  = document.getElementById('h3d-fret-column-marker-cadence');
+            const ilv   = document.getElementById('h3d-inlay-labels-visible');
             const fileInput = document.getElementById('h3d-bg-custom-image-file');
             const clearBtn  = document.getElementById('h3d-bg-custom-image-clear');
             const nameP     = document.getElementById('h3d-bg-custom-image-name');
@@ -610,6 +633,7 @@
             if (cdslbl) cdslbl.textContent = chordDiagramSize.toFixed(2);
             if (cdpos) cdpos.value  = chordDiagramPosition;
             if (fcmc)  fcmc.value   = String(fretColumnMarkerCadence);
+            if (ilv)   ilv.checked  = !inlayLabelsVisible;
 
             // Palette preview swatches. Mirror of PALETTES in screen.js —
             // KEEP IN SYNC. Settings panel paints these from the dropdown


### PR DESCRIPTION
## Summary

Adds a settings checkbox in the 3D Highway panel to hide the static fret-inlay number labels introduced in #179. Some users prefer a cleaner fretboard and already use the dynamic fret-row labels at the hit line for orientation, so the inlay numbers can feel redundant.

The checkbox uses **inverted polarity** for clarity — labelled "Hide static fret-inlay number labels". Storage stays `inlayLabelsVisible` (true = visible) so the renderer reads a natural-direction flag; the inversion only happens in the checkbox onchange / hydrate path.

**Default behaviour: labels shown** (matches the post-#179 default — opt-out, not opt-in).

## Implementation

- New `BG_DEFAULTS.inlayLabelsVisible = true` + `_BG_BOOL_KEYS` entry.
- New setter `window.h3dBgSetInlayLabelsVisible`.
- New module var `inlayLabelsVisible` + read in `_bgLoadSettings`.
- `_bgListener` handles `inlayLabelsVisible` separately: flips `.visible` on each entry in `_inlayLabels` instead of rebuilding the board. Preserves the cloned materials, skips palette re-apply churn.
- `buildBoard()` sets initial `lbl.visible = inlayLabelsVisible` per sprite.
- Bootstrap-order fix: `buildBoard()` runs first with the default, then `_bgLoadSettings()` populates the persisted value. A sync pass right after `_bgLoadSettings()` in `initScene()` corrects any persisted-hidden state before the first frame — without it, a user who had the labels off would see them flash back on for one frame on every reload.
- settings.html: `DEFAULTS` update, storage read, `coerceBool` hydrate (inverted for the UI polarity), checkbox row under the Chord Diagram section next to the rolling fret-column markers cadence.

## Files

- [plugins/highway_3d/screen.js](plugins/highway_3d/screen.js)
- [plugins/highway_3d/settings.html](plugins/highway_3d/settings.html)
- [plugins/highway_3d/plugin.json](plugins/highway_3d/plugin.json) — version 3.11.0 → 3.12.0

## Test plan

- [x] Default install: labels visible. Check the "Hide" box → labels disappear live (no reload).
- [x] Uncheck → labels reappear.
- [x] Hard reload with box checked → labels stay hidden on first frame, no flash.
- [x] Hard reload with box unchecked → labels visible.
- [x] Splitscreen panels: each instance honors the same global flag.
- [x] Palette change → board rebuilds, labels honor current flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)