### PR TITLE
Fix/song volume

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2639,14 +2639,17 @@ let _resetJuceAudioShimChain = function () {};
         const gen = _juceShimGen;
         const p = chain.then(async () => {
             if (gen !== _juceShimGen) return;
-            return fn();
+            return fn(gen);
         });
         chain = p.catch((e) => {
             console.warn('[juce-audio-shim]', e);
         });
         return p;
     }
-    function flushJuceShimBatchNow() {
+    // forUpcomingPlay: caller will enqueue a play() right after, so don't
+    // emit pause-state side effects for a wantsPause batch — play() will
+    // overwrite them anyway.
+    function flushJuceShimBatchNow({ forUpcomingPlay = false } = {}) {
         _juceShimBatchFlushScheduled = false;
         const batch = _juceShimBatch;
         _juceShimBatch = null;
@@ -2654,15 +2657,28 @@ let _resetJuceAudioShimChain = function () {};
         const wantsPause = !!batch.wantsPause;
         const seekTime = batch.seekTime;
         if (wantsPause && seekTime !== undefined) {
-            enqueue(async () => {
+            enqueue(async (gen) => {
                 await jucePlayer.seek(seekTime);
+                if (gen !== _juceShimGen) return;
+                if (!forUpcomingPlay) {
+                    await jucePlayer.pause();
+                    if (gen !== _juceShimGen) return;
+                    isPlaying = false;
+                    document.getElementById('btn-play').textContent = '▶ Play';
+                    const sm = window.slopsmith;
+                    if (sm) {
+                        sm.isPlaying = false;
+                        sm.emit('song:pause', { time: jucePlayer.currentTime });
+                    }
+                }
                 audio.dispatchEvent(new Event('seeked'));
             });
             return;
         }
         if (wantsPause) {
-            enqueue(async () => {
+            enqueue(async (gen) => {
                 await jucePlayer.pause();
+                if (gen !== _juceShimGen) return;
                 isPlaying = false;
                 document.getElementById('btn-play').textContent = '▶ Play';
                 const sm = window.slopsmith;
@@ -2674,8 +2690,9 @@ let _resetJuceAudioShimChain = function () {};
             return;
         }
         if (seekTime !== undefined) {
-            enqueue(async () => {
+            enqueue(async (gen) => {
                 await jucePlayer.seek(seekTime);
+                if (gen !== _juceShimGen) return;
                 audio.dispatchEvent(new Event('seeked'));
             });
         }
@@ -2737,17 +2754,16 @@ let _resetJuceAudioShimChain = function () {};
 
     audio.play = function () {
         if (window._juceMode) {
-            if (_juceShimBatch != null) flushJuceShimBatchNow();
-            const p = enqueue(async () => {
+            if (_juceShimBatch != null) flushJuceShimBatchNow({ forUpcomingPlay: true });
+            const p = enqueue(async (gen) => {
                 const started = await jucePlayer.play();
-                if (started) {
-                    isPlaying = true;
-                    document.getElementById('btn-play').textContent = '⏸ Pause';
-                    const sm = window.slopsmith;
-                    if (sm) {
-                        sm.isPlaying = true;
-                        sm.emit('song:play', { time: jucePlayer.currentTime });
-                    }
+                if (gen !== _juceShimGen || !started) return;
+                isPlaying = true;
+                document.getElementById('btn-play').textContent = '⏸ Pause';
+                const sm = window.slopsmith;
+                if (sm) {
+                    sm.isPlaying = true;
+                    sm.emit('song:play', { time: jucePlayer.currentTime });
                 }
             });
             return p.then(() => undefined);
@@ -2866,12 +2882,16 @@ async function playSong(filename, arrangement) {
     artAbortController = null;
 
     highway.stop();
+    // Reset the JUCE shim BEFORE awaiting jucePlayer.stop() so any in-flight
+    // shim closures see a stale generation after their await and bail out
+    // before mutating isPlaying / button label / song:* events for the
+    // outgoing song.
+    _resetJuceAudioShimChain();
     if (window._juceMode) {
         await jucePlayer.stop().catch(() => {});
         window._juceMode = false;
         window._juceAudioUrl = null;
     }
-    _resetJuceAudioShimChain();
     audio.pause();
     audio.src = '';
     isPlaying = false;

--- a/static/app.js
+++ b/static/app.js
@@ -2616,7 +2616,8 @@ window.jucePlayer = jucePlayer;
 
 // Desktop JUCE backing uses an empty <audio> element; plugins such as Section Map
 // still seek via audio.currentTime / pause / play. Mirror those onto jucePlayer
-// while _juceMode is active, and serialize ops so pause→seek→(seeked→play) works.
+// while _juceMode is active. Same-tick pause+seek coalesce into a single seek
+// (no stopBacking before seek — HTML5 needed that for buffering; JUCE does not).
 let _resetJuceAudioShimChain = function () {};
 (function _installJuceAudioElementShim() {
     if (!window.slopsmithDesktop?.audio) return;
@@ -2630,6 +2631,9 @@ let _resetJuceAudioShimChain = function () {};
     const nativePause = mediaProto.pause;
 
     let chain = Promise.resolve();
+    /** Same-tick pause + seek (Section Map): coalesce to one seek — no stopBacking before seek. */
+    let _juceShimBatch = null;
+    let _juceShimBatchFlushScheduled = false;
     function enqueue(fn) {
         const p = chain.then(fn);
         chain = p.catch((e) => {
@@ -2637,8 +2641,48 @@ let _resetJuceAudioShimChain = function () {};
         });
         return p;
     }
+    function scheduleJuceShimBatchFlush() {
+        if (_juceShimBatchFlushScheduled) return;
+        _juceShimBatchFlushScheduled = true;
+        queueMicrotask(() => {
+            _juceShimBatchFlushScheduled = false;
+            const batch = _juceShimBatch;
+            _juceShimBatch = null;
+            if (!batch || !window._juceMode) return;
+            const wantsPause = !!batch.wantsPause;
+            const seekTime = batch.seekTime;
+            if (wantsPause && seekTime !== undefined) {
+                enqueue(async () => {
+                    await jucePlayer.seek(seekTime);
+                    audio.dispatchEvent(new Event('seeked'));
+                });
+                return;
+            }
+            if (wantsPause) {
+                enqueue(async () => {
+                    await jucePlayer.pause();
+                    isPlaying = false;
+                    document.getElementById('btn-play').textContent = '▶ Play';
+                    const sm = window.slopsmith;
+                    if (sm) {
+                        sm.isPlaying = false;
+                        sm.emit('song:pause', { time: jucePlayer.currentTime });
+                    }
+                });
+                return;
+            }
+            if (seekTime !== undefined) {
+                enqueue(async () => {
+                    await jucePlayer.seek(seekTime);
+                    audio.dispatchEvent(new Event('seeked'));
+                });
+            }
+        });
+    }
     _resetJuceAudioShimChain = function () {
         chain = Promise.resolve();
+        _juceShimBatch = null;
+        _juceShimBatchFlushScheduled = false;
     };
 
     Object.defineProperty(audio, 'currentTime', {
@@ -2649,10 +2693,9 @@ let _resetJuceAudioShimChain = function () {};
         set(v) {
             if (window._juceMode) {
                 const t = Math.max(0, Number(v) || 0);
-                enqueue(async () => {
-                    await jucePlayer.seek(t);
-                    audio.dispatchEvent(new Event('seeked'));
-                });
+                _juceShimBatch = _juceShimBatch || {};
+                _juceShimBatch.seekTime = t;
+                scheduleJuceShimBatchFlush();
                 return;
             }
             ctDesc.set.call(this, v);
@@ -2670,16 +2713,9 @@ let _resetJuceAudioShimChain = function () {};
 
     audio.pause = function () {
         if (window._juceMode) {
-            enqueue(async () => {
-                await jucePlayer.pause();
-                isPlaying = false;
-                document.getElementById('btn-play').textContent = '▶ Play';
-                const sm = window.slopsmith;
-                if (sm) {
-                    sm.isPlaying = false;
-                    sm.emit('song:pause', { time: jucePlayer.currentTime });
-                }
-            });
+            _juceShimBatch = _juceShimBatch || {};
+            _juceShimBatch.wantsPause = true;
+            scheduleJuceShimBatchFlush();
             return;
         }
         nativePause.call(audio);

--- a/static/app.js
+++ b/static/app.js
@@ -2614,6 +2614,97 @@ const jucePlayer = {
 };
 window.jucePlayer = jucePlayer;
 
+// Desktop JUCE backing uses an empty <audio> element; plugins such as Section Map
+// still seek via audio.currentTime / pause / play. Mirror those onto jucePlayer
+// while _juceMode is active, and serialize ops so pause→seek→(seeked→play) works.
+let _resetJuceAudioShimChain = function () {};
+(function _installJuceAudioElementShim() {
+    if (!window.slopsmithDesktop?.audio) return;
+
+    const mediaProto = HTMLMediaElement.prototype;
+    const ctDesc = Object.getOwnPropertyDescriptor(mediaProto, 'currentTime');
+    const pausedDesc = Object.getOwnPropertyDescriptor(mediaProto, 'paused');
+    if (!ctDesc?.get || !ctDesc?.set || !pausedDesc?.get) return;
+
+    const nativePlay = mediaProto.play;
+    const nativePause = mediaProto.pause;
+
+    let chain = Promise.resolve();
+    function enqueue(fn) {
+        const p = chain.then(fn);
+        chain = p.catch((e) => {
+            console.warn('[juce-audio-shim]', e);
+        });
+        return p;
+    }
+    _resetJuceAudioShimChain = function () {
+        chain = Promise.resolve();
+    };
+
+    Object.defineProperty(audio, 'currentTime', {
+        get() {
+            if (window._juceMode) return jucePlayer.currentTime;
+            return ctDesc.get.call(this);
+        },
+        set(v) {
+            if (window._juceMode) {
+                const t = Math.max(0, Number(v) || 0);
+                enqueue(async () => {
+                    await jucePlayer.seek(t);
+                    audio.dispatchEvent(new Event('seeked'));
+                });
+                return;
+            }
+            ctDesc.set.call(this, v);
+        },
+        configurable: true,
+    });
+
+    Object.defineProperty(audio, 'paused', {
+        get() {
+            if (window._juceMode) return !isPlaying;
+            return pausedDesc.get.call(this);
+        },
+        configurable: true,
+    });
+
+    audio.pause = function () {
+        if (window._juceMode) {
+            enqueue(async () => {
+                await jucePlayer.pause();
+                isPlaying = false;
+                document.getElementById('btn-play').textContent = '▶ Play';
+                const sm = window.slopsmith;
+                if (sm) {
+                    sm.isPlaying = false;
+                    sm.emit('song:pause', { time: jucePlayer.currentTime });
+                }
+            });
+            return;
+        }
+        nativePause.call(audio);
+    };
+
+    audio.play = function () {
+        if (window._juceMode) {
+            const p = enqueue(async () => {
+                const started = await jucePlayer.play();
+                if (started) {
+                    isPlaying = true;
+                    document.getElementById('btn-play').textContent = '⏸ Pause';
+                    const sm = window.slopsmith;
+                    if (sm) {
+                        sm.isPlaying = true;
+                        sm.emit('song:play', { time: jucePlayer.currentTime });
+                    }
+                }
+            });
+            return p.then(() => undefined);
+        }
+        return nativePlay.call(audio);
+    };
+})();
+
 function _audioTime() { return window._juceMode ? jucePlayer.currentTime : audio.currentTime; }
 function _audioDuration() { return window._juceMode ? jucePlayer.duration : audio.duration; }
 async function _audioSeek(s) {
@@ -2729,6 +2820,7 @@ async function playSong(filename, arrangement) {
         window._juceMode = false;
         window._juceAudioUrl = null;
     }
+    _resetJuceAudioShimChain();
     audio.pause();
     audio.src = '';
     isPlaying = false;

--- a/static/app.js
+++ b/static/app.js
@@ -2634,55 +2634,69 @@ let _resetJuceAudioShimChain = function () {};
     /** Same-tick pause + seek (Section Map): coalesce to one seek — no stopBacking before seek. */
     let _juceShimBatch = null;
     let _juceShimBatchFlushScheduled = false;
+    let _juceShimGen = 0;
     function enqueue(fn) {
-        const p = chain.then(fn);
+        const gen = _juceShimGen;
+        const p = chain.then(async () => {
+            if (gen !== _juceShimGen) return;
+            return fn();
+        });
         chain = p.catch((e) => {
             console.warn('[juce-audio-shim]', e);
         });
         return p;
     }
+    function flushJuceShimBatchNow() {
+        _juceShimBatchFlushScheduled = false;
+        const batch = _juceShimBatch;
+        _juceShimBatch = null;
+        if (!batch || !window._juceMode) return;
+        const wantsPause = !!batch.wantsPause;
+        const seekTime = batch.seekTime;
+        if (wantsPause && seekTime !== undefined) {
+            enqueue(async () => {
+                await jucePlayer.seek(seekTime);
+                audio.dispatchEvent(new Event('seeked'));
+            });
+            return;
+        }
+        if (wantsPause) {
+            enqueue(async () => {
+                await jucePlayer.pause();
+                isPlaying = false;
+                document.getElementById('btn-play').textContent = '▶ Play';
+                const sm = window.slopsmith;
+                if (sm) {
+                    sm.isPlaying = false;
+                    sm.emit('song:pause', { time: jucePlayer.currentTime });
+                }
+            });
+            return;
+        }
+        if (seekTime !== undefined) {
+            enqueue(async () => {
+                await jucePlayer.seek(seekTime);
+                audio.dispatchEvent(new Event('seeked'));
+            });
+        }
+    }
     function scheduleJuceShimBatchFlush() {
         if (_juceShimBatchFlushScheduled) return;
         _juceShimBatchFlushScheduled = true;
+        const flushGen = _juceShimGen;
         queueMicrotask(() => {
-            _juceShimBatchFlushScheduled = false;
-            const batch = _juceShimBatch;
-            _juceShimBatch = null;
-            if (!batch || !window._juceMode) return;
-            const wantsPause = !!batch.wantsPause;
-            const seekTime = batch.seekTime;
-            if (wantsPause && seekTime !== undefined) {
-                enqueue(async () => {
-                    await jucePlayer.seek(seekTime);
-                    audio.dispatchEvent(new Event('seeked'));
-                });
+            if (flushGen !== _juceShimGen) {
+                _juceShimBatchFlushScheduled = false;
                 return;
             }
-            if (wantsPause) {
-                enqueue(async () => {
-                    await jucePlayer.pause();
-                    isPlaying = false;
-                    document.getElementById('btn-play').textContent = '▶ Play';
-                    const sm = window.slopsmith;
-                    if (sm) {
-                        sm.isPlaying = false;
-                        sm.emit('song:pause', { time: jucePlayer.currentTime });
-                    }
-                });
-                return;
-            }
-            if (seekTime !== undefined) {
-                enqueue(async () => {
-                    await jucePlayer.seek(seekTime);
-                    audio.dispatchEvent(new Event('seeked'));
-                });
-            }
+            flushJuceShimBatchNow();
         });
     }
     _resetJuceAudioShimChain = function () {
         chain = Promise.resolve();
         _juceShimBatch = null;
         _juceShimBatchFlushScheduled = false;
+        _juceShimGen++;
     };
 
     Object.defineProperty(audio, 'currentTime', {
@@ -2723,6 +2737,7 @@ let _resetJuceAudioShimChain = function () {};
 
     audio.play = function () {
         if (window._juceMode) {
+            if (_juceShimBatch != null) flushJuceShimBatchNow();
             const p = enqueue(async () => {
                 const started = await jucePlayer.play();
                 if (started) {

--- a/static/audio-mixer.js
+++ b/static/audio-mixer.js
@@ -53,6 +53,14 @@ function _writeSongVolume(v) {
     _songVolumeMemory = normalized;
     const a = _audioEl();
     if (a) a.volume = normalized / 100;
+    // Desktop + JUCE: song audio is mixed in the native engine; HTML5 volume is ignored.
+    const linear = normalized / 100;
+    if (window._juceMode) {
+        const setGain = window.slopsmithDesktop?.audio?.setGain;
+        if (typeof setGain === 'function') {
+            Promise.resolve(setGain('backing', linear)).catch(function () { /* IPC unavailable */ });
+        }
+    }
     try {
         localStorage.setItem('volume', String(normalized));
     } catch (e) {

--- a/static/highway.js
+++ b/static/highway.js
@@ -2170,7 +2170,16 @@ function createHighway() {
                                                         }
                                                         if (!Number.isFinite(songPct)) songPct = 80;
                                                         songPct = Math.min(100, Math.max(0, songPct));
-                                                        await juceApi.setGain('backing', songPct / 100);
+                                                        // Don't let setGain failures flip routing back to HTML5 —
+                                                        // the backing track already loaded successfully. Wrap in
+                                                        // its own try/catch and re-check generation after the
+                                                        // await so a reconnect mid-flight can't apply stale state.
+                                                        try {
+                                                            await juceApi.setGain('backing', songPct / 100);
+                                                        } catch (gainErr) {
+                                                            console.warn('[highway] JUCE setGain backing failed', gainErr);
+                                                        }
+                                                        if (gen !== _wsGen) return; // stale
                                                         // Clear the HTML5 element so it does not buffer an unused track
                                                         audio.src = '';
                                                         return;

--- a/static/highway.js
+++ b/static/highway.js
@@ -2156,6 +2156,17 @@ function createHighway() {
                                                         if (gen !== _wsGen) return; // stale
                                                         window._juceMode = true;
                                                         window._juceAudioUrl = audioUrl;
+                                                        // Match native backing gain to the Song mixer / persisted volume
+                                                        // (default engine backing is ~0.7 linear; HTML path uses audio.volume).
+                                                        let songPct = window.slopsmith?.audio?.readSongVolume?.();
+                                                        if (!Number.isFinite(songPct)) {
+                                                            try {
+                                                                songPct = parseFloat(localStorage.getItem('volume'));
+                                                            } catch (_e) { songPct = NaN; }
+                                                        }
+                                                        if (!Number.isFinite(songPct)) songPct = 80;
+                                                        songPct = Math.min(100, Math.max(0, songPct));
+                                                        await juceApi.setGain('backing', songPct / 100);
                                                         // Clear the HTML5 element so it does not buffer an unused track
                                                         audio.src = '';
                                                         return;

--- a/static/index.html
+++ b/static/index.html
@@ -434,7 +434,7 @@
             <div id="mixer-control">
                 <div id="mixer-anchor" class="relative">
                     <button id="btn-mixer" type="button" onclick="window.slopsmith.audio.toggleMixer()" class="px-3 py-1.5 bg-dark-600 hover:bg-dark-500 rounded-lg text-xs text-gray-300 transition" aria-haspopup="true" aria-expanded="false" aria-controls="mixer-popover" title="Audio mixer">Mixer ▾</button>
-                    <div id="mixer-popover" class="hidden absolute right-0 bottom-full mb-2 z-50 bg-dark-700 border border-gray-800 rounded-xl shadow-xl p-3" role="group" aria-label="Audio mixer"></div>
+                    <div id="mixer-popover" class="hidden absolute right-0 bottom-full mb-2 z-50 bg-dark-700 border border-gray-800 rounded-xl shadow-xl" role="group" aria-label="Audio mixer"></div>
                 </div>
             </div>
             <button onclick="highway.toggleLyrics()" id="btn-lyrics" class="px-3 py-1.5 bg-purple-900/40 hover:bg-purple-900/60 rounded-lg text-xs text-purple-300 transition">Lyrics ✓</button>

--- a/static/style.css
+++ b/static/style.css
@@ -396,9 +396,33 @@ html { scroll-behavior: smooth; }
 }
 #lib-filter-chips .chip button:hover { color: #fff; }
 
-/* Audio mixer popover */
-#mixer-popover { min-width: 200px; }
-#mixer-popover .mixer-strip { display: flex; flex-direction: column; align-items: center; gap: 6px; padding: 0 10px; }
+/* Audio mixer popover — centered faders with symmetric inset; scrolling lives on the
+   popover so the scrollbar does not carve space only on one side of .mixer-row. */
+#mixer-popover:not(.hidden) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: fit-content;
+    max-width: 90vw;
+    min-width: 0;
+    box-sizing: border-box;
+    /* Single symmetric inset (replaces Tailwind p-3 on the node). */
+    padding: 12px;
+    overflow-x: auto;
+    overflow-y: visible;
+}
+#mixer-popover .mixer-strip {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 0;
+    /* Same column width — fit-content strips differ when labels differ (“Song” vs “Amp…”),
+       which pushes fader tracks closer to one edge of the popover despite justify-content:center. */
+    width: 110px;
+    flex: 0 0 auto;
+    box-sizing: border-box;
+}
 #mixer-popover .mixer-strip-label {
     font-size: 11px; color: #9ca3af; max-width: 80px;
     overflow: hidden; text-overflow: ellipsis; white-space: nowrap; text-align: center;
@@ -406,6 +430,9 @@ html { scroll-behavior: smooth; }
 #mixer-popover .mixer-strip-fader {
     width: 110px;
     height: 24px;
+    margin: 0;
+    padding: 0;
+    vertical-align: middle;
     transform: rotate(-90deg);
     transform-origin: center;
 }
@@ -422,4 +449,13 @@ html { scroll-behavior: smooth; }
     }
 }
 #mixer-popover .mixer-strip-value { font-size: 10px; color: #6b7280; font-variant-numeric: tabular-nums; }
-#mixer-popover .mixer-row { display: flex; align-items: stretch; gap: 4px; max-width: 90vw; overflow-x: auto; flex-wrap: wrap; }
+#mixer-popover .mixer-row {
+    display: flex;
+    justify-content: center;
+    align-items: stretch;
+    gap: 12px;
+    flex: 0 0 auto;
+    width: max-content;
+    overflow: visible;
+    flex-wrap: nowrap;
+}


### PR DESCRIPTION
### Summary
This branch fixes song/backing volume when running in desktop JUCE mode (where the HTML <audio> element is effectively a stub and real playback goes through the native engine). It also adds a shim so code that still drives the global audio element (currentTime, play, pause, paused)—for example Section Map—stays in sync with jucePlayer. Finally, it refines the audio mixer popover layout and scrolling so faders stay centered and the scrollbar behaves symmetrically.

Changes

- static/audio-mixer.js — When _juceMode is active, song volume changes call slopsmithDesktop.audio.setGain('backing', …) so the UI mixer matches native gain (HTML audio.volume alone is not enough on desktop).

- static/highway.js — On JUCE highway startup, apply backing gain from the song mixer / persisted localStorage volume (with sensible defaults) so native level matches the web path.

- static/app.js — Install a JUCE audio element shim: redirect audio.currentTime, paused, play, and pause to jucePlayer when _juceMode is set; batch same-tick pause + seek into a single seek; reset shim promise chain when switching songs via _resetJuceAudioShimChain().

- static/index.html + static/style.css — Remove outer popover padding from Tailwind and move spacing/layout into CSS: flex column, fit-content width, horizontal scroll on the popover, fixed-width mixer strips, centered row with consistent gaps—avoids uneven fader alignment when strip labels differ in length.

### Testing suggestions

- [ ]  Browser / non-JUCE: mixer sliders and playback unchanged.

- [ ] Desktop JUCE: adjust Song fader; confirm backing loudness follows UI and persists across reload / new song.

- [ ]  Desktop JUCE: Section Map (or any flow that seeks/pauses via audio) still seeks and reflects play/pause state correctly.
