### PR TITLE
fix: guard plugin script rehydration

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3954,17 +3954,40 @@ async function loadPlugins() {
 
         const settingsContainer = document.getElementById('plugin-settings');
 
-        // Plugins whose screen.js has already been evaluated this session at
-        // the current version. Their listeners were bound to the existing
-        // settings / screen DOM, so we must preserve that DOM — the script
-        // load guard below skips re-evaluating screen.js, and a fresh empty
-        // DOM with no listeners would leave the plugin half-hydrated on
-        // subsequent loadPlugins() calls (e.g. _scheduleStartupRehydration).
+        // Plugins whose screen.js has already been evaluated this session
+        // at the current version AND whose DOM is still in the document.
+        // Their listeners were bound to the existing settings / screen DOM,
+        // so we must preserve that DOM — the script load guard below skips
+        // re-evaluating screen.js, and a fresh empty DOM with no listeners
+        // would leave the plugin half-hydrated on subsequent loadPlugins()
+        // calls (e.g. _scheduleStartupRehydration).
+        //
+        // The DOM-existence check is the safety net for plugins that
+        // disappeared and reappeared between calls (uninstall + reinstall,
+        // or a backend snapshot churn that drops a plugin then restores
+        // it). In that case the loadedScripts key would still be set, but
+        // any listeners are bound to elements that have since been removed
+        // — drop the stale key so screen.js re-runs against the fresh DOM
+        // we're about to inject.
         const loadedScripts = window.slopsmith._loadedPluginScripts || (window.slopsmith._loadedPluginScripts = new Set());
+        const existingSettingsByPluginId = new Map();
+        if (settingsContainer) {
+            for (const child of settingsContainer.children) {
+                const pid = child.dataset ? child.dataset.pluginId : null;
+                if (pid) existingSettingsByPluginId.set(pid, child);
+            }
+        }
         const alreadyHydrated = new Set();
         for (const p of plugins) {
-            if (p.has_script && loadedScripts.has(`${p.id}@${p.version || ''}`)) {
+            if (!p.has_script) continue;
+            const key = `${p.id}@${p.version || ''}`;
+            if (!loadedScripts.has(key)) continue;
+            const screenOk = !p.has_screen || !!document.getElementById(`plugin-${p.id}`);
+            const settingsOk = !p.has_settings || existingSettingsByPluginId.has(p.id);
+            if (screenOk && settingsOk) {
                 alreadyHydrated.add(p.id);
+            } else {
+                loadedScripts.delete(key);
             }
         }
 

--- a/static/app.js
+++ b/static/app.js
@@ -3970,6 +3970,10 @@ async function loadPlugins() {
         // — drop the stale key so screen.js re-runs against the fresh DOM
         // we're about to inject.
         const loadedScripts = window.slopsmith._loadedPluginScripts || (window.slopsmith._loadedPluginScripts = new Set());
+        // JSON.stringify ensures id and version can't ambiguously merge —
+        // a raw `id@version` concat would collide on `id='a@b', v='c'` vs
+        // `id='a', v='b@c'`. Plugin IDs are not constrained server-side.
+        const _pluginScriptKey = (p) => JSON.stringify([p.id, p.version || '']);
         const existingSettingsByPluginId = new Map();
         if (settingsContainer) {
             for (const child of settingsContainer.children) {
@@ -3980,7 +3984,7 @@ async function loadPlugins() {
         const alreadyHydrated = new Set();
         for (const p of plugins) {
             if (!p.has_script) continue;
-            const key = `${p.id}@${p.version || ''}`;
+            const key = _pluginScriptKey(p);
             if (!loadedScripts.has(key)) continue;
             const screenOk = !p.has_screen || !!document.getElementById(`plugin-${p.id}`);
             const settingsOk = !p.has_settings || existingSettingsByPluginId.has(p.id);
@@ -3988,6 +3992,13 @@ async function loadPlugins() {
                 alreadyHydrated.add(p.id);
             } else {
                 loadedScripts.delete(key);
+                // Remove the orphaned <script> tag for this plugin so that
+                // multiple disappear/reappear cycles in one session don't
+                // accumulate stale <script data-plugin-id=...> nodes in
+                // the DOM.
+                document.querySelectorAll(
+                    `script[data-plugin-id="${CSS.escape(p.id)}"]`
+                ).forEach((s) => s.remove());
             }
         }
 
@@ -4003,7 +4014,10 @@ async function loadPlugins() {
             });
         }
         document.querySelectorAll('.screen[id^="plugin-"]').forEach((el) => {
-            const pid = el.id.replace(/^plugin-/, '');
+            // Prefer dataset.pluginId (set on injection) — id-prefix parse
+            // would mis-handle a plugin whose id starts with "plugin-".
+            const pid = (el.dataset && el.dataset.pluginId)
+                || el.id.replace(/^plugin-/, '');
             if (!alreadyHydrated.has(pid)) el.remove();
         });
 
@@ -4202,7 +4216,7 @@ async function loadPlugins() {
 
             // Load plugin JS
             if (plugin.has_script) {
-                const scriptKey = `${plugin.id}@${plugin.version || ''}`;
+                const scriptKey = _pluginScriptKey(plugin);
                 if (!loadedScripts.has(scriptKey)) {
                     await new Promise((resolve, reject) => {
                         const script = document.createElement('script');

--- a/static/app.js
+++ b/static/app.js
@@ -4149,7 +4149,12 @@ async function loadPlugins() {
                 if (!loadedScripts.has(scriptKey)) {
                     await new Promise((resolve, reject) => {
                         const script = document.createElement('script');
-                        script.src = `/api/plugins/${plugin.id}/screen.js`;
+                        // Include version in URL so a plugin upgrade within the
+                        // same browser session fetches the new screen.js instead
+                        // of a cached copy keyed only by path (matches the art
+                        // URL ?v=mtime convention elsewhere in this file).
+                        const v = encodeURIComponent(plugin.version || '');
+                        script.src = `/api/plugins/${plugin.id}/screen.js${v ? `?v=${v}` : ''}`;
                         script.dataset.pluginId = plugin.id;
                         script.dataset.pluginVersion = plugin.version || '';
                         script.onload = () => { loadedScripts.add(scriptKey); resolve(); };

--- a/static/app.js
+++ b/static/app.js
@@ -3995,10 +3995,12 @@ async function loadPlugins() {
                 // Remove the orphaned <script> tag for this plugin so that
                 // multiple disappear/reappear cycles in one session don't
                 // accumulate stale <script data-plugin-id=...> nodes in
-                // the DOM.
-                document.querySelectorAll(
-                    `script[data-plugin-id="${CSS.escape(p.id)}"]`
-                ).forEach((s) => s.remove());
+                // the DOM. Filter via dataset rather than a CSS attribute
+                // selector — CSS.escape is not universally available in
+                // older runtimes / non-browser test contexts.
+                document.querySelectorAll('script[data-plugin-id]').forEach((s) => {
+                    if (s.dataset.pluginId === p.id) s.remove();
+                });
             }
         }
 

--- a/static/app.js
+++ b/static/app.js
@@ -3969,11 +3969,25 @@ async function loadPlugins() {
         // any listeners are bound to elements that have since been removed
         // — drop the stale key so screen.js re-runs against the fresh DOM
         // we're about to inject.
-        const loadedScripts = window.slopsmith._loadedPluginScripts || (window.slopsmith._loadedPluginScripts = new Set());
-        // JSON.stringify ensures id and version can't ambiguously merge —
-        // a raw `id@version` concat would collide on `id='a@b', v='c'` vs
-        // `id='a', v='b@c'`. Plugin IDs are not constrained server-side.
-        const _pluginScriptKey = (p) => JSON.stringify([p.id, p.version || '']);
+        // Map<pluginId, version> — one entry per plugin. Storing only the
+        // currently-loaded version (rather than a Set of all (id, version)
+        // pairs ever loaded) means upgrade → downgrade → upgrade cycles
+        // within one session don't leave stale keys that could mistakenly
+        // mark an old version as already-hydrated. Coerce a legacy Set, if
+        // present, to an empty Map — the previous shape never shipped.
+        let loadedScripts = window.slopsmith._loadedPluginScripts;
+        if (!(loadedScripts instanceof Map)) {
+            loadedScripts = new Map();
+            window.slopsmith._loadedPluginScripts = loadedScripts;
+        }
+        const _removePluginScriptTags = (pluginId) => {
+            // Filter via dataset rather than a CSS attribute selector —
+            // CSS.escape is not universally available, and plugin IDs
+            // aren't constrained server-side.
+            document.querySelectorAll('script[data-plugin-id]').forEach((s) => {
+                if (s.dataset.pluginId === pluginId) s.remove();
+            });
+        };
         const existingSettingsByPluginId = new Map();
         if (settingsContainer) {
             for (const child of settingsContainer.children) {
@@ -3984,23 +3998,19 @@ async function loadPlugins() {
         const alreadyHydrated = new Set();
         for (const p of plugins) {
             if (!p.has_script) continue;
-            const key = _pluginScriptKey(p);
-            if (!loadedScripts.has(key)) continue;
+            // Version must match exactly — an upgrade / downgrade has to
+            // re-run the new script against fresh DOM.
+            if (loadedScripts.get(p.id) !== (p.version || '')) continue;
             const screenOk = !p.has_screen || !!document.getElementById(`plugin-${p.id}`);
             const settingsOk = !p.has_settings || existingSettingsByPluginId.has(p.id);
             if (screenOk && settingsOk) {
                 alreadyHydrated.add(p.id);
             } else {
-                loadedScripts.delete(key);
-                // Remove the orphaned <script> tag for this plugin so that
-                // multiple disappear/reappear cycles in one session don't
-                // accumulate stale <script data-plugin-id=...> nodes in
-                // the DOM. Filter via dataset rather than a CSS attribute
-                // selector — CSS.escape is not universally available in
-                // older runtimes / non-browser test contexts.
-                document.querySelectorAll('script[data-plugin-id]').forEach((s) => {
-                    if (s.dataset.pluginId === p.id) s.remove();
-                });
+                // DOM was wiped externally (uninstall + reinstall, snapshot
+                // churn) — drop the entry and remove the orphaned <script>
+                // so screen.js re-runs against fresh DOM below.
+                loadedScripts.delete(p.id);
+                _removePluginScriptTags(p.id);
             }
         }
 
@@ -4016,8 +4026,9 @@ async function loadPlugins() {
             });
         }
         document.querySelectorAll('.screen[id^="plugin-"]').forEach((el) => {
-            // Prefer dataset.pluginId (set on injection) — id-prefix parse
-            // would mis-handle a plugin whose id starts with "plugin-".
+            // dataset.pluginId is the source of truth (set on injection);
+            // the id-prefix fallback covers screens injected before this
+            // change shipped — both forms strip a single leading "plugin-".
             const pid = (el.dataset && el.dataset.pluginId)
                 || el.id.replace(/^plugin-/, '');
             if (!alreadyHydrated.has(pid)) el.remove();
@@ -4218,20 +4229,24 @@ async function loadPlugins() {
 
             // Load plugin JS
             if (plugin.has_script) {
-                const scriptKey = _pluginScriptKey(plugin);
-                if (!loadedScripts.has(scriptKey)) {
+                const wantedVersion = plugin.version || '';
+                if (loadedScripts.get(plugin.id) !== wantedVersion) {
+                    // A different version (or none) was loaded previously —
+                    // remove the prior <script> tag for this plugin id so we
+                    // don't accumulate stale versions on upgrade/downgrade.
+                    _removePluginScriptTags(plugin.id);
                     await new Promise((resolve, reject) => {
                         const script = document.createElement('script');
                         // Include version in URL so a plugin upgrade within the
                         // same browser session fetches the new screen.js instead
                         // of a cached copy keyed only by path (matches the art
                         // URL ?v=mtime convention elsewhere in this file).
-                        const v = encodeURIComponent(plugin.version || '');
+                        const v = encodeURIComponent(wantedVersion);
                         script.src = `/api/plugins/${plugin.id}/screen.js${v ? `?v=${v}` : ''}`;
                         script.dataset.pluginId = plugin.id;
-                        script.dataset.pluginVersion = plugin.version || '';
-                        script.onload = () => { loadedScripts.add(scriptKey); resolve(); };
-                        script.onerror = (err) => { loadedScripts.delete(scriptKey); reject(err); };
+                        script.dataset.pluginVersion = wantedVersion;
+                        script.onload = () => { loadedScripts.set(plugin.id, wantedVersion); resolve(); };
+                        script.onerror = (err) => { loadedScripts.delete(plugin.id); reject(err); };
                         document.body.appendChild(script);
                     });
                 }

--- a/static/app.js
+++ b/static/app.js
@@ -3954,11 +3954,35 @@ async function loadPlugins() {
 
         const settingsContainer = document.getElementById('plugin-settings');
 
-        // One-shot hydration guard: always clear plugin-owned containers first.
+        // Plugins whose screen.js has already been evaluated this session at
+        // the current version. Their listeners were bound to the existing
+        // settings / screen DOM, so we must preserve that DOM — the script
+        // load guard below skips re-evaluating screen.js, and a fresh empty
+        // DOM with no listeners would leave the plugin half-hydrated on
+        // subsequent loadPlugins() calls (e.g. _scheduleStartupRehydration).
+        const loadedScripts = window.slopsmith._loadedPluginScripts || (window.slopsmith._loadedPluginScripts = new Set());
+        const alreadyHydrated = new Set();
+        for (const p of plugins) {
+            if (p.has_script && loadedScripts.has(`${p.id}@${p.version || ''}`)) {
+                alreadyHydrated.add(p.id);
+            }
+        }
+
+        // Clear plugin-owned containers, but keep already-hydrated plugins'
+        // settings / screen DOM. Nav links carry no per-plugin script state,
+        // so always rebuild them.
         navContainer.innerHTML = '';
         mobileNavContainer.innerHTML = '<span class="text-xs text-gray-600 uppercase tracking-wider">Plugins</span>';
-        if (settingsContainer) settingsContainer.innerHTML = '';
-        document.querySelectorAll('.screen[id^="plugin-"]').forEach((el) => el.remove());
+        if (settingsContainer) {
+            [...settingsContainer.children].forEach((el) => {
+                const pid = el.dataset ? el.dataset.pluginId : null;
+                if (!pid || !alreadyHydrated.has(pid)) el.remove();
+            });
+        }
+        document.querySelectorAll('.screen[id^="plugin-"]').forEach((el) => {
+            const pid = el.id.replace(/^plugin-/, '');
+            if (!alreadyHydrated.has(pid)) el.remove();
+        });
 
         // Plugin settings area hosts both "Plugin Updates" and per-plugin
         // collapsibles. Reveal it whenever any plugins are installed —
@@ -4010,11 +4034,17 @@ async function loadPlugins() {
             try {
             const screenId = `plugin-${plugin.id}`;
 
-            // Inject screen container
-            if (plugin.has_screen) {
+            // Inject screen container. Skip for already-hydrated plugins —
+            // their existing screen DOM still has the listeners that
+            // screen.js bound on first load (rebuilding here would orphan
+            // them, since the script load guard further down won't re-run
+            // screen.js to re-bind).
+            if (plugin.has_screen && !alreadyHydrated.has(plugin.id)) {
                 const screenDiv = document.createElement('div');
                 screenDiv.id = screenId;
                 screenDiv.className = 'screen';
+                screenDiv.dataset.pluginId = plugin.id;
+                screenDiv.dataset.pluginVersion = plugin.version || '';
                 // Insert before the player screen
                 const player = document.getElementById('player');
                 player.parentNode.insertBefore(screenDiv, player);
@@ -4026,9 +4056,14 @@ async function loadPlugins() {
             // Inject settings section — wrapped in a collapsible <details>
             // per plugin so the page stays scannable as plugins accumulate.
             // Collapsed by default; <details>/<summary> handles state natively.
-            if (plugin.has_settings && settingsContainer) {
+            // Skip for already-hydrated plugins — preserved details element
+            // still carries listeners wired by its inline settings script
+            // and by screen.js on first load.
+            if (plugin.has_settings && settingsContainer && !alreadyHydrated.has(plugin.id)) {
                 const details = document.createElement('details');
                 details.className = 'bg-dark-700/40 border border-gray-800 rounded-xl overflow-hidden group';
+                details.dataset.pluginId = plugin.id;
+                details.dataset.pluginVersion = plugin.version || '';
 
                 const summary = document.createElement('summary');
                 // .plugin-settings-summary class hides the browser's native
@@ -4144,7 +4179,6 @@ async function loadPlugins() {
 
             // Load plugin JS
             if (plugin.has_script) {
-                const loadedScripts = window.slopsmith._loadedPluginScripts || (window.slopsmith._loadedPluginScripts = new Set());
                 const scriptKey = `${plugin.id}@${plugin.version || ''}`;
                 if (!loadedScripts.has(scriptKey)) {
                     await new Promise((resolve, reject) => {

--- a/static/app.js
+++ b/static/app.js
@@ -4144,13 +4144,19 @@ async function loadPlugins() {
 
             // Load plugin JS
             if (plugin.has_script) {
-                await new Promise((resolve, reject) => {
-                    const script = document.createElement('script');
-                    script.src = `/api/plugins/${plugin.id}/screen.js`;
-                    script.onload = resolve;
-                    script.onerror = reject;
-                    document.body.appendChild(script);
-                });
+                const loadedScripts = window.slopsmith._loadedPluginScripts || (window.slopsmith._loadedPluginScripts = new Set());
+                const scriptKey = `${plugin.id}@${plugin.version || ''}`;
+                if (!loadedScripts.has(scriptKey)) {
+                    await new Promise((resolve, reject) => {
+                        const script = document.createElement('script');
+                        script.src = `/api/plugins/${plugin.id}/screen.js`;
+                        script.dataset.pluginId = plugin.id;
+                        script.dataset.pluginVersion = plugin.version || '';
+                        script.onload = () => { loadedScripts.add(scriptKey); resolve(); };
+                        script.onerror = (err) => { loadedScripts.delete(scriptKey); reject(err); };
+                        document.body.appendChild(script);
+                    });
+                }
             }
             } catch (e) {
                 console.warn(`Plugin '${plugin.id}' failed to load, skipping:`, e);


### PR DESCRIPTION
## Summary
- Add a renderer-session guard for dynamically loaded plugin `screen.js` files.
- Key loaded scripts by `plugin.id@version` so repeated plugin loading does not re-evaluate the same plugin script.

## Validation
- `node --check static/app.js`
- `git diff --check`
