### PR TITLE
RFC for Remote Support feature

### DIFF
--- a/specs/003-remote-support-sessions/checklists/requirements.md
+++ b/specs/003-remote-support-sessions/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Remote Support Sessions
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-10
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed on 2026-05-10. No clarification markers remain.
+- The spec uses product-level terms from the RFC such as support relay, diagnostic bundle, capability grants, and audit trail while avoiding implementation-specific frameworks, languages, or API names.
+- Open RFC questions were resolved as assumptions for planning: bundled but disabled until enabled, diagnostics-only first, 30-day local audit retention, separate grants for live view and actions, and local-only fallback when relay use is unavailable.

--- a/specs/003-remote-support-sessions/contracts/plugin-policy.md
+++ b/specs/003-remote-support-sessions/contracts/plugin-policy.md
@@ -1,0 +1,94 @@
+# Contract: Plugin Manifest and Capability Policy
+
+Remote support participation is an eligibility declaration, not a privilege grant.
+
+## Remote Support Plugin Manifest
+
+```json
+{
+  "id": "remote_support",
+  "name": "Remote Support",
+  "standards": [
+    "capability-pipelines.v1",
+    "plugin-runtime-idempotent.v1",
+    "remote-support.v1"
+  ],
+  "settings": { "html": "settings.html" },
+  "script": "screen.js",
+  "routes": "routes.py",
+  "capabilities": {
+    "remote-support": {
+      "roles": ["requester", "provider"],
+      "commands": ["start", "join", "stop", "inspect", "relay.connect", "relay.disconnect"],
+      "events": ["session.started", "session.ended", "session.activity", "session.warning-required"]
+    },
+    "settings": {
+      "roles": ["provider"],
+      "commands": ["register-contribution", "mount", "unmount", "inspect"]
+    },
+    "diagnostics": {
+      "roles": ["contributor"],
+      "events": ["remote-support.session.summary"]
+    }
+  },
+  "domains": {
+    "backend.routes": { "legacy_source": "routes" },
+    "diagnostics": [{ "id": "remote-support-session" }]
+  }
+}
+```
+
+## Capability Remote Support Policy
+
+Capability owners can declare which commands are eligible during remote support.
+
+```json
+{
+  "capabilities": {
+    "plugins": {
+      "roles": ["provider"],
+      "commands": ["inspect", "reload", "disable-for-session"],
+      "remote_support": {
+        "inspect": { "allow": true, "approval": "none", "risk": "low" },
+        "reload": { "allow": true, "approval": "required", "risk": "medium" },
+        "disable-for-session": { "allow": true, "approval": "required", "risk": "medium" }
+      }
+    }
+  }
+}
+```
+
+## Runtime Participant Policy
+
+Runtime participants may narrow command availability when state changes.
+
+```js
+window.slopsmith.capabilities.registerParticipant("example", {
+  plugins: {
+    roles: ["provider"],
+    commands: ["inspect", "reload"],
+    remoteSupport: {
+      inspect: { allow: true, approval: "none", risk: "low" },
+      reload: { allow: false }
+    }
+  }
+});
+```
+
+## Core Decision Order
+
+1. Verify active session and required grant.
+2. Verify support identity warning acceptance if identity is unverified and grant is live view or actions.
+3. Verify capability owner remote-support policy.
+4. Apply global deny rules.
+5. Reject high-risk actions without a clear effect summary.
+6. Prompt the local user when approval is required.
+7. Dispatch through the normal capability command path.
+8. Redact result payload.
+9. Persist audit before delivering result to support.
+
+## Diagnostics Requirements
+
+- Capability diagnostics expose declared remote-support policies and runtime narrowing.
+- Remote support diagnostics expose active session id, status, grants, relay state, recent decisions, and unavailable providers using support-safe summaries.
+- Repeated plugin script evaluation must not duplicate participants, timers, relay handlers, indicators, or diagnostics contributors.

--- a/specs/003-remote-support-sessions/contracts/remote-support-api.md
+++ b/specs/003-remote-support-sessions/contracts/remote-support-api.md
@@ -1,0 +1,183 @@
+# Contract: Core Remote Support API
+
+This contract describes the core-owned local API that the bundled Remote Support plugin can call. Names are planned route shapes; implementation may register them in `server.py` or a route module, but policy decisions stay in core.
+
+## Common Rules
+
+- All responses are JSON except diagnostic bundle export.
+- Every successful remote read/action response must correspond to a persisted audit entry.
+- If audit persistence fails, the API returns `audit_failed`, blocks the read/action, and suspends or closes the session.
+- Remote callers never receive raw filesystem access, raw shell access, unrestricted local HTTP proxying, or unredacted secret fields.
+- Error response shape:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "grant_denied",
+    "message": "diagnostics.logs grant is not active",
+    "audit_id": "aud_123"
+  }
+}
+```
+
+## Session Lifecycle
+
+### `POST /api/support/sessions`
+
+Create a local session draft after user consent.
+
+Request:
+
+```json
+{
+  "mode": "diagnostics",
+  "ttl_minutes": 30,
+  "connection_kind": "managed-relay",
+  "requested_grants": ["diagnostics.snapshot", "diagnostics.logs"],
+  "support_identity": {
+    "display_name": "Community helper",
+    "kind": "human",
+    "verified": false
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "session": {
+    "id": "rs_abc123",
+    "status": "active",
+    "mode": "diagnostics",
+    "expires_at": "2026-05-10T18:30:00Z",
+    "grants": ["diagnostics.snapshot", "diagnostics.logs"],
+    "connection": { "kind": "managed-relay", "pairing_code": "842193" }
+  },
+  "audit_id": "aud_create"
+}
+```
+
+### `POST /api/support/sessions/join`
+
+Join a support-initiated code or link after local consent.
+
+Request:
+
+```json
+{
+  "code_or_url": "842193",
+  "mode": "diagnostics",
+  "requested_grants": ["diagnostics.snapshot", "diagnostics.console"],
+  "accepted_unverified_identity_warning": false
+}
+```
+
+### `GET /api/support/sessions`
+
+List local support session summaries, newest first.
+
+### `GET /api/support/sessions/{session_id}`
+
+Inspect one session summary, active grants, connection status, and last activity.
+
+### `POST /api/support/sessions/{session_id}/revoke`
+
+Revoke a session locally. Must end remote access before returning success.
+
+### `POST /api/support/sessions/{session_id}/extend`
+
+Extend within the allowed 15 to 60 minute range after local user confirmation.
+
+## Diagnostic Reads
+
+### `GET /api/support/sessions/{session_id}/diagnostics/snapshot`
+
+Returns a redacted support-safe aggregate of allowed diagnostics.
+
+Query parameters:
+
+- `kind`: `summary`, `logs.tail`, `console.snapshot`, `plugins.snapshot`, `capabilities.snapshot`, `health.check`, or `bundle.preview`.
+
+Response:
+
+```json
+{
+  "ok": true,
+  "audit_id": "aud_read",
+  "snapshot": {
+    "schema": "remote-support.diagnostics.snapshot.v1",
+    "kind": "plugins.snapshot",
+    "redacted": true,
+    "summary": { "loaded_count": 12, "orphan_count": 1 },
+    "payload": {}
+  }
+}
+```
+
+### `POST /api/support/sessions/{session_id}/diagnostics/bundle-preview`
+
+Returns the same support-safe preview tree used by Settings diagnostics export, filtered by active grants.
+
+### `POST /api/support/sessions/{session_id}/diagnostics/export-bundle`
+
+Creates a diagnostic bundle only when covered by grants and policy. If remote delivery is requested, the returned payload is still redacted and audited.
+
+## Action Requests
+
+### `POST /api/support/sessions/{session_id}/actions`
+
+Create a typed action request from support.
+
+Request:
+
+```json
+{
+  "action": "plugin.reload",
+  "summary": "Reload plugin list to recover a missing route",
+  "risk": "medium",
+  "payload": { "plugin_id": "sloppak_converter" },
+  "effect_summary": "Reloads plugin metadata and route registration; does not modify DLC files."
+}
+```
+
+Response status values:
+
+- `awaiting-approval`: request is eligible and shown locally.
+- `rejected`: policy, grant, summary, identity, or global deny rules rejected it before approval.
+- `denied`: local user denied it.
+- `audit_failed`: audit persistence failed and the session was suspended/closed.
+
+### `POST /api/support/actions/{action_id}/approve`
+
+Local-only approval endpoint. Executes only the exact request shown to the user.
+
+### `POST /api/support/actions/{action_id}/deny`
+
+Local-only denial endpoint. Records denial and does not mutate state.
+
+### `GET /api/support/actions/{action_id}`
+
+Inspect support-safe status and result summary.
+
+## Audit
+
+### `GET /api/support/sessions/{session_id}/audit`
+
+Returns local audit entries for the session.
+
+### `GET /api/support/audit`
+
+Returns recent audit summaries across sessions for Settings and diagnostic bundle inclusion.
+
+## Policy Settings
+
+### `GET /api/support/policy`
+
+Returns relay enablement, allowed provider labels, local-only availability, and retention summary.
+
+### `POST /api/support/policy`
+
+Updates advanced/user policy such as disabling remote relay sessions. Must not create a new mandatory environment variable.

--- a/specs/003-remote-support-sessions/contracts/support-protocol.md
+++ b/specs/003-remote-support-sessions/contracts/support-protocol.md
@@ -1,0 +1,160 @@
+# Contract: Remote Support Protocol
+
+The relay carries typed messages between the local Remote Support plugin and a support dashboard. The relay is a message room, not a policy authority and not a raw tunnel.
+
+## Envelope
+
+```json
+{
+  "schema": "remote-support.message.v1",
+  "id": "msg_001",
+  "session_id": "rs_abc123",
+  "type": "diagnostics.request",
+  "sent_at": "2026-05-10T18:00:00Z",
+  "actor": {
+    "display_name": "Community helper",
+    "kind": "human",
+    "verified": false
+  },
+  "payload": {}
+}
+```
+
+## Session Messages
+
+### `session.hello`
+
+Sent by support dashboard when joining a relay room.
+
+Payload:
+
+```json
+{
+  "pairing_code": "842193",
+  "reconnect_token": "opaque-if-reconnecting",
+  "requested_identity": { "display_name": "Support", "verified": false }
+}
+```
+
+Rules:
+
+- The local side accepts only one active support connection.
+- Additional viewers receive `session.rejected` while the active support connection remains uninterrupted.
+- Same-party reconnect is allowed before session expiry when local reconnect validation passes.
+
+### `session.ready`
+
+Sent by the local plugin when core has an active consented session.
+
+Payload includes session mode, active grants, expiration, identity verification status, and local warning requirements.
+
+### `session.closed`
+
+Sent by either side. Local closure reasons include `revoked`, `expired`, `app-exit`, `relay-failed`, `audit-failed`, and `support-disconnected`.
+
+## Diagnostic Messages
+
+### `diagnostics.request`
+
+Payload:
+
+```json
+{
+  "kind": "logs.tail",
+  "since": "2026-05-10T17:55:00Z"
+}
+```
+
+Rules:
+
+- The plugin forwards the request to core.
+- Core checks session, grant, allowlist, redaction, rate limit, and audit before data is returned.
+- On failure, support receives `diagnostics.error` with a support-safe reason.
+
+### `diagnostics.response`
+
+Payload:
+
+```json
+{
+  "kind": "logs.tail",
+  "audit_id": "aud_read",
+  "redacted": true,
+  "summary": { "line_count": 120 },
+  "payload": {}
+}
+```
+
+## Live View Messages
+
+### `live-view.frame`
+
+Payload:
+
+```json
+{
+  "audit_id": "aud_frame",
+  "format": "image/webp",
+  "width": 1280,
+  "height": 720,
+  "redacted": true,
+  "data": "base64-frame-data"
+}
+```
+
+Rules:
+
+- Requires `app.live_view` grant.
+- Frames are non-interactive screenshots of the Slopsmith app surface only.
+- The protocol does not define input gesture messages for MVP.
+- Desktop content outside the app surface must not be captured.
+
+## Action Messages
+
+### `action.request`
+
+Payload:
+
+```json
+{
+  "action": "diagnostics.export_bundle",
+  "summary": "Export redacted diagnostic bundle for this session",
+  "risk": "low",
+  "payload": {},
+  "effect_summary": "Creates a redacted bundle containing diagnostics and session audit."
+}
+```
+
+Rules:
+
+- Requires `actions.request` grant.
+- Mutating actions require local approval.
+- High-risk actions without clear effect summary are rejected before approval.
+- Unverified identities require the local user to accept the extra warning before live view or action grants are enabled.
+
+### `action.status`
+
+Payload includes action id, status, audit id, and support-safe result summary.
+
+## Error Messages
+
+### `error`
+
+Payload:
+
+```json
+{
+  "code": "grant_denied",
+  "message": "Requested diagnostic kind is not granted",
+  "audit_id": "aud_denied"
+}
+```
+
+## Forbidden Payloads
+
+- Arbitrary HTTP requests.
+- TCP forwarding.
+- Shell commands.
+- Raw filesystem reads.
+- Desktop remote-control events.
+- Unbounded log, console, or screenshot streams.

--- a/specs/003-remote-support-sessions/data-model.md
+++ b/specs/003-remote-support-sessions/data-model.md
@@ -1,0 +1,230 @@
+# Data Model: Remote Support Sessions
+
+## RemoteSupportSession
+
+Represents one temporary support relationship approved by the local user.
+
+**Fields**
+
+- `id`: opaque local session identifier.
+- `created_at`: UTC timestamp.
+- `expires_at`: UTC timestamp; must be 15 to 60 minutes after creation unless extended within policy.
+- `status`: `starting`, `pending-consent`, `active`, `suspended`, `revoked`, `expired`, `failed`, or `closed`.
+- `mode`: `diagnostics`, `live-view`, or `approved-actions`.
+- `connection_kind`: `managed-relay`, `support-hosted-relay`, or `local-only`.
+- `connection_summary`: support-safe endpoint/code/provider summary, never raw secrets.
+- `support_identity_id`: optional link to `SupportIdentity`.
+- `active_grants`: list of `SupportGrant` values.
+- `closure_reason`: optional reason for terminal states.
+- `last_activity_at`: UTC timestamp for the last audited read/action/lifecycle event.
+
+**Relationships**
+
+- Has many `AuditEntry` records.
+- Has zero or one active `SupportConnection`.
+- Has many `SupportActionRequest` records.
+- Has one `RelayConfiguration` snapshot.
+
+**Validation Rules**
+
+- Only one active support connection is allowed per active session.
+- A session cannot become active until consent is recorded and an audit entry is persisted.
+- Session state changes must persist audit before remote access continues.
+- If audit persistence fails, the session transitions to `suspended` or `failed` before any remote read/action continues.
+
+**State Transitions**
+
+```text
+starting -> pending-consent -> active -> revoked
+starting -> pending-consent -> active -> expired
+starting -> failed
+active -> suspended -> revoked
+active -> failed
+active -> closed
+```
+
+## SupportConnection
+
+Represents the currently connected support party for a session.
+
+**Fields**
+
+- `id`: connection identifier.
+- `session_id`: parent `RemoteSupportSession`.
+- `support_identity_id`: optional displayed identity.
+- `connected_at`: UTC timestamp.
+- `last_seen_at`: UTC timestamp.
+- `reconnect_token_hash`: optional local-only hash for same-party reconnect.
+- `verified`: boolean.
+
+**Validation Rules**
+
+- Additional support viewers are rejected while an active connection exists.
+- Same-party reconnect is allowed before session expiration when the reconnect token matches and the old connection is no longer active.
+- Rejected joins create audit entries.
+
+## SupportIdentity
+
+Represents the displayed remote party.
+
+**Fields**
+
+- `id`: local identity reference.
+- `display_name`: support-safe name shown to the user.
+- `kind`: `human`, `ai-agent`, `organization`, or `unknown`.
+- `verified`: boolean.
+- `verification_source`: optional support-safe relay/provider claim.
+
+**Validation Rules**
+
+- Unknown or unverified identities must be labeled as such.
+- Live-view and action-request grants require an extra warning approval when identity is unverified.
+
+## SupportGrant
+
+Scoped permission active for one session.
+
+**Values**
+
+- `diagnostics.snapshot`
+- `diagnostics.logs`
+- `diagnostics.console`
+- `diagnostics.plugins`
+- `diagnostics.capabilities`
+- `diagnostics.health`
+- `diagnostics.bundle_preview`
+- `diagnostics.bundle_export`
+- `app.live_view`
+- `actions.request`
+
+**Validation Rules**
+
+- Grants are session-scoped and expire with the session.
+- Grants can be narrower than session mode.
+- Remote support plugin eligibility does not imply grants.
+
+## SupportDiagnosticRead
+
+Represents a read request and its support-safe result summary.
+
+**Fields**
+
+- `id`: read request identifier.
+- `session_id`: parent session.
+- `requested_by`: `SupportIdentity` or connection reference.
+- `kind`: `snapshot`, `logs.tail`, `console.snapshot`, `plugins.snapshot`, `capabilities.snapshot`, `health.check`, or `bundle.preview`.
+- `grant_used`: support grant that authorized the read.
+- `status`: `allowed`, `denied`, `rate-limited`, `failed`, or `audit-failed`.
+- `summary`: support-safe result metadata.
+- `created_at`: UTC timestamp.
+
+**Validation Rules**
+
+- A read cannot return payload data until audit persistence succeeds.
+- Payload fields must be allowlisted and redacted before transport.
+- Logs, console, and snapshots use bounded history and size limits.
+
+## SupportActionRequest
+
+Represents a typed action requested by support and decided locally.
+
+**Fields**
+
+- `id`: action request identifier.
+- `session_id`: parent session.
+- `requested_by`: support identity/connection reference.
+- `action`: `app.restart`, `diagnostics.export_bundle`, `plugin.reload`, `plugin.disable_for_session`, `integration.test`, `config.patch`, or future allowlisted action.
+- `summary`: user-readable request summary.
+- `risk`: `low`, `medium`, or `high`.
+- `payload_summary`: bounded, redacted summary.
+- `effect_summary`: diff, exact effect, or equivalent impact summary when required.
+- `status`: `requested`, `awaiting-approval`, `approved`, `denied`, `rejected`, `expired`, `running`, `completed`, `failed`, or `audit-failed`.
+- `decision_at`: optional UTC timestamp.
+- `result_summary`: optional support-safe result.
+
+**Validation Rules**
+
+- Actions require active session and `actions.request` grant.
+- Mutating actions require explicit local approval.
+- High-risk actions without `effect_summary` are rejected before approval.
+- Capability owner policy and global deny rules must allow the action.
+- Denied, rejected, failed, and completed actions are audited.
+
+## AuditEntry
+
+Local accountability record for support activity.
+
+**Fields**
+
+- `id`: audit identifier.
+- `session_id`: parent session.
+- `time`: UTC timestamp.
+- `actor`: `local-user`, `support`, `core`, `plugin`, or `relay`.
+- `actor_identity`: support-safe identity summary when known.
+- `event`: lifecycle, read, join, action, approval, denial, failure, or close event type.
+- `category`: affected diagnostic/action/session category.
+- `outcome`: `allowed`, `denied`, `rejected`, `completed`, `failed`, `revoked`, `expired`, or `audit-failed`.
+- `summary`: support-safe human-readable summary.
+- `redaction_summary`: optional redaction counts or note.
+
+**Validation Rules**
+
+- Required audit entries must persist before remote reads/actions continue.
+- Audit entries must avoid raw secrets, raw local file contents, and unrestricted filesystem details.
+- Audit summaries are included in diagnostic bundle export after session close.
+
+## RelayConfiguration
+
+Captures the selected support path and policy restrictions.
+
+**Fields**
+
+- `kind`: `managed-relay`, `support-hosted-relay`, or `local-only`.
+- `enabled`: boolean.
+- `display_name`: user-visible provider label.
+- `endpoint_summary`: support-safe endpoint label.
+- `policy`: options for disabled remote relay, allowed provider list, and retention display.
+
+**Validation Rules**
+
+- `local-only` must remain available when remote relay is disabled or unavailable.
+- Relay configuration cannot weaken consent, grants, redaction, approval, audit, or fail-closed behavior.
+
+## RemoteSupportPolicy
+
+Capability-level eligibility for remote support actions.
+
+**Fields**
+
+- `capability`: capability name.
+- `command`: command name.
+- `allow`: boolean.
+- `approval`: `none` or `required`.
+- `risk`: `low`, `medium`, or `high`.
+- `effect_summary_required`: boolean.
+
+**Validation Rules**
+
+- Core global deny rules override capability policy.
+- Runtime participant policy can narrow availability, not bypass core grants or approval.
+- Policies are visible in capability diagnostics.
+
+## SupportProtocolMessage
+
+Typed relay message between support dashboard and local plugin.
+
+**Fields**
+
+- `schema`: `remote-support.message.v1`.
+- `id`: message identifier.
+- `session_id`: support session reference.
+- `type`: typed message name.
+- `sent_at`: UTC timestamp.
+- `actor`: support-safe sender summary.
+- `payload`: bounded object specific to the message type.
+
+**Validation Rules**
+
+- Messages never carry arbitrary HTTP/TCP traffic.
+- Unknown message types are rejected and audited when associated with a session.
+- Payloads are size-bounded before dispatch.

--- a/specs/003-remote-support-sessions/plan.md
+++ b/specs/003-remote-support-sessions/plan.md
@@ -1,0 +1,104 @@
+# Implementation Plan: Remote Support Sessions
+
+**Branch**: `003-remote-support-sessions` | **Date**: 2026-05-10 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/003-remote-support-sessions/spec.md`
+
+**Setup Note**: The Spec Kit setup script resolved this feature directory from `.specify/feature.json`, but reported the current top-level git branch as `002-configuration-profiles`. The feature artifacts remain under `specs/003-remote-support-sessions/` and the spec declares `003-remote-support-sessions`.
+
+## Summary
+
+Implement temporary Remote Support Sessions as a bundled support plugin backed by a narrow core trust boundary. Core owns session lifecycle, consent, grants, redaction, audit persistence, diagnostic reads, and approved-action policy; the plugin owns Settings entry points, local/remote dashboard UX, pairing, and relay transport. The first deliverable proves diagnostics-only and local-only support using existing diagnostic bundle, console, plugin, and capability diagnostics surfaces, then layers in outbound typed relay transport, approved actions, and non-interactive app-surface live view.
+
+## Technical Context
+
+**Language/Version**: Python 3 backend; vanilla browser JavaScript using existing ES2020-style patterns
+**Primary Dependencies**: FastAPI route registration, existing plugin loader, `window.slopsmith` EventTarget namespace, `window.slopsmith.capabilities`, `window.slopsmith.diagnostics`, stdlib logging, existing diagnostic bundle/redaction helpers, WebSocket-capable transport adapter
+**Storage**: File-backed JSON/JSONL state under `CONFIG_DIR` for session summaries, audit entries, relay policy, and pending action requests; in-memory registry for active connection state; browser `localStorage` only for plugin UI preferences
+**Testing**: pytest/FastAPI TestClient for core services and routes, existing diagnostics and plugin tests, JavaScript syntax checks with Node, Playwright browser checks for Settings consent, support indicator, local dashboard, revoke, and approval prompts
+**Target Platform**: Slopsmith self-hosted Docker runtime, local browser, and desktop wrapper environments
+**Project Type**: Single-user web app with plugin extension surface
+**Performance Goals**: Support diagnostics dashboard visible within 30 seconds after approval; audit entries visible within 5 seconds; revoke ends remote access within 10 seconds in normal network conditions; bounded diagnostics reads keep console/log/snapshot payloads under existing caps or stricter support-specific caps
+**Constraints**: No user account model or core auth middleware; no arbitrary shell; no raw desktop access; no inbound public localhost exposure; no frontend framework or build step in core; no new persistent database; no new mandatory path or environment variable; redaction before data leaves the machine; fail closed when required audit persistence fails
+**Scale/Scope**: Single local user, one active support connection per session, 15 to 60 minute TTL with a 30 minute default, diagnostics-only MVP, live view as non-interactive app-surface screenshots, approved actions as typed allowlisted requests
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **Capability Pipeline Gate**: PASS. Affected capabilities are `settings`, `diagnostics`, `support-session`, `support-audit`, `support-actions`, `app.live-view`, `plugins`, `integration-health`, `configuration-sources`, `profiles`, and `settings-packs`. Core is owner/provider for policy, redaction, audit, lifecycle, approval, and privileged reads. The remote support plugin is requester/provider for UX, pairing, relay, and dashboard. Capability owners may declare remote-support policy for action eligibility, but core remains final authority.
+- **Ordering and Short-Circuit Gate**: PASS. Diagnostic reads resolve in this order: active session, grant coverage, field allowlist, redaction, rate limit, audit persistence, response delivery. Action requests resolve in this order: active session, `actions.request` grant, support identity warning if unverified, capability owner policy, global deny rules, high-risk summary availability, user approval, dispatch through capability command path, result redaction, audit persistence. Any failed gate short-circuits with a denied/rejected/audit-failed outcome and no remote data or mutation.
+- **User Intent Gate**: PASS. User-originated actions are session start/join, consent, grant selection, revoke, approve, deny, extend, local-only export, and policy toggles. Remote/support-originated actions are diagnostic reads and typed action requests. Local revoke, denial, session expiry, audit failure, and policy restrictions override all remote requests. Automation does not persist user approval beyond the specific request shown.
+- **UI Capability Gate**: PASS. The feature contributes a Settings Remote Support panel, persistent support indicator, local dashboard, approval prompts, post-session audit summary, and plugin remote dashboard. These are additive and reversible; they do not replace player layout regions. Plugin UI registration uses existing Settings/screen contribution patterns and must unmount idempotently on repeated plugin loading.
+- **Compatibility and Diagnostics Gate**: PASS. Missing optional diagnostic contributors, live view provider, relay adapter, or capability owners degrade that pane/action to unavailable without failing the session. Capability diagnostics expose active support session state, grants, relay state, last decisions, unavailable providers, and recent audit/action outcomes using support-safe summaries.
+- **Runtime Lifecycle Gate**: PASS. The remote support plugin must be rehydratable: repeated `screen.js` evaluation cannot duplicate DOM roots, support indicators, event listeners, timers, relay handlers, diagnostics contributors, pending approval prompts, or capability participants. The plugin declares `capability-pipelines.v1`, `plugin-runtime-idempotent.v1`, and `remote-support.v1`; tests cover repeated load and core-visible self-declaration.
+- **Testability Gate**: PASS. Each user story has independent scenarios in the spec. Planned tests cover provider/requester grants, diagnostic pass-through, audit-failure short-circuit, multiple-viewer rejection, unverified-identity warning, high-risk action summary rejection, user revoke, and local-only fallback.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-remote-support-sessions/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── remote-support-api.md
+│   ├── support-protocol.md
+│   └── plugin-policy.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+slopsmith/
+├── lib/
+│   ├── remote_support.py              # session, grant, action, audit domain logic
+│   ├── remote_support_store.py        # CONFIG_DIR-backed JSON/JSONL persistence
+│   └── remote_support_protocol.py     # typed support message validation helpers
+├── server.py                          # thin FastAPI route registration for core support APIs
+├── plugins/
+│   └── remote_support/
+│       ├── plugin.json
+│       ├── routes.py                  # relay/pairing adapter and plugin-owned dashboard routes
+│       ├── settings.html
+│       └── screen.js                  # Settings panel, indicator, local dashboard, relay client
+├── static/
+│   ├── app.js                         # mount core-visible support indicator/settings entry if needed
+│   ├── capabilities.js                # remote-support policy surface and diagnostics snapshot additions
+│   └── diagnostics.js                 # live-view/client diagnostics snapshot helpers if needed
+└── tests/
+    ├── test_remote_support.py
+    ├── test_remote_support_diagnostics.py
+    ├── test_remote_support_actions.py
+    ├── test_diagnostics_bundle.py
+    ├── test_plugins.py
+    └── test_plugin_runtime_idempotence.py
+```
+
+**Structure Decision**: Keep risky policy and persistence in core `lib/` plus thin FastAPI adapters, while placing user-facing Remote Support workflow and relay transport in the bundled `plugins/remote_support/` plugin. This follows the constitution: generic support product experience is plugin-owned, but privileged reads/actions stay in core.
+
+## Phase 0: Research Summary
+
+Research decisions are captured in [research.md](research.md). No unresolved `NEEDS CLARIFICATION` items remain.
+
+## Phase 1: Design Summary
+
+Design artifacts are captured in [data-model.md](data-model.md), [contracts/remote-support-api.md](contracts/remote-support-api.md), [contracts/support-protocol.md](contracts/support-protocol.md), [contracts/plugin-policy.md](contracts/plugin-policy.md), and [quickstart.md](quickstart.md).
+
+## Post-Design Constitution Check
+
+- **Capability Pipeline Gate**: PASS. Contracts define core-owned support APIs, typed support protocol messages, and plugin/capability remote-support policy declarations.
+- **Ordering and Short-Circuit Gate**: PASS. Data model and contracts define session/grant/audit/action state transitions and explicit short-circuit outcomes for denial, audit failure, policy failure, missing summaries, and unavailable providers.
+- **User Intent Gate**: PASS. Approval, deny, revoke, local-only fallback, and unverified-identity warning flows remain local-user controlled.
+- **UI Capability Gate**: PASS. Quickstart and contracts keep UI additive: Settings entry, support indicator, local dashboard, approval prompt, and audit summary.
+- **Compatibility and Diagnostics Gate**: PASS. Contracts include unavailable-provider behavior and support-safe diagnostic snapshots. No optional plugin absence blocks the diagnostics-only session.
+- **Runtime Lifecycle Gate**: PASS. Plugin policy and quickstart require idempotent manifest declarations and repeated-load tests.
+- **Testability Gate**: PASS. Quickstart lists focused pytest, syntax, and Playwright validation for each risky behavior.
+
+## Complexity Tracking
+
+No constitutional violations or justified complexity exceptions are required.

--- a/specs/003-remote-support-sessions/quickstart.md
+++ b/specs/003-remote-support-sessions/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart: Remote Support Sessions
+
+This guide describes the validation flow for implementing the plan.
+
+## Prerequisites
+
+- Work from the Slopsmith core app directory: `/Users/barlind/Code/barlind/ss/slopsmith`.
+- Use the existing Python environment or create one compatible with the repository tests.
+- Keep Remote Support disabled unless a local test explicitly starts a session.
+
+## Focused Implementation Order
+
+1. Add core remote support domain logic and CONFIG_DIR-backed audit/session store.
+2. Add core support API routes as thin adapters over the domain logic.
+3. Reuse diagnostics preview/export and redaction for support-safe reads.
+4. Add the bundled `plugins/remote_support` plugin with Settings entry, local dashboard, support indicator, and idempotent runtime behavior.
+5. Add relay protocol adapter and local-only fallback.
+6. Add approved action request policy and local approval prompts.
+7. Add non-interactive app-surface screenshot live view.
+
+## Validation Commands
+
+From `/Users/barlind/Code/barlind/ss/slopsmith`:
+
+```bash
+python3 -m pytest tests/test_remote_support.py tests/test_remote_support_diagnostics.py tests/test_remote_support_actions.py -q
+python3 -m pytest tests/test_diagnostics_bundle.py tests/test_plugins.py tests/test_plugin_runtime_idempotence.py -q
+node --check static/capabilities.js
+node --check static/diagnostics.js
+node --check static/app.js
+node --check plugins/remote_support/screen.js
+```
+
+Run browser coverage when UI surfaces are implemented:
+
+```bash
+npx playwright test tests/browser/remote-support.spec.ts
+```
+
+## Manual Acceptance Flow
+
+1. Open Settings and confirm Remote Support is present but inactive.
+2. Start a diagnostics-only local session and confirm the consent screen lists redacted logs, plugins, health, browser console, settings summary, and optional live view/actions as disabled.
+3. Open the local dashboard and confirm diagnostic panes use support-safe summaries.
+4. Trigger a remote diagnostic read and confirm the persistent support indicator shows recent activity.
+5. Revoke the session and confirm remote reads are rejected within the expected window.
+6. Simulate audit persistence failure and confirm Slopsmith blocks the read/action, suspends or closes the session, and offers local-only diagnostic export.
+7. Attempt a second viewer join and confirm it is rejected without disrupting the active connection.
+8. Use an unverified support identity and confirm live view/action grants require an extra warning before activation.
+9. Request a high-risk action without an effect summary and confirm it is rejected before approval.
+10. Enable live view and confirm support sees only a non-interactive app-surface screenshot stream.
+
+## Expected Diagnostic Bundle Additions
+
+- Session audit summary after a session closes.
+- Remote support plugin diagnostics under the plugin diagnostics section.
+- Capability diagnostics including remote-support policy and recent support decisions.

--- a/specs/003-remote-support-sessions/research.md
+++ b/specs/003-remote-support-sessions/research.md
@@ -1,0 +1,91 @@
+# Phase 0 Research: Remote Support Sessions
+
+## Decision: Keep core as the policy authority and plugin as the product experience
+
+**Rationale**: The constitution requires generic user-facing extensions to live in plugins, while the RFC and spec make consent, grants, redaction, audit, and privileged reads non-delegable. A split design lets the bundled Remote Support plugin own Settings UI, pairing, dashboard, and relay transport, while core owns the trust boundary.
+
+**Alternatives considered**:
+
+- Put the entire feature in core: rejected because the Remote Support dashboard, relay, and Settings experience are plugin-shaped product surface.
+- Let the plugin own privileged reads and audit: rejected because support plugins must not bypass core controls.
+- Make relay policy authoritative: rejected because transport providers must remain replaceable and must not decide local access.
+
+## Decision: Store support state under `CONFIG_DIR` as JSON/JSONL with in-memory active connection state
+
+**Rationale**: Slopsmith is a single-user app with file-backed config and no new persistent database. Session summaries, policy settings, pending action requests, and audit entries fit naturally under `CONFIG_DIR/remote_support/`. Active sockets, timers, and relay state are runtime-only and should not be treated as durable truth.
+
+**Alternatives considered**:
+
+- New SQLite tables in `meta.db`: rejected because remote support audit/config is not CDLC metadata and does not need relational querying for MVP.
+- Browser-only storage: rejected because audit, lifecycle, and action policy must survive page reloads and be available to backend diagnostic bundle export.
+- Relay-hosted transcript as source of truth: rejected because the relay is not the policy authority and may be unavailable.
+
+## Decision: Reuse existing diagnostics bundle preview/export and redaction primitives
+
+**Rationale**: `diagnostics_bundle.py`, `diagnostics_redact.py`, `static/diagnostics.js`, and capability diagnostics already provide bounded, support-safe, AI-friendly data shapes. Remote support diagnostic reads should expose the same allowlisted shapes instead of creating a second diagnostics universe.
+
+**Alternatives considered**:
+
+- Stream raw logs and config files: rejected because it bypasses redaction and allowlisting.
+- Add a separate remote-only diagnostics schema: rejected because it duplicates bundle behavior and creates more places for redaction mistakes.
+- Let every plugin publish arbitrary remote diagnostics: rejected because plugin payloads must remain allowlisted, capped, and routed through core grants.
+
+## Decision: Use an outbound typed support protocol with swappable relay adapters
+
+**Rationale**: The spec explicitly forbids exposing raw localhost or unrestricted proxy traffic. A typed message protocol over an outbound connection keeps the relay small and replaceable while letting core validate every read and action. The plan should define protocol contracts and relay adapter expectations, not bind the product to one provider.
+
+**Alternatives considered**:
+
+- Generic tunnel or localhost sharing: rejected because it exposes surfaces remote support does not need.
+- Relay-specific APIs throughout the plugin: rejected because managed, support-hosted, and local-only modes must share the same session contract.
+- Local-only export only: rejected as insufficient for the remote support goal, but kept as the fallback and Phase 1 proof path.
+
+## Decision: Fail closed when audit persistence fails
+
+**Rationale**: The support safety model depends on every remote read/action being visible locally. If a required audit entry cannot persist, remote access must stop before unaudited access continues.
+
+**Alternatives considered**:
+
+- Continue with in-memory audit retry: rejected because the user cannot trust the post-session audit.
+- Continue diagnostic reads only: rejected because read access is still remote access.
+- Keep the session active with warning: rejected because warnings do not restore accountability.
+
+## Decision: Permit one active support connection per session
+
+**Rationale**: Single-party support keeps identity display, audit attribution, and approval prompts clear for the first implementation. The same verified or unverified party may reconnect before expiration so transient network failures do not force a new session.
+
+**Alternatives considered**:
+
+- Multiple fully authorized support participants: deferred because it adds per-participant grants and audit complexity.
+- Primary plus observers: deferred because observer attribution and UI would complicate the MVP.
+- Relay-defined participant policy: rejected because Slopsmith core must own local consent and audit semantics.
+
+## Decision: Allow unverified support identity with extra warning for higher-risk grants
+
+**Rationale**: Community support often cannot provide verified identity, so diagnostics-only sessions remain useful. Live view and action requests carry higher risk and require an extra local warning approval when identity is unverified.
+
+**Alternatives considered**:
+
+- Block all unverified remote sessions: rejected as too restrictive for community support.
+- Allow all grants with normal consent: rejected because unverified live view/actions deserve stronger local awareness.
+- Delegate identity rules to relay: rejected because relay trust varies by provider.
+
+## Decision: Implement live view as non-interactive app-surface screenshots first
+
+**Rationale**: Screenshot streaming answers the primary support question, "what state is the app in?", without granting remote input or desktop access. It also keeps testing simple: support can see app-surface images and cannot send gestures.
+
+**Alternatives considered**:
+
+- DOM/state snapshots only: useful, but less directly understandable than the visual state users describe.
+- App-surface remote interaction: deferred because every input gesture introduces a remote-control consent problem.
+- Full browser control: rejected for MVP because the spec calls out live view as separate from remote control.
+
+## Decision: Reject high-risk actions that cannot explain their effect
+
+**Rationale**: Local approval is meaningful only if the user can understand the effect. High-risk requests need a diff, exact effect, or equivalent impact summary before the approval prompt is shown.
+
+**Alternatives considered**:
+
+- Show a generic warning: rejected because it asks the user to approve an unknown change.
+- Restrict this escape hatch to verified support: rejected because verified identity does not replace local comprehension.
+- Convert automatically to manual recommendation: useful as a support dashboard behavior, but the remote action itself must be rejected.

--- a/specs/003-remote-support-sessions/spec.md
+++ b/specs/003-remote-support-sessions/spec.md
@@ -1,0 +1,204 @@
+# Feature Specification: Remote Support Sessions
+
+**Feature Branch**: `003-remote-support-sessions`
+**Created**: 2026-05-10
+**Status**: Draft
+**Input**: User description: "Create a spec based on RFC 0001: Remote Support Sessions"
+
+## Clarifications
+
+### Session 2026-05-10
+
+- Q: If the local audit trail cannot persist a required audit entry, how should Slopsmith handle the active support session? → A: Fail closed: block the read/action, close or suspend the session, and offer local-only diagnostic export.
+- Q: How should Slopsmith handle multiple support viewers attempting to join the same active session? → A: Allow one active support connection; reject additional viewers while active, but allow the same support party to reconnect.
+- Q: What permissions should Slopsmith allow when the connected support identity cannot be verified? → A: Unverified identity sessions may use live view or action requests only after the local user approves an extra warning.
+- Q: What is the minimum live app view capability Slopsmith should support for this feature? → A: Non-interactive screenshot stream of the Slopsmith app surface only.
+- Q: How should Slopsmith handle a high-risk action request when it cannot generate a clear diff or exact effect summary for local approval? → A: Reject the high-risk action until Slopsmith can show a clear diff, exact effect, or equivalent impact summary.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Start a Read-Only Support Session (Priority: P1)
+
+A Slopsmith user who is asking for help can open Remote Support from Settings, enter a support-provided code or create a shareable session code, review exactly what diagnostic categories will be shared, and start a temporary diagnostics-only session.
+
+**Why this priority**: This delivers the safest useful MVP by replacing manual log, screenshot, environment, plugin, and console gathering with one consented flow while preventing remote mutation.
+
+**Independent Test**: Can be fully tested by starting Remote Support from Settings, approving diagnostics-only sharing, connecting a support viewer, and confirming that support sees only redacted diagnostic information.
+
+**Acceptance Scenarios**:
+
+1. **Given** Remote Support is disabled and the user has a valid support code, **When** the user opens Settings, enters the code, reviews the sharing summary, and chooses diagnostics-only mode, **Then** Slopsmith creates an active temporary session and the support side can view support-safe diagnostics.
+2. **Given** a user wants community support and no support-provided code exists, **When** the user chooses to create a support session, **Then** Slopsmith produces a short-lived code or URL that can be shared with support.
+3. **Given** the user reviews the consent screen, **When** the screen lists shared categories, **Then** it includes redacted logs, plugin list and versions, runtime health, browser console entries, support-safe settings summary, and clearly identifies any optional live app view as disabled unless separately selected.
+
+---
+
+### User Story 2 - Inspect Support-Safe App State Remotely (Priority: P1)
+
+A human support person or AI support agent can open the remote dashboard for an active session and inspect the current health summary, plugin status, recent failures, logs, browser console entries, capability diagnostics, and diagnostic bundle preview without asking the user to manually export files.
+
+**Why this priority**: Remote diagnostics are the central value of the feature and must work before live view or action requests are useful.
+
+**Independent Test**: Can be tested by connecting a support dashboard to an active diagnostics-only session and verifying each diagnostic pane updates with redacted, bounded, support-safe information.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active diagnostics-only support session, **When** support opens the dashboard, **Then** the dashboard shows the Slopsmith version, runtime summary, plugin load status, orphaned plugins, health checks, recent server log entries, browser console entries, capability diagnostics, and diagnostic bundle preview.
+2. **Given** sensitive values exist in logs or settings, **When** support views diagnostics, **Then** secrets, raw local file contents, unrestricted filesystem details, and unsupported diagnostic fields are not exposed.
+3. **Given** the support side is an AI support agent, **When** it inspects the dashboard, **Then** it receives the same support-safe evidence available to human support and no privileged backdoor data.
+
+---
+
+### User Story 3 - Maintain Local Visibility and Control (Priority: P1)
+
+While a session is active, the local user sees a persistent support indicator that shows who is connected when known, the session mode, session age, expiration time, recent activity, and a one-click revoke control.
+
+**Why this priority**: Remote support is a trust-boundary feature, so the user must never lose awareness or control once sharing begins.
+
+**Independent Test**: Can be tested by starting a session, observing the local indicator during remote reads, revoking the session, and confirming remote access ends quickly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a support session is active, **When** support reads diagnostics, **Then** the local indicator remains visible and the recent activity list reflects the read.
+2. **Given** the user selects revoke, **When** the revoke action is confirmed, **Then** all remote access for that session ends and support sees the session as closed.
+3. **Given** a session reaches its expiration time, the app exits, the relay fails, or support disconnects, **When** the session closes, **Then** Slopsmith updates the local state and records the closure reason.
+
+---
+
+### User Story 4 - Request User-Approved Support Actions (Priority: P2)
+
+When diagnostics indicate a likely fix, support can request a typed action such as exporting a diagnostic bundle, rerunning health checks, restarting the backend, reloading plugins, testing an integration, or applying a proposed configuration change, and the local user can approve or deny it after seeing the purpose and risk.
+
+**Why this priority**: Approved actions reduce back-and-forth after diagnostics work, but they must remain secondary to the read-only foundation.
+
+**Independent Test**: Can be tested by submitting both low-risk and mutating action requests from the support dashboard and confirming that only eligible, granted, approved actions run.
+
+**Acceptance Scenarios**:
+
+1. **Given** an active session with action requests enabled, **When** support requests a plugin reload, **Then** Slopsmith shows the action summary, requester, risk, expected effect, and approval controls before the action can run.
+2. **Given** the user denies an action request, **When** support checks the dashboard, **Then** the action remains denied, no mutation occurs, and the denial is audited.
+3. **Given** support requests an action that is not allowed by the active session, the affected capability owner, or global safety policy, **When** the request is evaluated, **Then** Slopsmith rejects the request and records the rejection.
+
+---
+
+### User Story 5 - Use Local-Only and Policy-Restricted Support Paths (Priority: P3)
+
+A cautious user or organization can avoid remote connectivity while still using the same local diagnostic dashboard and bundle export flow, and administrators can restrict whether remote relay sessions are allowed.
+
+**Why this priority**: The feature must remain optional and useful even when relay access is unavailable or prohibited.
+
+**Independent Test**: Can be tested by disabling remote relay use, opening Remote Support, and verifying that local dashboard and diagnostic bundle export remain available while remote session creation is blocked or hidden.
+
+**Acceptance Scenarios**:
+
+1. **Given** remote relay use is disabled by policy, **When** the user opens Remote Support, **Then** Slopsmith offers local diagnostics and bundle export without creating a remote session.
+2. **Given** relay setup fails, **When** the user tries to start a remote support session, **Then** Slopsmith explains the failure, closes any partial session safely, and offers local-only diagnostic export.
+3. **Given** an organization requires a self-controlled support relay, **When** Remote Support is configured, **Then** sessions can use that approved relay option without changing the user consent, grants, redaction, or audit behavior.
+
+### Edge Cases
+
+- Session codes or URLs are expired, malformed, already used, or belong to a different relay.
+- The remote party disconnects and reconnects before the session expires.
+- The relay becomes unreachable during a diagnostic read or pending action request.
+- The support identity is unknown or cannot be verified; diagnostics may proceed with normal consent, but live view or action requests require an extra local warning approval.
+- The user closes Slopsmith while a session is active or while an approval prompt is pending.
+- Diagnostic data contains secrets, tokens, local paths, personal information, or plugin-provided fields that are not explicitly allowed for support sharing.
+- A plugin declares remote support participation but is not currently loaded, fails to initialize, or is orphaned.
+- Multiple support viewers attempt to join the same session; Slopsmith allows one active support connection, rejects additional viewers while active, and allows the same support party to reconnect before expiration.
+- Support requests actions in diagnostics-only or live-view-only mode.
+- High-risk configuration changes have large diffs or effects that cannot be summarized safely; Slopsmith rejects the action request until it can show a clear diff, exact effect, or equivalent impact summary.
+- The local audit store is unavailable, full, or cannot persist a required entry; Slopsmith fails closed by blocking the remote read or action, closing or suspending the session, and offering local-only diagnostic export.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Slopsmith MUST provide a Remote Support entry point from Settings.
+- **FR-002**: Users MUST be able to create a short-lived support session code or URL for user-initiated support.
+- **FR-003**: Users MUST be able to join a support-initiated session by entering a short-lived code or opening a session link.
+- **FR-004**: Slopsmith MUST show a consent screen before any remote session becomes active.
+- **FR-005**: The consent screen MUST list the categories of information that will be shared and distinguish required diagnostics from optional live app view or action-request access.
+- **FR-006**: Slopsmith MUST support separate session modes for view-only diagnostics, live app view, and action requests with user approval.
+- **FR-007**: View-only diagnostics mode MUST prevent remote mutation, remote control, and action execution.
+- **FR-008**: Sessions MUST have a short expiration time selected from an allowed range of 15 to 60 minutes, with a 30-minute default.
+- **FR-009**: Users MUST be able to revoke an active support session with one local action.
+- **FR-010**: Slopsmith MUST display a persistent local support indicator while any remote support session is active.
+- **FR-011**: The support indicator MUST show connected identity when known, session mode, session age, expiration time, revoke control, and recent activity.
+- **FR-012**: User installs MUST connect outward to an approved support relay or support-hosted endpoint and MUST NOT expose raw localhost services, unrestricted local endpoints, or inbound public access as the primary support mechanism.
+- **FR-013**: Remote support transport MUST carry typed support messages and MUST NOT provide arbitrary shell access, unrestricted traffic proxying, or raw desktop access.
+- **FR-014**: The support relay or transport provider MUST NOT be able to override local consent, grants, redaction, action approval, or audit policy.
+- **FR-015**: Slopsmith MUST provide a local-only fallback that can show the same support-safe diagnostics and export a diagnostic bundle without creating a remote session.
+- **FR-016**: The remote support dashboard MUST show health summary, Slopsmith version and runtime summary, plugin load status, orphaned plugins, recent server log entries, browser console entries, capability diagnostics, client and backend hardware summaries, support-safe settings summary, and diagnostic bundle preview when covered by active grants.
+- **FR-017**: Diagnostic reads MUST use allowlisted support-safe fields and the same redaction rules used for diagnostic bundle export.
+- **FR-018**: Slopsmith MUST block raw secret reads, arbitrary filesystem reads, unsupported diagnostic fields, and unredacted local file contents from leaving the machine through remote support.
+- **FR-019**: Every remote read MUST create a local audit entry that includes session, time, requester when known, category requested, grant used, and outcome.
+- **FR-020**: Every session lifecycle event MUST create a local audit entry, including creation, activation, expiration, revocation, failure, support disconnect, and app exit closure.
+- **FR-021**: Support action requests MUST be typed, allowlisted, and include requester, summary, risk level, requested effect, and bounded payload summary.
+- **FR-022**: Read-only actions MAY run without a separate approval prompt only when they are covered by the active session grants and support policy.
+- **FR-023**: Mutating actions, actions touching local files, and actions changing configuration MUST require explicit local user approval.
+- **FR-024**: High-risk action requests MUST show a diff, exact effect, or equivalent user-understandable impact summary before approval, and MUST be rejected when Slopsmith cannot generate that summary.
+- **FR-025**: Denied, expired, rejected, failed, and approved action requests MUST all be recorded in the local audit trail.
+- **FR-026**: Capability owners MAY declare which support actions are eligible, but Slopsmith core MUST remain the final authority for active grants, global safety rules, user approval, dispatch eligibility, and auditing.
+- **FR-027**: A plugin declaring remote support participation MUST NOT receive privileged access unless the local user grants an active session and core policy authorizes the specific read or action.
+- **FR-028**: Live app view MUST require a separate explicit grant and MUST provide a non-interactive screenshot stream scoped to the Slopsmith app surface rather than the desktop environment.
+- **FR-029**: Slopsmith MUST end sessions when the user revokes access, the TTL expires, the app exits, the relay fails, or support explicitly disconnects.
+- **FR-030**: After a session closes, users MUST be able to view an audit summary and export a diagnostic bundle that includes the session audit.
+- **FR-031**: Organizations or advanced users MUST be able to disable remote relay sessions while preserving local diagnostic export.
+- **FR-032**: Remote support MUST apply bounded history and rate limits for logs, console entries, snapshots, and repeated reads to preserve local performance and reduce accidental data exposure.
+- **FR-033**: If Slopsmith cannot persist a required audit entry, it MUST fail closed by blocking the remote read or action, closing or suspending the active support session, and offering local-only diagnostic export.
+- **FR-034**: A support session MUST allow only one active support connection at a time, MUST reject additional support viewers while one is active, and MAY allow the same support party to reconnect before the session expires.
+- **FR-035**: When the connected support identity cannot be verified, Slopsmith MUST label the identity as unverified and MUST require an extra local warning approval before enabling live app view or action requests.
+
+### Key Entities *(include if feature involves data)*
+
+- **Remote Support Session**: A temporary consented support relationship with an identifier, created time, expiration time, mode, status, connection summary, grants, and closure reason.
+- **Support Grant**: A scoped permission that allows a specific class of diagnostic read, live app view, or action request during one active session.
+- **Support Diagnostic Snapshot**: A redacted, bounded view of logs, console entries, plugin state, capability diagnostics, health checks, runtime summaries, settings summaries, and bundle preview data.
+- **Support Action Request**: A typed support request with requester, action type, summary, risk, expected effect, payload summary, approval state, result, and audit linkage.
+- **Audit Entry**: A local record of session lifecycle, remote reads, action requests, approvals, denials, failures, and session closure details.
+- **Support Identity**: The displayed identity of the connected human support person, organization, or AI support agent when the relay or support workflow can verify it.
+- **Relay Configuration**: The selected managed, support-hosted, or local-only support path, including policy restrictions and user-visible connection details.
+
+### Capability Pipelines *(mandatory for plugin interoperability)*
+
+- **Capabilities Affected**: settings, diagnostics, support-session lifecycle, support-audit, app live view, action requests, plugin lifecycle, integration health, capability diagnostics, diagnostic bundle export.
+- **Owners/Providers**: Slopsmith core owns consent, grants, redaction, audit, lifecycle state, safety policy, approval prompts, and privileged reads. The remote support plugin owns Settings experience, support dashboard experience, relay configuration, support pairing, and typed support message exchange. Existing diagnostic and capability owners provide support-safe summaries through core-controlled grants.
+- **Participants**: The remote support plugin requests session lifecycle changes, observes session activity, presents the local and remote experiences, and transports typed support messages. Core handles grant checks, redaction, approval, dispatch, and audit. Diagnostic contributors provide allowlisted read models. Capability owners declare eligible support actions. Human support viewers and AI support agents consume the same support-safe dashboard and may request eligible actions.
+- **Events**: Session started, session activated, session activity recorded, session expiring, session ended, diagnostics read requested, diagnostics read completed, action requested, action approved, action denied, action completed, and action failed. Event payloads include session identifier, time, requester when known, mode, affected diagnostic or action category, support-safe summary, and outcome.
+- **Commands**: Start session, join session, revoke session, inspect session, extend session within the allowed TTL range, list audit entries, request diagnostic snapshot, request log or console snapshot, request plugin or capability snapshot, request health check, request diagnostic bundle export, request approved action, approve action, deny action, and inspect action status. Commands return support-safe summaries and explicit success, denial, expiration, or failure states.
+- **Ordering**: Diagnostic reads are evaluated by active session status, grant coverage, read allowlist, redaction, rate limits, transport delivery, and audit recording. Action requests are evaluated by active session status, action-request grant, capability owner policy, global safety rules, user approval requirement, dispatch eligibility, result handling, returned support-safe payload, and audit recording.
+- **User Override Policy**: Local user revoke, denial, session close, and policy restrictions override remote support requests. User-initiated actions outside remote support are not silently converted into remote approvals. Remote action approval applies only to the specific request shown to the user.
+- **Compatibility Behavior**: If optional plugins, diagnostic contributors, capability owners, or live view providers are absent, the dashboard shows the unavailable category without failing the whole session. If relay connectivity is unavailable or disabled, local-only diagnostics and bundle export remain available.
+- **Runtime Lifecycle**: Remote support plugin scripts and dashboard surfaces must be rehydratable. Re-running plugin code in the same renderer session must not duplicate session indicators, event listeners, timers, diagnostics contributors, relay handlers, action prompts, or capability participants.
+- **Standard Declarations**: The remote support plugin declares capability pipeline support, idempotent plugin runtime support, and remote support participation. Core treats remote support participation as a privileged eligibility signal, not as automatic access, and validates behavior through session grant checks, audit records, and repeated-load regression coverage.
+- **Diagnostics**: Capability diagnostics expose active remote support session state, active grants, last redacted reads, recent action decisions, relay status, unavailable diagnostic contributors, and plugin participation status using support-safe summaries.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 90% of users can create or join a diagnostics-only support session from Settings in under 2 minutes during usability testing.
+- **SC-002**: Support can view health summary, plugin status, recent logs, console entries, and capability diagnostics for an active diagnostics-only session within 30 seconds of user approval.
+- **SC-003**: 100% of remote reads and support action requests produce local audit entries visible to the user within 5 seconds.
+- **SC-004**: In security validation, 100% of seeded secrets, unsupported diagnostic fields, and raw local file contents are absent from remote support diagnostic views.
+- **SC-005**: Users can revoke an active session with one local action, and remote access ends within 10 seconds in 99% of tested revocations.
+- **SC-006**: View-only diagnostics mode blocks 100% of mutating action requests, remote control attempts, and ungranted live view attempts in acceptance testing.
+- **SC-007**: Sessions expire automatically at or before the configured expiration time in 100% of tested sessions.
+- **SC-008**: At least 80% of support investigations for seeded plugin load, route, health, or console failures can identify the likely failing area without asking the user for additional files.
+- **SC-009**: Local-only fallback allows diagnostic bundle export and local dashboard review in under 2 minutes when remote relay access is unavailable or disabled.
+- **SC-010**: In 100% of audit persistence failure tests, Slopsmith blocks the remote read or action and closes or suspends the support session before any unaudited access continues.
+- **SC-011**: In 100% of multiple-viewer tests, Slopsmith rejects additional active support viewers and records the rejected join attempt without disrupting the existing allowed support connection.
+- **SC-012**: In 100% of unverified-identity tests, live app view and action-request grants remain disabled until the local user accepts the additional warning.
+- **SC-013**: In 100% of live-view tests, support can inspect a non-interactive screenshot stream of the Slopsmith app surface and cannot send input gestures or view desktop content outside the app surface.
+- **SC-014**: In 100% of high-risk action tests without a clear diff, exact effect, or equivalent impact summary, Slopsmith rejects the action request before presenting it for approval.
+
+## Assumptions
+
+- Remote Support is bundled as a supported Slopsmith experience but remains disabled until the local user enables or joins a session.
+- Diagnostics-only is the default and first production mode; live app view and approved actions require separate explicit grants, and live app view starts as a non-interactive app-surface screenshot stream.
+- The default session TTL is 30 minutes, with product policy allowing values from 15 to 60 minutes.
+- Support identity is displayed when it can be verified by the configured support workflow; otherwise the session clearly labels the connected party as unverified or unknown and requires an additional warning before higher-risk grants.
+- Audit summaries are retained locally for at least 30 days unless the user or organization clears them earlier by policy.
+- Local-only diagnostic dashboard and bundle export are available even when remote relay support is unavailable, disabled, or not configured.
+- The first implementation proves read-only diagnostics before enabling live app view or mutating actions.
+- Remote support never includes arbitrary shell access, raw desktop sharing, or unrestricted local service exposure.


### PR DESCRIPTION
This is an RFC for a remote support feature in the form of a speckit spec. Once reviewd, accepted and merged the spec can then be implemented in another PR by anyone. 