### PR TITLE
feat(plugin-api): emit beats:loaded when WS delivers the beats array

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -2244,8 +2244,10 @@ function createHighway() {
                             // Notify plugins that beats are now available so
                             // they don't have to poll highway.getBeats() in a
                             // setInterval to know when the WS finished
-                            // streaming the beats array.
-                            if (window.slopsmith) {
+                            // streaming the beats array. Verify .emit is
+                            // callable too — the namespace can be partially
+                            // attached during early boot.
+                            if (window.slopsmith && typeof window.slopsmith.emit === 'function') {
                                 window.slopsmith.emit('beats:loaded', { count: beats.length });
                             }
                             break;

--- a/static/highway.js
+++ b/static/highway.js
@@ -2239,7 +2239,16 @@ function createHighway() {
                                 window.slopsmith.emit('song:loaded', window.slopsmith.currentSong);
                             }
                             break;
-                        case 'beats': beats = msg.data; break;
+                        case 'beats':
+                            beats = msg.data;
+                            // Notify plugins that beats are now available so
+                            // they don't have to poll highway.getBeats() in a
+                            // setInterval to know when the WS finished
+                            // streaming the beats array.
+                            if (window.slopsmith) {
+                                window.slopsmith.emit('beats:loaded', { count: beats.length });
+                            }
+                            break;
                         case 'sections': sections = msg.data; break;
                         case 'anchors':
                             anchors = msg.data;

--- a/tests/js/beats_loaded.test.js
+++ b/tests/js/beats_loaded.test.js
@@ -63,16 +63,17 @@ test('beats:loaded emit is guarded against missing window.slopsmith', () => {
     );
 });
 
-test('beats:loaded guard verifies emit is callable', () => {
+test('beats:loaded guard verifies emit is callable (typeof check)', () => {
     // A partially-attached namespace (window.slopsmith exists but emit
     // isn't a function yet during early boot) would throw without this
-    // extra check. Accept either a typeof check or a direct truthiness
-    // check on .emit alongside the namespace test.
+    // extra check. A truthy check (`window.slopsmith.emit && ...`) lets
+    // non-callable values pass; require an explicit typeof === 'function'
+    // check so the guard catches that real edge.
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
     const block = getCaseBlock(src, 'beats');
     assert.match(
         block,
-        /typeof\s+window\.slopsmith\.emit\s*===\s*['"]function['"]|window\.slopsmith\.emit\s*&&|&&\s*window\.slopsmith\.emit/,
-        'guard must verify emit is callable, not just that the namespace exists',
+        /typeof\s+window\.slopsmith\.emit\s*===\s*['"]function['"]/,
+        'guard must use typeof === \'function\' (not just truthy) to confirm emit is callable',
     );
 });

--- a/tests/js/beats_loaded.test.js
+++ b/tests/js/beats_loaded.test.js
@@ -62,3 +62,17 @@ test('beats:loaded emit is guarded against missing window.slopsmith', () => {
         'beats:loaded emit must be guarded against a missing window.slopsmith',
     );
 });
+
+test('beats:loaded guard verifies emit is callable', () => {
+    // A partially-attached namespace (window.slopsmith exists but emit
+    // isn't a function yet during early boot) would throw without this
+    // extra check. Accept either a typeof check or a direct truthiness
+    // check on .emit alongside the namespace test.
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const block = getCaseBlock(src, 'beats');
+    assert.match(
+        block,
+        /typeof\s+window\.slopsmith\.emit\s*===\s*['"]function['"]|window\.slopsmith\.emit\s*&&|&&\s*window\.slopsmith\.emit/,
+        'guard must verify emit is callable, not just that the namespace exists',
+    );
+});

--- a/tests/js/beats_loaded.test.js
+++ b/tests/js/beats_loaded.test.js
@@ -1,0 +1,51 @@
+// Verify static/highway.js emits `beats:loaded` exactly once when the
+// WebSocket delivers the song's beats array, with `{ count }` payload.
+// Plugins that need to know when beats are available (metronome, beat-
+// snapping editors, sync visualizers) consume this contract.
+//
+// Same isolation strategy as the other tests/js/ files — extract just
+// the relevant case-block source by string matching and exercise it in
+// a vm sandbox with stubbed deps.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
+
+test('beats:loaded emit is wired into the WS beats case', () => {
+    // Source-level guard: catch a future contributor removing the emit
+    // (regression) or replacing window.slopsmith.emit with something
+    // else (intentional refactor — this test then needs updating).
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const idx = src.indexOf("case 'beats'");
+    assert.ok(idx !== -1, "case 'beats' not found in highway.js");
+
+    // Read a few hundred chars after the case label to capture the body.
+    const slice = src.slice(idx, idx + 500);
+    assert.match(
+        slice,
+        /window\.slopsmith\.emit\(\s*['"]beats:loaded['"]/,
+        'beats case must emit beats:loaded',
+    );
+    assert.match(
+        slice,
+        /count:\s*beats\.length/,
+        'beats:loaded payload must include count = beats.length',
+    );
+});
+
+test('beats:loaded emit is guarded against missing window.slopsmith', () => {
+    // The WS handler can fire before the slopsmith namespace is defined
+    // (early in app boot). The emit must be guarded so a missing
+    // namespace doesn't throw inside the WS message dispatcher.
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const idx = src.indexOf("case 'beats'");
+    const slice = src.slice(idx, idx + 500);
+    assert.match(
+        slice,
+        /if\s*\(\s*window\.slopsmith\s*\)/,
+        'beats:loaded emit must be wrapped in `if (window.slopsmith)` guard',
+    );
+});

--- a/tests/js/beats_loaded.test.js
+++ b/tests/js/beats_loaded.test.js
@@ -14,23 +14,34 @@ const path = require('node:path');
 
 const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
 
+// Extract a single switch case body so assertions can match against just
+// that block rather than a fixed-length slice (more robust to harmless
+// edits adjacent to the case).
+function getCaseBlock(src, label) {
+    const start = src.indexOf(`case '${label}'`);
+    assert.ok(start !== -1, `case '${label}' not found in highway.js`);
+    const tail = src.slice(start);
+    const nextCase = tail.search(/\n\s*case\s+['"]/);
+    const nextDefault = tail.search(/\n\s*default\s*:/);
+    let end = tail.length;
+    if (nextCase > 0) end = Math.min(end, nextCase);
+    if (nextDefault > 0) end = Math.min(end, nextDefault);
+    return tail.slice(0, end);
+}
+
 test('beats:loaded emit is wired into the WS beats case', () => {
     // Source-level guard: catch a future contributor removing the emit
     // (regression) or replacing window.slopsmith.emit with something
     // else (intentional refactor — this test then needs updating).
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    const idx = src.indexOf("case 'beats'");
-    assert.ok(idx !== -1, "case 'beats' not found in highway.js");
-
-    // Read a few hundred chars after the case label to capture the body.
-    const slice = src.slice(idx, idx + 500);
+    const block = getCaseBlock(src, 'beats');
     assert.match(
-        slice,
+        block,
         /window\.slopsmith\.emit\(\s*['"]beats:loaded['"]/,
         'beats case must emit beats:loaded',
     );
     assert.match(
-        slice,
+        block,
         /count:\s*beats\.length/,
         'beats:loaded payload must include count = beats.length',
     );
@@ -40,12 +51,14 @@ test('beats:loaded emit is guarded against missing window.slopsmith', () => {
     // The WS handler can fire before the slopsmith namespace is defined
     // (early in app boot). The emit must be guarded so a missing
     // namespace doesn't throw inside the WS message dispatcher.
+    // Looser pattern accepts any guard that reads window.slopsmith
+    // (including typeof checks and combined conditions) rather than
+    // mandating the exact `if (window.slopsmith)` form.
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    const idx = src.indexOf("case 'beats'");
-    const slice = src.slice(idx, idx + 500);
+    const block = getCaseBlock(src, 'beats');
     assert.match(
-        slice,
-        /if\s*\(\s*window\.slopsmith\s*\)/,
-        'beats:loaded emit must be wrapped in `if (window.slopsmith)` guard',
+        block,
+        /if\s*\(\s*[^)]*window\.slopsmith\b[^)]*\)/,
+        'beats:loaded emit must be guarded against a missing window.slopsmith',
     );
 });


### PR DESCRIPTION
## Summary
PR-7 in the plugin-API series (after #198/#199/#200/#201).

Plugins that depend on the song's beats (metronome, beat-snap editors, sync visualizers) currently have to poll \`highway.getBeats()\` in a \`setInterval\` to know when the array is populated. The WS handler in \`highway.js\` already knows exactly when beats arrive — emit a \`beats:loaded\` event from there so plugins can listen instead of poll.

```js
// In static/highway.js, on WS 'beats' message:
beats = msg.data;
if (window.slopsmith) {
    window.slopsmith.emit('beats:loaded', { count: beats.length });
}
```

## Payload shape
\`{ count: beats.length }\`. Plugins that need the actual array read it via the existing \`highway.getBeats()\` — keeping the event payload small and avoiding cross-realm copy of large arrays (a song can have hundreds of beats).

The emit is guarded with \`if (window.slopsmith)\` because the WS handler can fire before the slopsmith namespace is fully attached during early boot.

## Test plan
- [x] \`npm run test:js\` — 32/32. Two new source-level tests assert the wiring (case-block contains the emit + payload shape + guard).
- [x] Codex preflight against main — no actionable issues.

## Plugin-side cleanup unlocked
- Plugins that today poll \`highway.getBeats()\` for a non-empty array can switch to \`window.slopsmith.on('beats:loaded', ...)\` and call \`getBeats()\` once on the event.

## Followups in the series (not yet open)
- PR-6: \`highway.getAudioElement()\` so plugins stop reaching for \`getElementById('audio')\`.
- PR-1: monotonic \`highway.getTime()\` (eliminates ~23 ms quantization from \`audio.currentTime\` coarse steps). Largest blast radius — last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)