### PR TITLE
feat(plugin-api): expose highway.getAudioElement()

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -2327,6 +2327,13 @@ function createHighway() {
 
         getBeats() { return beats; },
         getTime() { return chartTime; },
+        // Returns the slopsmith <audio> element so plugins don't have to
+        // reach for `document.getElementById('audio')` directly. In JUCE
+        // mode this is the empty audio element that the JUCE shim writes
+        // to (sets currentTime, calls play/pause through to jucePlayer);
+        // plugins that want the actual JUCE clock should use the
+        // song:play/song:seek/song:* events' enriched payload instead.
+        getAudioElement() { return document.getElementById('audio'); },
         getNotes() { return notes; },
         getChords() { return chords; },
         // Live reference to the chord-template lookup table —

--- a/static/highway.js
+++ b/static/highway.js
@@ -2329,10 +2329,10 @@ function createHighway() {
         getTime() { return chartTime; },
         // Returns the slopsmith <audio> element so plugins don't have to
         // reach for `document.getElementById('audio')` directly. In JUCE
-        // mode this is the empty audio element that the JUCE shim writes
-        // to (sets currentTime, calls play/pause through to jucePlayer);
-        // plugins that want the actual JUCE clock should use the
-        // song:play/song:seek/song:* events' enriched payload instead.
+        // mode the same element is shimmed: `audio.currentTime` reads
+        // jucePlayer's clock and writes go through the seek queue, and
+        // `audio.play/pause` route to the JUCE backing engine — so the
+        // returned element behaves uniformly regardless of mode.
         getAudioElement() { return document.getElementById('audio'); },
         getNotes() { return notes; },
         getChords() { return chords; },

--- a/tests/js/audio_element_accessor.test.js
+++ b/tests/js/audio_element_accessor.test.js
@@ -37,6 +37,7 @@ function extractMethodBody(src, signature) {
     const start = src.indexOf(signature);
     assert.ok(start !== -1, `signature '${signature}' not found`);
     const openBrace = src.indexOf('{', start);
+    assert.ok(openBrace !== -1, `opening brace after '${signature}' not found`);
     let depth = 1;
     let i = openBrace + 1;
     while (i < src.length && depth > 0) {

--- a/tests/js/audio_element_accessor.test.js
+++ b/tests/js/audio_element_accessor.test.js
@@ -1,0 +1,53 @@
+// Verify static/highway.js exposes `getAudioElement()` on the public api
+// so plugins don't have to reach for `document.getElementById('audio')`
+// directly. Static + behavioral checks.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
+
+test('highway.api object declares getAudioElement', () => {
+    // Source-level guard: catches a future contributor renaming or
+    // dropping the method silently. The api object lives at the bottom
+    // of the closure; we look for the method's signature inside it.
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    // Locate the api block boundaries.
+    const apiStart = src.indexOf('const api = {');
+    assert.ok(apiStart !== -1, 'highway api block not found');
+    // The api block extends to `return api;`.
+    const apiEnd = src.indexOf('return api;', apiStart);
+    assert.ok(apiEnd !== -1, 'api block end (return api) not found');
+    const apiBlock = src.slice(apiStart, apiEnd);
+
+    assert.match(
+        apiBlock,
+        /getAudioElement\s*\(\s*\)\s*\{/,
+        'api object must declare getAudioElement()',
+    );
+});
+
+test('getAudioElement returns the #audio element from document', () => {
+    // Behavioral check: extract the getAudioElement method body and
+    // exercise it against a fake document. Confirms it's calling
+    // getElementById('audio') (not 'btn-play' or anything else).
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const m = src.match(/getAudioElement\s*\(\s*\)\s*\{[^}]*\}/);
+    assert.ok(m, 'getAudioElement method body not found');
+
+    // Wrap it so we can call it standalone.
+    const stub = { id: 'audio-stub' };
+    const sandbox = {
+        document: {
+            getElementById: (id) => (id === 'audio' ? stub : null),
+        },
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(`globalThis.__getAudioElement = function ${m[0]};`, sandbox);
+
+    const result = sandbox.__getAudioElement();
+    assert.equal(result, stub, 'getAudioElement must return getElementById("audio")');
+});

--- a/tests/js/audio_element_accessor.test.js
+++ b/tests/js/audio_element_accessor.test.js
@@ -30,13 +30,31 @@ test('highway.api object declares getAudioElement', () => {
     );
 });
 
+// Brace-balanced extraction so a future getAudioElement that grows
+// (guards, try/catch, nested object literals) doesn't get truncated by
+// a naive `[^}]*\}` regex.
+function extractMethodBody(src, signature) {
+    const start = src.indexOf(signature);
+    assert.ok(start !== -1, `signature '${signature}' not found`);
+    const openBrace = src.indexOf('{', start);
+    let depth = 1;
+    let i = openBrace + 1;
+    while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    assert.ok(depth === 0, `unbalanced braces after '${signature}'`);
+    return src.slice(start, i);
+}
+
 test('getAudioElement returns the #audio element from document', () => {
     // Behavioral check: extract the getAudioElement method body and
     // exercise it against a fake document. Confirms it's calling
     // getElementById('audio') (not 'btn-play' or anything else).
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    const m = src.match(/getAudioElement\s*\(\s*\)\s*\{[^}]*\}/);
-    assert.ok(m, 'getAudioElement method body not found');
+    const body = extractMethodBody(src, 'getAudioElement()');
 
     // Wrap it so we can call it standalone.
     const stub = { id: 'audio-stub' };
@@ -46,7 +64,7 @@ test('getAudioElement returns the #audio element from document', () => {
         },
     };
     vm.createContext(sandbox);
-    vm.runInContext(`globalThis.__getAudioElement = function ${m[0]};`, sandbox);
+    vm.runInContext(`globalThis.__getAudioElement = function ${body};`, sandbox);
 
     const result = sandbox.__getAudioElement();
     assert.equal(result, stub, 'getAudioElement must return getElementById("audio")');


### PR DESCRIPTION
## Summary
PR-6 in the plugin-API series (after #198/#199/#200/#201/#249).

Plugins that need slopsmith's \`<audio>\` element today reach for \`document.getElementById('audio')\` directly. That's a DOM coupling that breaks if the element is renamed or moved, and it bypasses any future indirection (e.g. JUCE-only mode might want to return a shim).

Adds \`getAudioElement()\` to the highway public api alongside the existing getters (\`getTime\`, \`getBeats\`, \`getBPM\`, …).

```js
// Plugins that already use window.highway (the canonical exposure):
const audio = window.highway.getAudioElement();
audio.addEventListener('timeupdate', () => { ... });
```

(Copilot caught my earlier draft using \`window.slopsmith.highway\` — that path doesn't exist; highway is exposed as \`window.highway\` directly. Updated.)

## Tests
- [x] \`npm run test:js\` — 35/35.
- [x] Source-level guard: api object declares \`getAudioElement()\`.
- [x] Behavioral: method body returns the \`#audio\` element from document, not some other id. Uses a brace-balanced extractor so a future method that grows guards/try-catch/nested blocks doesn't trip a naive regex.
- [x] Codex preflight against main — no actionable issues.

## Migration
In-tree consumers (\`static/app.js\`, \`static/audio-mixer.js\`, plugins) keep using \`getElementById('audio')\` for now — they execute in the same context as highway and the indirection isn't needed. External plugins that today reach into the DOM can opt in to the new accessor on their own pace.

## Followups
- PR-1: monotonic \`highway.getTime()\` (eliminates ~23 ms quantization from \`audio.currentTime\` coarse steps). Largest blast radius — last in the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)