### PR TITLE
feat(plugin-api): monotonic highway.getTime() via perfNow interpolation

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -37,7 +37,10 @@ function createHighway() {
     // anchor's perfNow fixed so interpolation continues from the right
     // origin instead of stuttering.
     let _chartAnchorAudioT = 0;
-    let _chartAnchorPerfNow = 0;
+    // NaN sentinel — `> 0` would have falsely treated perf=0 as "no prior
+    // anchor" in environments where performance.now() can return 0 (jsdom,
+    // unit test sandboxes); NaN is unambiguous.
+    let _chartAnchorPerfNow = NaN;
     // Pause detection: the 60Hz tick in app.js keeps calling setTime()
     // even while paused (with a stalled audio clock). Track when t last
     // ADVANCED (not just when setTime was called) — if it's been still
@@ -2352,8 +2355,9 @@ function createHighway() {
                 // initial anchor (no prior segment) and on near-zero
                 // dt (would divide by ~0). Clamp to a sane window so
                 // a noisy seek doesn't poison the estimate.
-                const dPerf = (newPerfNow - _chartAnchorPerfNow) / 1000;
-                if (_chartAnchorPerfNow > 0 && dPerf > 0.001 && dPerf < 0.5) {
+                const hadPriorAnchor = !Number.isNaN(_chartAnchorPerfNow);
+                const dPerf = hadPriorAnchor ? (newPerfNow - _chartAnchorPerfNow) / 1000 : 0;
+                if (hadPriorAnchor && dPerf > 0.001 && dPerf < 0.5) {
                     const observed = (t - _chartAnchorAudioT) / dPerf;
                     if (observed > 0.05 && observed < 5) {
                         _chartObservedRate = observed;
@@ -2364,7 +2368,7 @@ function createHighway() {
                         // a stale estimate from the prior segment.
                         _chartObservedRate = 1;
                     }
-                } else if (_chartAnchorPerfNow > 0 && dPerf >= 0.5) {
+                } else if (hadPriorAnchor && dPerf >= 0.5) {
                     // Long gap between anchor updates — anchor was stale
                     // (paused, tab inactive, seek). Same reset.
                     _chartObservedRate = 1;
@@ -2523,7 +2527,7 @@ function createHighway() {
             // doesn't see stale advance timestamps from the previous
             // session, and reset the observed rate to the 1x default.
             _chartAnchorAudioT = 0;
-            _chartAnchorPerfNow = 0;
+            _chartAnchorPerfNow = NaN;
             _chartLastAdvanceAt = 0;
             _chartObservedRate = 1;
             // Release the renderer's GPU / DOM / event-listener resources

--- a/static/highway.js
+++ b/static/highway.js
@@ -27,6 +27,27 @@ function createHighway() {
     let chartTime = 0;
     let currentTime = 0;
     let avOffsetSec = 0;
+    // Monotonic getTime support: between setTime() calls, getTime()
+    // interpolates forward using performance.now() so plugins observe a
+    // smooth sub-frame clock instead of the ~23 ms quantization that
+    // audio.currentTime exposes (browser updates the audio clock every
+    // ~256 samples). The anchor only updates when setTime() receives a
+    // genuinely new value — repeated calls with the same chartTime
+    // (e.g. browser hasn't refreshed audio.currentTime yet) keep the
+    // anchor's perfNow fixed so interpolation continues from the right
+    // origin instead of stuttering.
+    let _chartAnchorAudioT = 0;
+    let _chartAnchorPerfNow = 0;
+    // Playing/paused gates the interpolation: when paused, getTime
+    // returns the raw chartTime so plugins don't see a clock that
+    // drifts forward against silent audio. Driven by song:play /
+    // song:pause / song:ended events (bound lazily — window.slopsmith
+    // may not exist when createHighway runs).
+    let _chartIsPlaying = false;
+    let _slopsmithBound = false;
+    // Cap the interpolation so a stalled main thread (long task, GC,
+    // dropped tick) can't make getTime drift far past reality.
+    const _CHART_MAX_INTERP_MS = 100;
     let animFrame = null;
     let _connectOpts = {};
     let _resizeContainer = null;
@@ -2303,7 +2324,33 @@ function createHighway() {
             };
         },
 
-        setTime(t) { chartTime = t; currentTime = t + avOffsetSec; },
+        setTime(t) {
+            // Lazy-bind to song:* events so we can gate interpolation on
+            // play/pause without requiring window.slopsmith to exist when
+            // createHighway() ran.
+            if (!_slopsmithBound) {
+                _slopsmithBound = true;
+                if (typeof window !== 'undefined' && window.slopsmith && typeof window.slopsmith.on === 'function') {
+                    window.slopsmith.on('song:play', () => {
+                        _chartIsPlaying = true;
+                        _chartAnchorAudioT = chartTime;
+                        _chartAnchorPerfNow = performance.now();
+                    });
+                    window.slopsmith.on('song:pause', () => { _chartIsPlaying = false; });
+                    window.slopsmith.on('song:ended', () => { _chartIsPlaying = false; });
+                }
+            }
+            chartTime = t;
+            currentTime = t + avOffsetSec;
+            // Only re-anchor on a genuinely new audio time. Repeated
+            // calls with the same `t` (audio.currentTime hasn't updated
+            // yet) keep the anchor's perfNow fixed so interpolation
+            // continues smoothly between audio updates.
+            if (t !== _chartAnchorAudioT) {
+                _chartAnchorAudioT = t;
+                _chartAnchorPerfNow = performance.now();
+            }
+        },
         setAvOffset(ms) { avOffsetSec = (Number(ms) || 0) / 1000; currentTime = chartTime + avOffsetSec; },
         getAvOffset() { return avOffsetSec * 1000; },
 
@@ -2326,7 +2373,20 @@ function createHighway() {
         },
 
         getBeats() { return beats; },
-        getTime() { return chartTime; },
+        // Returns the chart clock smoothed via performance.now()
+        // interpolation while playing — sub-frame accurate even though
+        // the underlying audio.currentTime updates only ~every 23 ms.
+        // While paused, returns the raw chartTime (no interpolation
+        // beyond what setTime last set).
+        getTime() {
+            if (!_chartIsPlaying) return chartTime;
+            const elapsedMs = performance.now() - _chartAnchorPerfNow;
+            // If the anchor is stale (long main-thread task, dropped
+            // tick), trust the latest chartTime rather than letting
+            // interpolation drift further.
+            if (elapsedMs > _CHART_MAX_INTERP_MS) return chartTime;
+            return _chartAnchorAudioT + elapsedMs / 1000;
+        },
         // Returns the slopsmith <audio> element so plugins don't have to
         // reach for `document.getElementById('audio')` directly. In JUCE
         // mode the same element is shimmed: `audio.currentTime` reads

--- a/static/highway.js
+++ b/static/highway.js
@@ -29,9 +29,12 @@ function createHighway() {
     let avOffsetSec = 0;
     // Monotonic getTime support: between setTime() calls, getTime()
     // interpolates forward using performance.now() so plugins observe a
-    // smooth sub-frame clock instead of the ~23 ms quantization that
-    // audio.currentTime exposes (browser updates the audio clock every
-    // ~256 samples). The anchor only updates when setTime() receives a
+    // smooth sub-frame clock instead of the coarse step-quantization
+    // that audio.currentTime exposes (browsers don't refresh the
+    // reported value every audio frame — the practical gap between
+    // distinct readings is closer to 20+ ms in Chrome/Firefox even
+    // though the underlying audio thread runs much faster). The anchor
+    // only updates when setTime() receives a
     // genuinely new value — repeated calls with the same chartTime
     // (e.g. browser hasn't refreshed audio.currentTime yet) keep the
     // anchor's perfNow fixed so interpolation continues from the right

--- a/static/highway.js
+++ b/static/highway.js
@@ -36,10 +36,12 @@ function createHighway() {
     // (e.g. browser hasn't refreshed audio.currentTime yet) keep the
     // anchor's perfNow fixed so interpolation continues from the right
     // origin instead of stuttering.
-    let _chartAnchorAudioT = 0;
-    // NaN sentinel — `> 0` would have falsely treated perf=0 as "no prior
-    // anchor" in environments where performance.now() can return 0 (jsdom,
-    // unit test sandboxes); NaN is unambiguous.
+    // NaN sentinel for "no prior anchor" so the very first setTime call
+    // always triggers the re-anchor branch — even setTime(0) on the
+    // initial 60 Hz tick. Plain 0 would compare equal to setTime(0) and
+    // skip the branch, leaving _chartAnchorPerfNow uninitialized and
+    // causing getTime() to return NaN.
+    let _chartAnchorAudioT = NaN;
     let _chartAnchorPerfNow = NaN;
     // Pause detection: the 60Hz tick in app.js keeps calling setTime()
     // even while paused (with a stalled audio clock). Track when t last
@@ -2408,6 +2410,11 @@ function createHighway() {
         // so plugins don't see a clock drifting forward against silent
         // audio.
         getTime() {
+            // No anchor yet (called before the first setTime, e.g. during
+            // early boot before the 60 Hz tick has fired): just return
+            // chartTime. Without this guard, elapsedMs would be NaN and
+            // the rate-scaled return would propagate NaN to plugins.
+            if (Number.isNaN(_chartAnchorPerfNow)) return chartTime;
             const nowP = performance.now();
             // If t hasn't advanced for a while, audio is paused or the
             // tick has stopped — trust the raw chartTime.
@@ -2526,7 +2533,7 @@ function createHighway() {
             // Reset the anchor state so a fresh init/connect cycle
             // doesn't see stale advance timestamps from the previous
             // session, and reset the observed rate to the 1x default.
-            _chartAnchorAudioT = 0;
+            _chartAnchorAudioT = NaN;
             _chartAnchorPerfNow = NaN;
             _chartLastAdvanceAt = 0;
             _chartObservedRate = 1;

--- a/static/highway.js
+++ b/static/highway.js
@@ -38,15 +38,25 @@ function createHighway() {
     // origin instead of stuttering.
     let _chartAnchorAudioT = 0;
     let _chartAnchorPerfNow = 0;
-    // Playing/paused gates the interpolation: when paused, getTime
-    // returns the raw chartTime so plugins don't see a clock that
-    // drifts forward against silent audio. Driven by song:play /
-    // song:pause / song:ended events (bound lazily — window.slopsmith
-    // may not exist when createHighway runs).
-    let _chartIsPlaying = false;
-    let _slopsmithBound = false;
+    // Pause detection: the 60Hz tick in app.js keeps calling setTime()
+    // even while paused (with a stalled audio clock). Track when t last
+    // ADVANCED (not just when setTime was called) — if it's been still
+    // for a while, audio is paused and getTime() should return raw
+    // chartTime instead of interpolating forward against silent audio.
+    // Independent of song:* events — avoids the edge cases where the
+    // pause listener early-returns and never emits.
+    let _chartLastAdvanceAt = 0;
+    // Observed playback rate, derived from the actual delta between
+    // successive anchor updates. Slopsmith's speed slider (audio
+    // playbackRate != 1) means audio time advances slower/faster than
+    // real time; interpolating with a fixed 1x rate would drift. Each
+    // re-anchor refines the estimate from the latest segment. Default
+    // to 1 until we have two anchors to compare.
+    let _chartObservedRate = 1;
     // Cap the interpolation so a stalled main thread (long task, GC,
-    // dropped tick) can't make getTime drift far past reality.
+    // dropped tick) can't make getTime drift far past reality. Also the
+    // threshold for "audio looks paused" — if setTime hasn't advanced t
+    // in this long, treat as paused.
     const _CHART_MAX_INTERP_MS = 100;
     let animFrame = null;
     let _connectOpts = {};
@@ -2325,30 +2335,43 @@ function createHighway() {
         },
 
         setTime(t) {
-            // Lazy-bind to song:* events so we can gate interpolation on
-            // play/pause without requiring window.slopsmith to exist when
-            // createHighway() ran.
-            if (!_slopsmithBound) {
-                _slopsmithBound = true;
-                if (typeof window !== 'undefined' && window.slopsmith && typeof window.slopsmith.on === 'function') {
-                    window.slopsmith.on('song:play', () => {
-                        _chartIsPlaying = true;
-                        _chartAnchorAudioT = chartTime;
-                        _chartAnchorPerfNow = performance.now();
-                    });
-                    window.slopsmith.on('song:pause', () => { _chartIsPlaying = false; });
-                    window.slopsmith.on('song:ended', () => { _chartIsPlaying = false; });
-                }
-            }
             chartTime = t;
             currentTime = t + avOffsetSec;
             // Only re-anchor on a genuinely new audio time. Repeated
             // calls with the same `t` (audio.currentTime hasn't updated
             // yet) keep the anchor's perfNow fixed so interpolation
-            // continues smoothly between audio updates.
+            // continues smoothly between audio updates. Tracking
+            // _chartLastAdvanceAt here too lets getTime() detect when
+            // the audio clock has stalled (= paused) without coupling
+            // to song:* events.
             if (t !== _chartAnchorAudioT) {
+                const newPerfNow = performance.now();
+                // Derive observed rate from this anchor segment so
+                // interpolation respects speed slider changes (and
+                // any DSP-induced rate drift). Skip refresh on the
+                // initial anchor (no prior segment) and on near-zero
+                // dt (would divide by ~0). Clamp to a sane window so
+                // a noisy seek doesn't poison the estimate.
+                const dPerf = (newPerfNow - _chartAnchorPerfNow) / 1000;
+                if (_chartAnchorPerfNow > 0 && dPerf > 0.001 && dPerf < 0.5) {
+                    const observed = (t - _chartAnchorAudioT) / dPerf;
+                    if (observed > 0.05 && observed < 5) {
+                        _chartObservedRate = observed;
+                    } else {
+                        // Out-of-band rate (seek discontinuity, loop wrap,
+                        // negative jump back). We can't measure rate from
+                        // this segment, so reset to 1 instead of carrying
+                        // a stale estimate from the prior segment.
+                        _chartObservedRate = 1;
+                    }
+                } else if (_chartAnchorPerfNow > 0 && dPerf >= 0.5) {
+                    // Long gap between anchor updates — anchor was stale
+                    // (paused, tab inactive, seek). Same reset.
+                    _chartObservedRate = 1;
+                }
                 _chartAnchorAudioT = t;
-                _chartAnchorPerfNow = performance.now();
+                _chartAnchorPerfNow = newPerfNow;
+                _chartLastAdvanceAt = newPerfNow;
             }
         },
         setAvOffset(ms) { avOffsetSec = (Number(ms) || 0) / 1000; currentTime = chartTime + avOffsetSec; },
@@ -2374,18 +2397,26 @@ function createHighway() {
 
         getBeats() { return beats; },
         // Returns the chart clock smoothed via performance.now()
-        // interpolation while playing — sub-frame accurate even though
-        // the underlying audio.currentTime updates only ~every 23 ms.
-        // While paused, returns the raw chartTime (no interpolation
-        // beyond what setTime last set).
+        // interpolation while audio is actively advancing — sub-frame
+        // accurate even though audio.currentTime updates only ~every
+        // 23 ms. When audio is paused/stalled (setTime keeps being
+        // called with the same t for >100 ms), returns raw chartTime
+        // so plugins don't see a clock drifting forward against silent
+        // audio.
         getTime() {
-            if (!_chartIsPlaying) return chartTime;
-            const elapsedMs = performance.now() - _chartAnchorPerfNow;
-            // If the anchor is stale (long main-thread task, dropped
-            // tick), trust the latest chartTime rather than letting
-            // interpolation drift further.
+            const nowP = performance.now();
+            // If t hasn't advanced for a while, audio is paused or the
+            // tick has stopped — trust the raw chartTime.
+            if (nowP - _chartLastAdvanceAt > _CHART_MAX_INTERP_MS) return chartTime;
+            const elapsedMs = nowP - _chartAnchorPerfNow;
+            // Same cap as a backstop for the "long main-thread task"
+            // case — audio briefly advanced just before the stall, so
+            // we'd interpolate beyond what reality permits.
             if (elapsedMs > _CHART_MAX_INTERP_MS) return chartTime;
-            return _chartAnchorAudioT + elapsedMs / 1000;
+            // Scale by the observed playback rate so getTime stays
+            // accurate across slowdowns / speedups (audio.playbackRate
+            // != 1 is a first-class slopsmith feature).
+            return _chartAnchorAudioT + (_chartObservedRate * elapsedMs) / 1000;
         },
         // Returns the slopsmith <audio> element so plugins don't have to
         // reach for `document.getElementById('audio')` directly. In JUCE
@@ -2486,6 +2517,15 @@ function createHighway() {
                 window.removeEventListener('resize', _resizeHandler);
                 _resizeHandler = null;
             }
+            // No song:* listeners to tear down — the monotonic clock
+            // detects pause via setTime call patterns, not events.
+            // Reset the anchor state so a fresh init/connect cycle
+            // doesn't see stale advance timestamps from the previous
+            // session, and reset the observed rate to the 1x default.
+            _chartAnchorAudioT = 0;
+            _chartAnchorPerfNow = 0;
+            _chartLastAdvanceAt = 0;
+            _chartObservedRate = 1;
             // Release the renderer's GPU / DOM / event-listener resources
             // when leaving the player — anything it allocated in init()
             // should be torn down here so navigating away doesn't leak.

--- a/tests/js/highway_monotonic_clock.test.js
+++ b/tests/js/highway_monotonic_clock.test.js
@@ -1,0 +1,56 @@
+// Verify static/highway.js's getTime() interpolates smoothly via
+// performance.now() between setTime() calls (so plugins observe sub-
+// frame clock motion despite audio.currentTime's ~23 ms quantization).
+//
+// Source-level checks confirm the anchor + gating wiring is in place;
+// behavioral checks are skipped here because reproducing the createHighway
+// closure with all its dependencies (canvas, WebSocket, song state) in
+// a vm sandbox would balloon test infrastructure for marginal gain over
+// the static contract guards.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
+
+test('highway declares chart anchor + playing-gate state', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    assert.match(src, /let\s+_chartAnchorAudioT\s*=\s*0/, 'missing _chartAnchorAudioT');
+    assert.match(src, /let\s+_chartAnchorPerfNow\s*=\s*0/, 'missing _chartAnchorPerfNow');
+    assert.match(src, /let\s+_chartIsPlaying\s*=\s*false/, 'missing _chartIsPlaying');
+    assert.match(src, /const\s+_CHART_MAX_INTERP_MS\s*=\s*100/, 'missing _CHART_MAX_INTERP_MS cap');
+});
+
+test('setTime re-anchors only when t changes (smooth interp during browser-clock dwell)', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    // The setTime body must guard the anchor update with `t !== _chartAnchorAudioT`
+    // so repeated calls with the same value (audio.currentTime hasn't ticked
+    // yet) don't reset the perfNow origin and break the interpolation.
+    assert.match(
+        src,
+        /if\s*\(\s*t\s*!==\s*_chartAnchorAudioT\s*\)\s*\{\s*[\s\S]*?_chartAnchorAudioT\s*=\s*t\s*;[\s\S]*?_chartAnchorPerfNow\s*=\s*performance\.now\(\)/,
+        'setTime must re-anchor only when t differs from the previous anchor value',
+    );
+});
+
+test('setTime lazy-binds to song:play / song:pause / song:ended', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    assert.match(src, /window\.slopsmith\.on\(\s*['"]song:play['"]/, 'missing song:play subscription');
+    assert.match(src, /window\.slopsmith\.on\(\s*['"]song:pause['"]/, 'missing song:pause subscription');
+    assert.match(src, /window\.slopsmith\.on\(\s*['"]song:ended['"]/, 'missing song:ended subscription');
+});
+
+test('getTime returns chartTime when paused, interpolates when playing, caps via _CHART_MAX_INTERP_MS', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    // Locate the actual method (skip any prose mentions in JSDoc / comments).
+    // The api object declares `getTime() { ... }` — match the signature
+    // followed by an opening brace and a few lines of body.
+    const m = src.match(/getTime\(\)\s*\{[\s\S]{0,800}?_chartIsPlaying[\s\S]{0,400}/);
+    assert.ok(m, 'getTime() method body referencing _chartIsPlaying not found');
+    const slice = m[0];
+    assert.match(slice, /if\s*\(\s*!_chartIsPlaying\s*\)\s*return\s+chartTime/, 'getTime must return raw chartTime when paused');
+    assert.match(slice, /performance\.now\(\)\s*-\s*_chartAnchorPerfNow/, 'getTime must interpolate via perfNow - anchorPerfNow');
+    assert.match(slice, /elapsedMs\s*>\s*_CHART_MAX_INTERP_MS/, 'getTime must enforce the interpolation cap');
+});

--- a/tests/js/highway_monotonic_clock.test.js
+++ b/tests/js/highway_monotonic_clock.test.js
@@ -2,11 +2,10 @@
 // performance.now() between setTime() calls (so plugins observe sub-
 // frame clock motion despite audio.currentTime's ~23 ms quantization).
 //
-// Source-level checks confirm the anchor + gating wiring is in place;
-// behavioral checks are skipped here because reproducing the createHighway
-// closure with all its dependencies (canvas, WebSocket, song state) in
-// a vm sandbox would balloon test infrastructure for marginal gain over
-// the static contract guards.
+// Source-level checks confirm the anchor + stall-detect wiring is in
+// place; behavioral tests would require reproducing the createHighway
+// closure with all its dependencies in a vm sandbox, which is out of
+// proportion to what these source-level guards already catch.
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
@@ -15,42 +14,77 @@ const path = require('node:path');
 
 const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
 
-test('highway declares chart anchor + playing-gate state', () => {
+test('highway declares chart anchor + stall-detect + rate state', () => {
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
     assert.match(src, /let\s+_chartAnchorAudioT\s*=\s*0/, 'missing _chartAnchorAudioT');
     assert.match(src, /let\s+_chartAnchorPerfNow\s*=\s*0/, 'missing _chartAnchorPerfNow');
-    assert.match(src, /let\s+_chartIsPlaying\s*=\s*false/, 'missing _chartIsPlaying');
+    assert.match(src, /let\s+_chartLastAdvanceAt\s*=\s*0/, 'missing _chartLastAdvanceAt (pause detection)');
+    assert.match(src, /let\s+_chartObservedRate\s*=\s*1/, 'missing _chartObservedRate (playback rate awareness)');
     assert.match(src, /const\s+_CHART_MAX_INTERP_MS\s*=\s*100/, 'missing _CHART_MAX_INTERP_MS cap');
 });
 
-test('setTime re-anchors only when t changes (smooth interp during browser-clock dwell)', () => {
+test('getTime scales interpolation by _chartObservedRate (speed-slider safe)', () => {
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    // The setTime body must guard the anchor update with `t !== _chartAnchorAudioT`
-    // so repeated calls with the same value (audio.currentTime hasn't ticked
-    // yet) don't reset the perfNow origin and break the interpolation.
+    const m = src.match(/getTime\(\)\s*\{[\s\S]+?\n\s*\},/);
+    assert.ok(m, 'getTime() body not found');
+    const slice = m[0];
     assert.match(
-        src,
-        /if\s*\(\s*t\s*!==\s*_chartAnchorAudioT\s*\)\s*\{\s*[\s\S]*?_chartAnchorAudioT\s*=\s*t\s*;[\s\S]*?_chartAnchorPerfNow\s*=\s*performance\.now\(\)/,
-        'setTime must re-anchor only when t differs from the previous anchor value',
+        slice,
+        /_chartObservedRate\s*\*\s*elapsedMs/,
+        'getTime must scale interpolation by observed rate so audio.playbackRate != 1 stays accurate',
     );
 });
 
-test('setTime lazy-binds to song:play / song:pause / song:ended', () => {
+test('setTime re-anchors and updates _chartLastAdvanceAt only when t actually changes', () => {
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    assert.match(src, /window\.slopsmith\.on\(\s*['"]song:play['"]/, 'missing song:play subscription');
-    assert.match(src, /window\.slopsmith\.on\(\s*['"]song:pause['"]/, 'missing song:pause subscription');
-    assert.match(src, /window\.slopsmith\.on\(\s*['"]song:ended['"]/, 'missing song:ended subscription');
+    // Repeated setTime calls with the same value must not refresh the
+    // anchor (else interpolation stutters); they also must not refresh
+    // _chartLastAdvanceAt (else getTime would never detect a stalled
+    // audio clock as paused).
+    // The implementation may capture performance.now() into a local
+    // (e.g. newPerfNow) and assign that to both fields; accept either
+    // direct or via-local writes.
+    const m = src.match(/if\s*\(\s*t\s*!==\s*_chartAnchorAudioT\s*\)\s*\{[\s\S]+?\}\s*\},/);
+    assert.ok(m, 'if (t !== _chartAnchorAudioT) block not found inside setTime');
+    const block = m[0];
+    assert.match(block, /_chartAnchorAudioT\s*=\s*t/, 'must assign _chartAnchorAudioT = t');
+    assert.match(block, /_chartAnchorPerfNow\s*=/, 'must assign _chartAnchorPerfNow');
+    assert.match(block, /_chartLastAdvanceAt\s*=/, 'must assign _chartLastAdvanceAt');
 });
 
-test('getTime returns chartTime when paused, interpolates when playing, caps via _CHART_MAX_INTERP_MS', () => {
+test('getTime falls back to chartTime when audio has stalled (paused)', () => {
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    // Locate the actual method (skip any prose mentions in JSDoc / comments).
-    // The api object declares `getTime() { ... }` — match the signature
-    // followed by an opening brace and a few lines of body.
-    const m = src.match(/getTime\(\)\s*\{[\s\S]{0,800}?_chartIsPlaying[\s\S]{0,400}/);
-    assert.ok(m, 'getTime() method body referencing _chartIsPlaying not found');
+    // Find the actual getTime body. Match the whole brace-balanced
+    // method (using a generous greedy slice to ensure we capture both
+    // the stall check and the interpolation expression below it).
+    const m = src.match(/getTime\(\)\s*\{[\s\S]+?\n\s*\},/);
+    assert.ok(m, 'getTime() body not found');
     const slice = m[0];
-    assert.match(slice, /if\s*\(\s*!_chartIsPlaying\s*\)\s*return\s+chartTime/, 'getTime must return raw chartTime when paused');
-    assert.match(slice, /performance\.now\(\)\s*-\s*_chartAnchorPerfNow/, 'getTime must interpolate via perfNow - anchorPerfNow');
-    assert.match(slice, /elapsedMs\s*>\s*_CHART_MAX_INTERP_MS/, 'getTime must enforce the interpolation cap');
+    // Must check stall-since-last-advance against the cap.
+    assert.match(
+        slice,
+        /nowP\s*-\s*_chartLastAdvanceAt\s*>\s*_CHART_MAX_INTERP_MS/,
+        'getTime must short-circuit when audio has stalled past the cap',
+    );
+    // Must interpolate when active.
+    assert.match(slice, /performance\.now\(\)|nowP/, 'getTime must use perfNow');
+    // Rate-scaled formula: _chartAnchorAudioT + (_chartObservedRate * elapsedMs) / 1000
+    assert.match(
+        slice,
+        /_chartAnchorAudioT\s*\+\s*\(\s*_chartObservedRate\s*\*\s*elapsedMs\s*\)\s*\/\s*1000/,
+        'getTime must compute anchor + rate-scaled elapsed during play',
+    );
+});
+
+test('api.stop() clears the chart anchor state so re-init starts fresh', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const stopIdx = src.indexOf('stop() {');
+    assert.ok(stopIdx !== -1, 'api.stop() not found');
+    // The stop block runs until the next method declaration; grab a
+    // generous slice and assert the anchor state resets.
+    const stopBlock = src.slice(stopIdx, stopIdx + 1500);
+    assert.match(stopBlock, /_chartAnchorAudioT\s*=\s*0/, 'stop() must reset _chartAnchorAudioT');
+    assert.match(stopBlock, /_chartAnchorPerfNow\s*=\s*0/, 'stop() must reset _chartAnchorPerfNow');
+    assert.match(stopBlock, /_chartLastAdvanceAt\s*=\s*0/, 'stop() must reset _chartLastAdvanceAt');
+    assert.match(stopBlock, /_chartObservedRate\s*=\s*1/, 'stop() must reset _chartObservedRate to 1x');
 });

--- a/tests/js/highway_monotonic_clock.test.js
+++ b/tests/js/highway_monotonic_clock.test.js
@@ -1,6 +1,8 @@
 // Verify static/highway.js's getTime() interpolates smoothly via
 // performance.now() between setTime() calls (so plugins observe sub-
-// frame clock motion despite audio.currentTime's ~23 ms quantization).
+// frame clock motion despite audio.currentTime's coarse step
+// quantization — browsers refresh the reported value at ~20+ ms
+// granularity even though the underlying audio thread runs faster).
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');

--- a/tests/js/highway_monotonic_clock.test.js
+++ b/tests/js/highway_monotonic_clock.test.js
@@ -128,11 +128,10 @@ test('getTime falls back to chartTime when audio has stalled (paused)', () => {
 
 test('api.stop() clears the chart anchor state so re-init starts fresh', () => {
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    const stopIdx = src.indexOf('stop() {');
-    assert.ok(stopIdx !== -1, 'api.stop() not found');
-    // The stop block runs until the next method declaration; grab a
-    // generous slice and assert the anchor state resets.
-    const stopBlock = src.slice(stopIdx, stopIdx + 1500);
+    // Use the brace-balanced extractor so the assertions are scoped to
+    // the actual stop() body — a fixed-size slice would falsely match
+    // resets that landed in an adjacent method.
+    const stopBlock = extractBlock(src, 'stop() {');
     assert.match(stopBlock, /_chartAnchorAudioT\s*=\s*NaN/, 'stop() must reset _chartAnchorAudioT to the NaN sentinel');
     assert.match(stopBlock, /_chartAnchorPerfNow\s*=\s*NaN/, 'stop() must reset _chartAnchorPerfNow to the NaN sentinel');
     assert.match(stopBlock, /_chartLastAdvanceAt\s*=\s*0/, 'stop() must reset _chartLastAdvanceAt');

--- a/tests/js/highway_monotonic_clock.test.js
+++ b/tests/js/highway_monotonic_clock.test.js
@@ -37,9 +37,10 @@ function buildClockSandbox(perfNowImpl) {
         chartTime: 0,
         currentTime: 0,
         avOffsetSec: 0,
-        _chartAnchorAudioT: 0,
-        // Match production: NaN sentinel for "no prior anchor" so the
-        // first setTime call doesn't try to derive rate from nothing.
+        // Match production: NaN sentinels for "no prior anchor" so
+        // the first setTime call always re-anchors (even setTime(0))
+        // and so getTime() before any setTime returns chartTime.
+        _chartAnchorAudioT: NaN,
         _chartAnchorPerfNow: NaN,
         _chartLastAdvanceAt: 0,
         _chartObservedRate: 1,
@@ -61,9 +62,11 @@ function buildClockSandbox(perfNowImpl) {
 
 test('highway declares chart anchor + stall-detect + rate state', () => {
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
-    assert.match(src, /let\s+_chartAnchorAudioT\s*=\s*0/, 'missing _chartAnchorAudioT');
-    // Initialized to NaN as a "no prior anchor" sentinel — `> 0` on
-    // perf=0 was ambiguous in jsdom/test contexts.
+    // Both anchor fields use NaN sentinels — _chartAnchorAudioT in
+    // particular MUST start as NaN, not 0, otherwise setTime(0) on the
+    // very first 60 Hz tick fails the `t !== _chartAnchorAudioT` check
+    // and never re-anchors, leaving the clock uninitialized.
+    assert.match(src, /let\s+_chartAnchorAudioT\s*=\s*NaN/, 'missing _chartAnchorAudioT (NaN sentinel)');
     assert.match(src, /let\s+_chartAnchorPerfNow\s*=\s*NaN/, 'missing _chartAnchorPerfNow (NaN sentinel)');
     assert.match(src, /let\s+_chartLastAdvanceAt\s*=\s*0/, 'missing _chartLastAdvanceAt (pause detection)');
     assert.match(src, /let\s+_chartObservedRate\s*=\s*1/, 'missing _chartObservedRate (playback rate awareness)');
@@ -130,7 +133,7 @@ test('api.stop() clears the chart anchor state so re-init starts fresh', () => {
     // The stop block runs until the next method declaration; grab a
     // generous slice and assert the anchor state resets.
     const stopBlock = src.slice(stopIdx, stopIdx + 1500);
-    assert.match(stopBlock, /_chartAnchorAudioT\s*=\s*0/, 'stop() must reset _chartAnchorAudioT');
+    assert.match(stopBlock, /_chartAnchorAudioT\s*=\s*NaN/, 'stop() must reset _chartAnchorAudioT to the NaN sentinel');
     assert.match(stopBlock, /_chartAnchorPerfNow\s*=\s*NaN/, 'stop() must reset _chartAnchorPerfNow to the NaN sentinel');
     assert.match(stopBlock, /_chartLastAdvanceAt\s*=\s*0/, 'stop() must reset _chartLastAdvanceAt');
     assert.match(stopBlock, /_chartObservedRate\s*=\s*1/, 'stop() must reset _chartObservedRate to 1x');
@@ -206,4 +209,48 @@ test('behavior: getTime caps interpolation at _CHART_MAX_INTERP_MS', () => {
     now = 200;
     const t = sb.getTime();
     assert.equal(t, 10.05, 'beyond cap must fall back to chartTime');
+});
+
+test('behavior: setTime(0) on first tick anchors correctly (boot edge case)', () => {
+    // Regression: _chartAnchorAudioT used to start at 0, so setTime(0)
+    // on the very first 60 Hz tick failed the `t !== _chartAnchorAudioT`
+    // check and skipped the re-anchor branch entirely. _chartAnchorPerfNow
+    // would stay NaN, and getTime would propagate NaN to plugins.
+    let now = 16; // realistic first-tick perf
+    const sb = buildClockSandbox(() => now);
+    sb.setTime(0);
+    // Anchor must now be initialized.
+    assert.equal(sb._chartAnchorAudioT, 0, 'setTime(0) on first tick must set anchor.audioT');
+    assert.equal(sb._chartAnchorPerfNow, 16, 'setTime(0) on first tick must set anchor.perfNow');
+    // getTime should return a finite value, not NaN.
+    const t = sb.getTime();
+    assert.ok(!Number.isNaN(t), `getTime must not return NaN after setTime(0); got ${t}`);
+});
+
+test('behavior: getTime before any setTime returns chartTime (no NaN)', () => {
+    // Regression: getTime called during early boot (before the first
+    // 60 Hz tick) used to compute `nowP - NaN` and propagate NaN. Must
+    // bail to chartTime when the anchor is still the NaN sentinel.
+    let now = 0;
+    const sb = buildClockSandbox(() => now);
+    const t = sb.getTime();
+    assert.equal(t, 0, 'getTime before any setTime must return chartTime, not NaN');
+    assert.ok(!Number.isNaN(t), 'getTime must not return NaN');
+});
+
+test('behavior: long anchor gap resets observed rate to 1x', () => {
+    // After a long gap (e.g. tab inactive, paused for a while), the
+    // next setTime() shouldn't carry forward the prior segment's
+    // observed rate — it likely reflects a different playback state.
+    let now = 0;
+    const sb = buildClockSandbox(() => now);
+    sb.setTime(10);
+    now = 50;
+    sb.setTime(10.025); // observed rate ≈ 0.5
+    assert.ok(Math.abs(sb._chartObservedRate - 0.5) < 0.001, 'first segment measured 0.5x');
+    // Long gap (1 second) before next setTime — out of the dPerf < 0.5
+    // window, so the rate must reset to 1.
+    now = 1100;
+    sb.setTime(10.5);
+    assert.equal(sb._chartObservedRate, 1, 'long anchor gap must reset rate to 1x');
 });

--- a/tests/js/highway_monotonic_clock.test.js
+++ b/tests/js/highway_monotonic_clock.test.js
@@ -1,23 +1,70 @@
 // Verify static/highway.js's getTime() interpolates smoothly via
 // performance.now() between setTime() calls (so plugins observe sub-
 // frame clock motion despite audio.currentTime's ~23 ms quantization).
-//
-// Source-level checks confirm the anchor + stall-detect wiring is in
-// place; behavioral tests would require reproducing the createHighway
-// closure with all its dependencies in a vm sandbox, which is out of
-// proportion to what these source-level guards already catch.
 
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const vm = require('node:vm');
 
 const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
+
+// Brace-balanced extraction so source-level tests stay robust to body
+// growth. Returns the full method-or-block text including its braces.
+function extractBlock(src, signature) {
+    const start = src.indexOf(signature);
+    assert.ok(start !== -1, `signature '${signature}' not found`);
+    const openBrace = src.indexOf('{', start);
+    assert.ok(openBrace !== -1, `opening brace after '${signature}' not found`);
+    let depth = 1;
+    let i = openBrace + 1;
+    while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    assert.ok(depth === 0, `unbalanced braces after '${signature}'`);
+    return src.slice(start, i);
+}
+
+// Build a sandbox with the chart-clock state and the extracted setTime
+// + getTime methods so behavioral tests can exercise the real
+// implementation in isolation.
+function buildClockSandbox(perfNowImpl) {
+    const sandbox = {
+        chartTime: 0,
+        currentTime: 0,
+        avOffsetSec: 0,
+        _chartAnchorAudioT: 0,
+        // Match production: NaN sentinel for "no prior anchor" so the
+        // first setTime call doesn't try to derive rate from nothing.
+        _chartAnchorPerfNow: NaN,
+        _chartLastAdvanceAt: 0,
+        _chartObservedRate: 1,
+        _CHART_MAX_INTERP_MS: 100,
+        performance: { now: perfNowImpl },
+    };
+    vm.createContext(sandbox);
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const setTimeBody = extractBlock(src, 'setTime(t) {');
+    const getTimeBody = extractBlock(src, 'getTime() {');
+    // Strip trailing comma if present (object-literal method declarations).
+    const cleanup = (s) => s.replace(/,?\s*$/, '');
+    vm.runInContext(`
+        globalThis.setTime = function ${cleanup(setTimeBody)};
+        globalThis.getTime = function ${cleanup(getTimeBody)};
+    `, sandbox);
+    return sandbox;
+}
 
 test('highway declares chart anchor + stall-detect + rate state', () => {
     const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
     assert.match(src, /let\s+_chartAnchorAudioT\s*=\s*0/, 'missing _chartAnchorAudioT');
-    assert.match(src, /let\s+_chartAnchorPerfNow\s*=\s*0/, 'missing _chartAnchorPerfNow');
+    // Initialized to NaN as a "no prior anchor" sentinel — `> 0` on
+    // perf=0 was ambiguous in jsdom/test contexts.
+    assert.match(src, /let\s+_chartAnchorPerfNow\s*=\s*NaN/, 'missing _chartAnchorPerfNow (NaN sentinel)');
     assert.match(src, /let\s+_chartLastAdvanceAt\s*=\s*0/, 'missing _chartLastAdvanceAt (pause detection)');
     assert.match(src, /let\s+_chartObservedRate\s*=\s*1/, 'missing _chartObservedRate (playback rate awareness)');
     assert.match(src, /const\s+_CHART_MAX_INTERP_MS\s*=\s*100/, 'missing _CHART_MAX_INTERP_MS cap');
@@ -84,7 +131,79 @@ test('api.stop() clears the chart anchor state so re-init starts fresh', () => {
     // generous slice and assert the anchor state resets.
     const stopBlock = src.slice(stopIdx, stopIdx + 1500);
     assert.match(stopBlock, /_chartAnchorAudioT\s*=\s*0/, 'stop() must reset _chartAnchorAudioT');
-    assert.match(stopBlock, /_chartAnchorPerfNow\s*=\s*0/, 'stop() must reset _chartAnchorPerfNow');
+    assert.match(stopBlock, /_chartAnchorPerfNow\s*=\s*NaN/, 'stop() must reset _chartAnchorPerfNow to the NaN sentinel');
     assert.match(stopBlock, /_chartLastAdvanceAt\s*=\s*0/, 'stop() must reset _chartLastAdvanceAt');
     assert.match(stopBlock, /_chartObservedRate\s*=\s*1/, 'stop() must reset _chartObservedRate to 1x');
+});
+
+// ── Behavioral tests (run extracted setTime/getTime in vm sandbox) ──────
+
+test('behavior: getTime interpolates smoothly between two anchors at 1x', () => {
+    let now = 0;
+    const sb = buildClockSandbox(() => now);
+    // First anchor at audioT=10, perf=0.
+    sb.setTime(10);
+    // Browser hasn't refreshed audio.currentTime; setTime called again
+    // with the same value at perf=16. Anchor must NOT move.
+    now = 16;
+    sb.setTime(10);
+    // Plugin reads at perf=24 — interpolated 24ms from anchor.
+    now = 24;
+    const t = sb.getTime();
+    assert.ok(Math.abs(t - (10 + 0.024)) < 0.001, `expected ~10.024, got ${t}`);
+});
+
+test('behavior: getTime returns chartTime when audio has stalled (paused)', () => {
+    let now = 0;
+    const sb = buildClockSandbox(() => now);
+    sb.setTime(10);
+    now = 16; sb.setTime(10);
+    // 200ms after the last advance — well past the 100ms cap. Even
+    // though setTime is still being called every 16ms with the same
+    // value (the 60Hz tick), getTime must report raw chartTime.
+    now = 200;
+    const t = sb.getTime();
+    assert.equal(t, 10, `paused getTime must be chartTime (10), got ${t}`);
+});
+
+test('behavior: getTime adjusts for non-1x playback rate (observed)', () => {
+    let now = 0;
+    const sb = buildClockSandbox(() => now);
+    // Establish initial anchor.
+    sb.setTime(10);
+    // Audio advanced 0.025s in 50ms real time → observed rate = 0.5.
+    now = 50;
+    sb.setTime(10.025);
+    // Read 25ms after the latest anchor: chart should advance by
+    // rate * elapsed = 0.5 * 0.025 = 0.0125 → 10.0375.
+    now = 75;
+    const t = sb.getTime();
+    assert.ok(Math.abs(t - 10.0375) < 0.0005, `expected ~10.0375 (rate-scaled), got ${t}`);
+});
+
+test('behavior: seek discontinuity resets observed rate to 1x', () => {
+    let now = 0;
+    const sb = buildClockSandbox(() => now);
+    sb.setTime(10);
+    now = 50;
+    sb.setTime(10.025); // observed rate ≈ 0.5
+    assert.ok(Math.abs(sb._chartObservedRate - 0.5) < 0.001, `prior segment must measure ≈0.5, got ${sb._chartObservedRate}`);
+    // Seek: large t jump in same perf delta — observed-rate clamp
+    // rejects this segment, resets to 1.
+    now = 70;
+    sb.setTime(120); // dPerf=20ms, dT=110s → observed=5500 (out of clamp)
+    assert.equal(sb._chartObservedRate, 1, 'seek must reset rate to 1x');
+});
+
+test('behavior: getTime caps interpolation at _CHART_MAX_INTERP_MS', () => {
+    let now = 0;
+    const sb = buildClockSandbox(() => now);
+    sb.setTime(10);
+    now = 50;
+    sb.setTime(10.05); // observed rate ~1
+    // Long pause-like gap with NO setTime call. getTime should detect
+    // (now - _chartLastAdvanceAt > 100) and return chartTime.
+    now = 200;
+    const t = sb.getTime();
+    assert.equal(t, 10.05, 'beyond cap must fall back to chartTime');
 });


### PR DESCRIPTION
## Summary
PR-1 in the plugin-API series — final, largest blast radius (highway clock is hot-path for every renderer and plugin reading getTime).

Plugins reading \`highway.getTime()\` today see ~23 ms quantization because \`audio.currentTime\` only updates every ~256 audio samples (browser-side). The 60 Hz tick re-syncs chartTime each frame, but pulls the same audio value for ~1.4 frames in a row before it jumps. Plugins that score, hit-detect, or animate against getTime see step-quantized motion.

## Approach
Smooth via \`performance.now()\` interpolation between setTime() calls. Pause detection is **decoupled from song:* events** — derived from setTime call patterns instead, since the audio.pause listener intentionally suppresses song:pause at end-of-track (see #201 round 3) and would be unreliable here.

```
setTime(t):
    chartTime = t
    if t !== anchor.audioT:
        # audio actually advanced — re-anchor + measure rate
        observedRate = (t - anchor.audioT) / (perfNow - anchor.perfNow)
            (clamped: out-of-band → reset to 1)
        anchor = (t, perfNow)
        lastAdvanceAt = perfNow

getTime():
    if perfNow - lastAdvanceAt > 100ms: return chartTime  # paused
    elapsed = perfNow - anchor.perfNow
    if elapsed > 100ms: return chartTime  # stalled tick
    return anchor.audioT + observedRate * elapsed / 1000
```

## Trade-off acknowledged
With event-driven gating dropped, \`getTime()\` can drift forward up to 100 ms after audio pauses — until \`_chartLastAdvanceAt > _CHART_MAX_INTERP_MS\` trips. This is the deliberate cost of decoupling. Same parameter (100 ms) bounds the drift window. Plugins that need instant pause detection should listen to \`song:pause\` directly.

## Rate awareness
\`audio.playbackRate != 1\` (slopsmith's speed slider) is a first-class case. Each anchor refresh derives observed rate from the latest segment; getTime scales interpolation by it. Seek discontinuities (out-of-band rate values) reset to 1x rather than carrying a stale estimate.

## Risk surface
The highway clock is hot-path for every renderer and any plugin reading \`getTime\`. Risk areas:
- **Note hit detection**: getTime now reads slightly ahead of the previous quantized value. Hit windows expressed as \`Math.abs(noteTime - getTime()) < threshold\` should still work — they were calibrated against the noisy audio clock anyway.
- **A-B loop wrap detection**: 60 Hz tick uses \`_audioTime()\` (raw), not \`highway.getTime()\`, so unaffected.
- **Drill mode iteration boundaries**: subscribes to \`loop:restart\` (#198), not getTime polling. Unaffected.

## Tests
- [x] \`npm run test:js\` — 45/45 (5 source-level + 5 behavioral).
- [x] Behavioral tests run extracted setTime/getTime in a vm sandbox: smooth-interp at 1x, pause-stall fallback, rate-aware scaling at 0.5x, seek discontinuity reset, cap enforcement.
- [x] Codex preflight against main — no actionable issues.
- [ ] **Manual smoke required before merge**: note hit accuracy, A-B loop, drill mode, 3D highway. Will run a 30-min session against the running container before requesting final review.

## Series complete
With this PR landed, the original 7-PR plugin-API series (#198/#199/#200/#201/#249/#250 + this) is in main:
- \`loop:restart\`, \`song:seek\`, \`setLoop/clearLoop/getLoop\`, enriched \`song:*\` payloads, \`beats:loaded\`, \`highway.getAudioElement()\`, monotonic \`highway.getTime()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)