### PR TITLE
fix(highway): skip rAF draw when hidden; emit highway:visibility (#246)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,17 @@ Selecting this plugin in the main-player viz picker — or in splitscreen's per-
     });
     ```
     Plugins that re-query `document.getElementById('highway')` lazily inside their own event handlers don't need this listener — they pick up the new element automatically (it keeps `id="highway"`).
+  - **`highway:visibility`** — fired on `window.slopsmith` whenever the highway canvas transitions between displayed and hidden. Detection is DOM-based via `canvas.offsetParent === null` (catches `display:none` on the canvas or any ancestor — e.g. splitscreen's `#highway` hide) or whatever a host explicitly sets via `highway.setVisible(bool)`. While `visible === false`, core skips the rAF `renderer.draw(bundle)` call AND the default 2D draw, so renderers don't have to no-op themselves. The event is emitted only on transitions (including the first one after `init()`), not every frame. Payload `{ visible, canvas }` lives on `event.detail`:
+    ```js
+    window.slopsmith.on('highway:visibility', (event) => {
+        const { visible, canvas } = event.detail;
+        // Toggle any sibling DOM your renderer mounts. The 3D Highway
+        // renderer hides its `.h3d-wrap` overlay here so `display:none`
+        // on `#highway` actually hides the visible output.
+    });
+    ```
+    Renderers that only paint to the slopsmith canvas don't need this listener — the rAF skip is enough. Renderers that mount sibling DOM (separate WebGL contexts, overlays, etc.) do.
+  - **`highway.setVisible(bool | null)`** — forces the visibility state regardless of `offsetParent`. Pass `null` to clear the override and resume DOM-based detection. Useful when the host hides the highway via `visibility:hidden`, `opacity:0`, transforms, or clipping rather than `display:none`. The override re-emits any resulting transition immediately rather than waiting for the next rAF tick.
   - Default-renderer ctx is closure-cached. The replace path nulls the closure ctx so stale draw paths short-circuit; the next default-renderer `init()` re-acquires the 2D context from the new canvas cleanly.
 - `draw(bundle)` receives difficulty-filtered arrays — never read from `_filteredNotes` or other internals.
 - `_drawHooks` fire for the default 2D renderer (the factory calls them at the end of each frame). Custom WebGL renderers that maintain a 2D overlay canvas (like the bundled 3D highway) also call `window.highway.fireDrawHooks(ctx, W, H)` on that overlay so overlay plugins continue to work regardless of which renderer is active. Custom renderers without a 2D overlay context should not attempt to fire hooks.

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -1557,6 +1557,13 @@
         // hiding #highway leaves the WebGL scene painting full-screen.
         // Bound in initScene after wrap creation, unbound in destroy().
         let _visibilityHandler = null;
+        // highway:canvas-replaced listener — keeps highwayCanvas up to
+        // date across context-type swaps (e.g. swapping back to a 2D
+        // viz). The visibility handler's identity gate (event.detail.
+        // canvas === highwayCanvas) would otherwise stop matching
+        // after the swap; this listener follows the documented plugin
+        // contract from CLAUDE.md.
+        let _canvasReplacedHandler = null;
         let ambLight = null, dirLight = null;
         let fretG = null, tuningLblG = null, noteG = null, beatG = null, lblG = null;
         let gNote = null, gSus = null, gBeat = null, gTechArrow = null, gTapChevron = null;
@@ -2837,6 +2844,27 @@
                     window.slopsmith.on('highway:visibility', _visibilityHandler);
                 } catch (e) {
                     _visibilityHandler = null;
+                }
+                // Track canvas-replaced so the visibility handler's
+                // identity gate continues to match after core swaps the
+                // <canvas> element for a context-type change.
+                _canvasReplacedHandler = (e) => {
+                    if (!e || !e.detail) return;
+                    // Only update if the swap involves OUR canvas — in
+                    // splitscreen each panel has its own canvas.
+                    if (e.detail.oldCanvas !== highwayCanvas) return;
+                    highwayCanvas = e.detail.newCanvas;
+                    // Re-sync wrap visibility from the new canvas in
+                    // case its initial displayed-state differs.
+                    if (wrap) {
+                        const v = highwayCanvas && highwayCanvas.offsetParent !== null;
+                        wrap.style.display = v ? '' : 'none';
+                    }
+                };
+                try {
+                    window.slopsmith.on('highway:canvas-replaced', _canvasReplacedHandler);
+                } catch (e) {
+                    _canvasReplacedHandler = null;
                 }
                 // Sync once at bind time: the event is transition-only,
                 // so if the canvas was already hidden when we mounted
@@ -5829,9 +5857,13 @@
                 if (_visibilityHandler) {
                     try { window.slopsmith.off('highway:visibility', _visibilityHandler); } catch (e) {}
                 }
+                if (_canvasReplacedHandler) {
+                    try { window.slopsmith.off('highway:canvas-replaced', _canvasReplacedHandler); } catch (e) {}
+                }
             }
             _ndOnBusHit = _ndOnBusMiss = null;
             _visibilityHandler = null;
+            _canvasReplacedHandler = null;
             _ndHitMarks = [];
             _ndMissMarks = [];
             _ndLabels = [];

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -1551,6 +1551,12 @@
         // ── Per-instance Three.js state ───────────────────────────────────
         let scene = null, cam = null, ren = null;
         let wrap = null;
+        // highway:visibility listener (slopsmith#246). Hides the .h3d-wrap
+        // overlay when slopsmith's canvas is display:none'd (splitscreen
+        // case). Without this, the wrap is a *sibling* of #highway so
+        // hiding #highway leaves the WebGL scene painting full-screen.
+        // Bound in initScene after wrap creation, unbound in destroy().
+        let _visibilityHandler = null;
         let ambLight = null, dirLight = null;
         let fretG = null, tuningLblG = null, noteG = null, beatG = null, lblG = null;
         let gNote = null, gSus = null, gBeat = null, gTechArrow = null, gTapChevron = null;
@@ -2805,6 +2811,34 @@
                 el => el.removeAttribute('data-h3d-primary'));
             wrap.setAttribute('data-h3d-primary', '');
             highwayCanvas.parentNode.insertBefore(wrap, highwayCanvas.nextSibling);
+
+            // Subscribe to highway:visibility (slopsmith#246) so the
+            // .h3d-wrap overlay hides in sync with the slopsmith canvas.
+            // The wrap is a sibling of #highway, so display:none on
+            // #highway leaves us painting full-screen otherwise.
+            // Guarded lazy bind: tolerate hosts that don't yet expose
+            // slopsmith.on/off (older slopsmith versions, headless
+            // tests).
+            if (window.slopsmith
+                && typeof window.slopsmith.on === 'function'
+                && typeof window.slopsmith.off === 'function') {
+                _visibilityHandler = (e) => {
+                    if (!wrap) return;
+                    // Filter by canvas identity (splitscreen-safe).
+                    // Each createHighway() instance emits its own
+                    // visibility events on the shared slopsmith bus —
+                    // without this gate, one hidden panel would also
+                    // hide every other panel's 3D overlay.
+                    if (!e || !e.detail || e.detail.canvas !== highwayCanvas) return;
+                    const v = e.detail.visible;
+                    wrap.style.display = v === false ? 'none' : '';
+                };
+                try {
+                    window.slopsmith.on('highway:visibility', _visibilityHandler);
+                } catch (e) {
+                    _visibilityHandler = null;
+                }
+            }
 
             ren = new T.WebGLRenderer({ antialias: true });
             _probe = new T.Vector3();
@@ -5777,8 +5811,12 @@
             if (window.slopsmith && typeof window.slopsmith.off === 'function') {
                 if (_ndOnBusHit)  window.slopsmith.off('note:hit', _ndOnBusHit);
                 if (_ndOnBusMiss) window.slopsmith.off('note:miss', _ndOnBusMiss);
+                if (_visibilityHandler) {
+                    try { window.slopsmith.off('highway:visibility', _visibilityHandler); } catch (e) {}
+                }
             }
             _ndOnBusHit = _ndOnBusMiss = null;
+            _visibilityHandler = null;
             _ndHitMarks = [];
             _ndMissMarks = [];
             _ndLabels = [];

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -2838,6 +2838,21 @@
                 } catch (e) {
                     _visibilityHandler = null;
                 }
+                // Sync once at bind time: the event is transition-only,
+                // so if the canvas was already hidden when we mounted
+                // (e.g. plugin loaded while splitscreen was active),
+                // we'd never receive an emit and would leave the wrap
+                // visible. Compute from the local highwayCanvas (not
+                // window.highway.isVisible) so splitscreen panels get
+                // their own per-instance answer instead of inheriting
+                // the main highway's state.
+                if (_visibilityHandler) {
+                    try {
+                        const initialVisible = highwayCanvas
+                            && highwayCanvas.offsetParent !== null;
+                        wrap.style.display = initialVisible ? '' : 'none';
+                    } catch (e) { /* ignore — initial sync is best-effort */ }
+                }
             }
 
             ren = new T.WebGLRenderer({ antialias: true });

--- a/static/highway.js
+++ b/static/highway.js
@@ -66,6 +66,15 @@ function createHighway() {
     // threshold for "audio looks paused" — if setTime hasn't advanced t
     // in this long, treat as paused.
     const _CHART_MAX_INTERP_MS = 100;
+    // Visibility-aware rAF (slopsmith#246): when the canvas is hidden
+    // (display:none on itself or any ancestor — e.g. splitscreen's
+    // workaround), pause renderer.draw and emit highway:visibility on
+    // transitions so renderers that mount sibling DOM (3D Highway's
+    // .h3d-wrap overlay) can hide it. _visibleOverride !== null forces
+    // the state for hosts that hide via opacity / visibility / clipping
+    // where offsetParent === null isn't enough.
+    let _visibleOverride = null;
+    let _lastVisible = null;
     let animFrame = null;
     let _connectOpts = {};
     let _resizeContainer = null;
@@ -684,9 +693,40 @@ function createHighway() {
         }
     }
 
+    // Visibility check (#246). offsetParent === null catches display:none
+    // on the canvas OR any ancestor — the splitscreen case. Doesn't
+    // catch visibility:hidden / opacity:0 / off-screen transforms;
+    // hosts that need those use setVisible() instead.
+    function _isHighwayVisible() {
+        if (_visibleOverride !== null) return _visibleOverride;
+        return !!(canvas && canvas.offsetParent !== null);
+    }
+
+    // Emit only on transition so renderer-side listeners aren't woken
+    // every frame. The first call after init emits a transition from
+    // null → boolean — that's the documented contract: "fired on
+    // transitions including the first one."
+    function _emitVisibilityIfChanged() {
+        const v = _isHighwayVisible();
+        if (v === _lastVisible) return;
+        _lastVisible = v;
+        if (typeof window !== 'undefined'
+            && window.slopsmith
+            && typeof window.slopsmith.emit === 'function') {
+            window.slopsmith.emit('highway:visibility', { visible: v, canvas });
+        }
+    }
+
     function draw() {
         animFrame = requestAnimationFrame(draw);
         if (!canvas || !_renderer) return;
+        // Visibility-aware skip (#246). Run BEFORE the !ready bail so
+        // hide/show transitions during the loading / reconnect window
+        // still propagate to listeners (a splitscreen-driven hide that
+        // straddles a song change would otherwise leave 3D Highway's
+        // overlay visible across the not-ready frames).
+        _emitVisibilityIfChanged();
+        if (!_lastVisible) return;
         // Match pre-refactor behaviour: skip draw until WS ready fires.
         // This gates out the brief "arrays cleared, WS reconnecting"
         // window during playSong / reconnect. Renderers that want to
@@ -2439,6 +2479,18 @@ function createHighway() {
         // `audio.play/pause` route to the JUCE backing engine — so the
         // returned element behaves uniformly regardless of mode.
         getAudioElement() { return document.getElementById('audio'); },
+        // Force the highway's visibility state for the rAF skip
+        // (#246). Pass `true` or `false` to override; pass `null` to
+        // clear the override and resume DOM-based detection via
+        // canvas.offsetParent. Useful for hosts that hide the highway
+        // via `visibility:hidden`, `opacity:0`, transforms, or other
+        // means that offsetParent doesn't catch. Emits any resulting
+        // transition immediately rather than waiting for the next
+        // rAF tick.
+        setVisible(v) {
+            _visibleOverride = (v === null || v === undefined) ? null : !!v;
+            _emitVisibilityIfChanged();
+        },
         getNotes() { return notes; },
         getChords() { return chords; },
         // Live reference to the chord-template lookup table —

--- a/static/highway.js
+++ b/static/highway.js
@@ -527,6 +527,12 @@ function createHighway() {
         try { api.resize(); }
         catch (e) { console.error('resize after canvas replace:', e); }
         _currentCanvasContextType = newType;
+        // The visibility cache is per-canvas-instance: a freshly
+        // attached canvas could be in a different displayed state
+        // than the one it replaced, and _lastVisible would otherwise
+        // suppress the first transition. Reset to null so the next
+        // rAF tick re-emits unconditionally.
+        _lastVisible = null;
         // Defensive notify for plugins / overlays that cache the
         // canvas element across events. Lazy lookups via
         // getElementById('highway') do not need this — they'll pick
@@ -2490,6 +2496,14 @@ function createHighway() {
         setVisible(v) {
             _visibleOverride = (v === null || v === undefined) ? null : !!v;
             _emitVisibilityIfChanged();
+        },
+        // Snapshot of the current visibility state (the override if
+        // set, else the live DOM check). Renderers that bind to
+        // `highway:visibility` after a transition has already happened
+        // can call this once to sync their initial state — the event
+        // is transition-only and won't re-fire for late subscribers.
+        isVisible() {
+            return _isHighwayVisible();
         },
         getNotes() { return notes; },
         getChords() { return chords; },

--- a/tests/js/highway_visibility.test.js
+++ b/tests/js/highway_visibility.test.js
@@ -139,10 +139,28 @@ test('3D Highway subscribes to highway:visibility and toggles wrap on hide', () 
         /highwayCanvas\.offsetParent\s*!==\s*null/,
         'initScene must compute initial visibility from local highwayCanvas (splitscreen-safe)',
     );
-    // Teardown unbinds.
+    // Subscribes to highway:canvas-replaced so the identity gate
+    // (event.detail.canvas === highwayCanvas) survives core's
+    // context-type-driven canvas swap. Per CLAUDE.md plugin contract.
+    assert.match(
+        initSceneBlock,
+        /window\.slopsmith\.on\(\s*['"]highway:canvas-replaced['"]/,
+        'initScene must track canvas swaps so the visibility gate keeps matching',
+    );
+    assert.match(
+        initSceneBlock,
+        /highwayCanvas\s*=\s*e\.detail\.newCanvas/,
+        'canvas-replaced handler must update the local highwayCanvas reference',
+    );
+    // Teardown unbinds both listeners.
     assert.match(
         teardownBlock,
         /window\.slopsmith\.off\(\s*['"]highway:visibility['"]/,
         'teardown must unbind highway:visibility',
+    );
+    assert.match(
+        teardownBlock,
+        /window\.slopsmith\.off\(\s*['"]highway:canvas-replaced['"]/,
+        'teardown must unbind highway:canvas-replaced',
     );
 });

--- a/tests/js/highway_visibility.test.js
+++ b/tests/js/highway_visibility.test.js
@@ -8,8 +8,8 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
-const HIGHWAY_3D_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+const highwayJs = path.join(__dirname, '..', '..', 'static', 'highway.js');
+const highway3dJs = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
 
 // Brace-balanced extraction so a future method that grows guards or
 // nested blocks doesn't get truncated by a naive `[^}]*\}` regex.
@@ -31,20 +31,20 @@ function extractBlock(src, signature) {
 }
 
 test('highway declares visibility state (_visibleOverride + _lastVisible)', () => {
-    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const src = fs.readFileSync(highwayJs, 'utf8');
     assert.match(src, /let\s+_visibleOverride\s*=\s*null/, 'missing _visibleOverride (override sentinel)');
     assert.match(src, /let\s+_lastVisible\s*=\s*null/, 'missing _lastVisible (last-emitted state)');
 });
 
 test('_isHighwayVisible respects _visibleOverride and falls back to offsetParent', () => {
-    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const src = fs.readFileSync(highwayJs, 'utf8');
     const fn = extractBlock(src, 'function _isHighwayVisible()');
     assert.match(fn, /_visibleOverride\s*!==\s*null/, 'must check the override before the DOM');
     assert.match(fn, /canvas\.offsetParent\s*!==\s*null/, 'DOM fallback must use offsetParent !== null');
 });
 
 test('_emitVisibilityIfChanged is transition-only (no per-frame spam)', () => {
-    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const src = fs.readFileSync(highwayJs, 'utf8');
     const fn = extractBlock(src, 'function _emitVisibilityIfChanged()');
     // Must short-circuit when the current state equals the cached one.
     assert.match(fn, /v\s*===\s*_lastVisible/, 'must compare current vs _lastVisible and bail when equal');
@@ -58,7 +58,7 @@ test('_emitVisibilityIfChanged is transition-only (no per-frame spam)', () => {
 });
 
 test('rAF draw() loop calls _emitVisibilityIfChanged and skips when hidden', () => {
-    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const src = fs.readFileSync(highwayJs, 'utf8');
     const fn = extractBlock(src, 'function draw()');
     assert.match(fn, /_emitVisibilityIfChanged\(\)/, 'rAF draw() must call _emitVisibilityIfChanged each tick');
     // Ordering: emit → skip-when-hidden → ready gate → renderer.draw.
@@ -74,8 +74,27 @@ test('rAF draw() loop calls _emitVisibilityIfChanged and skips when hidden', () 
     assert.ok(readyIdx < drawIdx, 'ready gate must run before renderer.draw');
 });
 
+test('api.isVisible() exposes a snapshot for late subscribers', () => {
+    // The event is transition-only, so renderers that bind after the
+    // initial frame need a way to sync. isVisible() returns the same
+    // value _isHighwayVisible() would return on the next tick.
+    const src = fs.readFileSync(highwayJs, 'utf8');
+    const fn = extractBlock(src, 'isVisible()');
+    assert.match(fn, /return\s+_isHighwayVisible\(\)/, 'isVisible() must return _isHighwayVisible()');
+});
+
+test('canvas-replace resets _lastVisible so the new canvas re-emits', () => {
+    // _lastVisible is per-canvas-lifecycle: a fresh canvas could
+    // be in a different displayed state than the one it replaced.
+    // Without the reset, _emitVisibilityIfChanged would suppress
+    // the first transition on the new canvas.
+    const src = fs.readFileSync(highwayJs, 'utf8');
+    const fn = extractBlock(src, 'function _replaceCanvas(newType)');
+    assert.match(fn, /_lastVisible\s*=\s*null/, '_replaceCanvas must reset _lastVisible so the new canvas re-emits');
+});
+
 test('api.setVisible accepts bool / null and re-emits inline', () => {
-    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const src = fs.readFileSync(highwayJs, 'utf8');
     const fn = extractBlock(src, 'setVisible(v)');
     // null/undefined → clears the override
     assert.match(fn, /v\s*===\s*null\s*\|\|\s*v\s*===\s*undefined/, 'null/undefined must clear the override');
@@ -86,7 +105,7 @@ test('api.setVisible accepts bool / null and re-emits inline', () => {
 });
 
 test('3D Highway subscribes to highway:visibility and toggles wrap on hide', () => {
-    const src = fs.readFileSync(HIGHWAY_3D_JS, 'utf8');
+    const src = fs.readFileSync(highway3dJs, 'utf8');
     // Listener registration with the documented event name.
     assert.match(
         src,
@@ -112,5 +131,13 @@ test('3D Highway subscribes to highway:visibility and toggles wrap on hide', () 
         src,
         /window\.slopsmith\.off\(\s*['"]highway:visibility['"]/,
         '3D Highway must unbind highway:visibility on teardown',
+    );
+    // Initial-sync on bind so renderers that mount while the canvas
+    // is already hidden (e.g. plugin loaded mid-splitscreen) don't
+    // leave the wrap stuck in the wrong state.
+    assert.match(
+        src,
+        /highwayCanvas\.offsetParent\s*!==\s*null/,
+        '3D Highway must compute initial visibility from local highwayCanvas (splitscreen-safe)',
     );
 });

--- a/tests/js/highway_visibility.test.js
+++ b/tests/js/highway_visibility.test.js
@@ -106,38 +106,43 @@ test('api.setVisible accepts bool / null and re-emits inline', () => {
 
 test('3D Highway subscribes to highway:visibility and toggles wrap on hide', () => {
     const src = fs.readFileSync(highway3dJs, 'utf8');
-    // Listener registration with the documented event name.
+    // Scope to lifecycle blocks so unrelated / commented mentions
+    // elsewhere in screen.js can't cause false positives.
+    const initSceneBlock = extractBlock(src, 'function initScene()');
+    const teardownBlock = extractBlock(src, 'function teardown()');
+
+    // Listener registration with the documented event name (in init).
     assert.match(
-        src,
+        initSceneBlock,
         /window\.slopsmith\.on\(\s*['"]highway:visibility['"]/,
-        '3D Highway must subscribe to highway:visibility',
+        'initScene must subscribe to highway:visibility',
     );
     // Handler filters by canvas identity so splitscreen panels don't
     // hide each other's overlays — every instance receives every event
     // on the shared slopsmith bus, so this gate is essential.
     assert.match(
-        src,
+        initSceneBlock,
         /e\.detail\.canvas\s*!==\s*highwayCanvas/,
         'handler must filter on event.detail.canvas !== highwayCanvas (splitscreen-safe)',
     );
     // Handler toggles wrap.style.display based on visible === false.
     assert.match(
-        src,
+        initSceneBlock,
         /wrap\.style\.display\s*=\s*v\s*===\s*false\s*\?\s*['"]none['"]\s*:\s*['"]['"]/,
         'handler must hide the wrap when visible === false',
-    );
-    // Teardown unbinds.
-    assert.match(
-        src,
-        /window\.slopsmith\.off\(\s*['"]highway:visibility['"]/,
-        '3D Highway must unbind highway:visibility on teardown',
     );
     // Initial-sync on bind so renderers that mount while the canvas
     // is already hidden (e.g. plugin loaded mid-splitscreen) don't
     // leave the wrap stuck in the wrong state.
     assert.match(
-        src,
+        initSceneBlock,
         /highwayCanvas\.offsetParent\s*!==\s*null/,
-        '3D Highway must compute initial visibility from local highwayCanvas (splitscreen-safe)',
+        'initScene must compute initial visibility from local highwayCanvas (splitscreen-safe)',
+    );
+    // Teardown unbinds.
+    assert.match(
+        teardownBlock,
+        /window\.slopsmith\.off\(\s*['"]highway:visibility['"]/,
+        'teardown must unbind highway:visibility',
     );
 });

--- a/tests/js/highway_visibility.test.js
+++ b/tests/js/highway_visibility.test.js
@@ -1,0 +1,116 @@
+// Source-level guards for the visibility-aware rAF skip and the
+// highway:visibility event (slopsmith#246). The createHighway closure
+// owns the canvas + WebGL context lifecycle that's too heavy to
+// reproduce in a vm sandbox — these checks lock in the wiring instead.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HIGHWAY_JS = path.join(__dirname, '..', '..', 'static', 'highway.js');
+const HIGHWAY_3D_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+// Brace-balanced extraction so a future method that grows guards or
+// nested blocks doesn't get truncated by a naive `[^}]*\}` regex.
+function extractBlock(src, signature) {
+    const start = src.indexOf(signature);
+    assert.ok(start !== -1, `signature '${signature}' not found`);
+    const openBrace = src.indexOf('{', start);
+    assert.ok(openBrace !== -1, `opening brace after '${signature}' not found`);
+    let depth = 1;
+    let i = openBrace + 1;
+    while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    assert.ok(depth === 0, `unbalanced braces after '${signature}'`);
+    return src.slice(start, i);
+}
+
+test('highway declares visibility state (_visibleOverride + _lastVisible)', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    assert.match(src, /let\s+_visibleOverride\s*=\s*null/, 'missing _visibleOverride (override sentinel)');
+    assert.match(src, /let\s+_lastVisible\s*=\s*null/, 'missing _lastVisible (last-emitted state)');
+});
+
+test('_isHighwayVisible respects _visibleOverride and falls back to offsetParent', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const fn = extractBlock(src, 'function _isHighwayVisible()');
+    assert.match(fn, /_visibleOverride\s*!==\s*null/, 'must check the override before the DOM');
+    assert.match(fn, /canvas\.offsetParent\s*!==\s*null/, 'DOM fallback must use offsetParent !== null');
+});
+
+test('_emitVisibilityIfChanged is transition-only (no per-frame spam)', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const fn = extractBlock(src, 'function _emitVisibilityIfChanged()');
+    // Must short-circuit when the current state equals the cached one.
+    assert.match(fn, /v\s*===\s*_lastVisible/, 'must compare current vs _lastVisible and bail when equal');
+    // Must update the cache and emit the event with the documented payload shape.
+    assert.match(fn, /_lastVisible\s*=\s*v/, 'must update _lastVisible after a transition');
+    assert.match(
+        fn,
+        /window\.slopsmith\.emit\(\s*['"]highway:visibility['"][\s\S]*?visible:\s*v[\s\S]*?canvas/,
+        'must emit highway:visibility with { visible, canvas }',
+    );
+});
+
+test('rAF draw() loop calls _emitVisibilityIfChanged and skips when hidden', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const fn = extractBlock(src, 'function draw()');
+    assert.match(fn, /_emitVisibilityIfChanged\(\)/, 'rAF draw() must call _emitVisibilityIfChanged each tick');
+    // Ordering: emit → skip-when-hidden → ready gate → renderer.draw.
+    // The emit must run BEFORE the !ready bail so visibility
+    // transitions during loading/reconnect windows still propagate.
+    const emitIdx = fn.search(/_emitVisibilityIfChanged\(\)/);
+    const skipIdx = fn.search(/if\s*\(\s*!_lastVisible\s*\)\s*return/);
+    const readyIdx = fn.search(/if\s*\(\s*!ready\s*\)\s*return/);
+    const drawIdx = fn.search(/_renderer\.draw\(/);
+    assert.ok(emitIdx !== -1 && skipIdx !== -1 && readyIdx !== -1 && drawIdx !== -1, 'all four landmarks must be present');
+    assert.ok(emitIdx < readyIdx, 'emit must run BEFORE the !ready gate (transitions during loading must still fire)');
+    assert.ok(skipIdx < readyIdx, 'skip-when-hidden must short-circuit before the ready gate');
+    assert.ok(readyIdx < drawIdx, 'ready gate must run before renderer.draw');
+});
+
+test('api.setVisible accepts bool / null and re-emits inline', () => {
+    const src = fs.readFileSync(HIGHWAY_JS, 'utf8');
+    const fn = extractBlock(src, 'setVisible(v)');
+    // null/undefined → clears the override
+    assert.match(fn, /v\s*===\s*null\s*\|\|\s*v\s*===\s*undefined/, 'null/undefined must clear the override');
+    // Non-null → coerce to boolean
+    assert.match(fn, /_visibleOverride\s*=.*\?\s*null\s*:\s*!!v/, 'non-null must coerce to !!v');
+    // Re-evaluate immediately so the transition fires on the call, not the next rAF.
+    assert.match(fn, /_emitVisibilityIfChanged\(\)/, 'setVisible must call _emitVisibilityIfChanged inline');
+});
+
+test('3D Highway subscribes to highway:visibility and toggles wrap on hide', () => {
+    const src = fs.readFileSync(HIGHWAY_3D_JS, 'utf8');
+    // Listener registration with the documented event name.
+    assert.match(
+        src,
+        /window\.slopsmith\.on\(\s*['"]highway:visibility['"]/,
+        '3D Highway must subscribe to highway:visibility',
+    );
+    // Handler filters by canvas identity so splitscreen panels don't
+    // hide each other's overlays — every instance receives every event
+    // on the shared slopsmith bus, so this gate is essential.
+    assert.match(
+        src,
+        /e\.detail\.canvas\s*!==\s*highwayCanvas/,
+        'handler must filter on event.detail.canvas !== highwayCanvas (splitscreen-safe)',
+    );
+    // Handler toggles wrap.style.display based on visible === false.
+    assert.match(
+        src,
+        /wrap\.style\.display\s*=\s*v\s*===\s*false\s*\?\s*['"]none['"]\s*:\s*['"]['"]/,
+        'handler must hide the wrap when visible === false',
+    );
+    // Teardown unbinds.
+    assert.match(
+        src,
+        /window\.slopsmith\.off\(\s*['"]highway:visibility['"]/,
+        '3D Highway must unbind highway:visibility on teardown',
+    );
+});


### PR DESCRIPTION
## Summary
Closes #246.

When the highway `<canvas>` is hidden via `display:none` on itself or any ancestor (the splitscreen plugin's workaround), `createHighway()`'s rAF loop kept firing and `renderer.draw()` kept producing a full WebGL scene that nobody could see. For renderers that mount sibling DOM (3D Highway's `.h3d-wrap` overlay), `display:none` on `#highway` didn't even hide the visible output — the overlay painted full-screen behind the panels and bled through the panels' translucent bottom bars.

## What's new

**Core (`static/highway.js`):**
- rAF `draw()` reads `canvas.offsetParent === null` once per tick. When the canvas is hidden, skip `renderer.draw(bundle)` and the default 2D draw.
- Emit `highway:visibility` on `window.slopsmith` only on transitions: `{ visible, canvas }` on `event.detail`.
- The emit runs BEFORE the `!ready` bail so transitions during loading/reconnect windows still propagate (catches the splitscreen-toggled-during-song-change case).
- New public method `highway.setVisible(bool | null)` overrides the DOM check for hosts that hide via `visibility:hidden`, `opacity:0`, transforms, or clipping. `null` clears the override.

**3D Highway (`plugins/highway_3d/screen.js`):**
- Subscribes to `highway:visibility` in `initScene`; unbinds in `teardown`.
- Handler filters by `event.detail.canvas === highwayCanvas` so splitscreen's N highway instances don't toggle each other's overlays (each emits on the shared bus).
- Toggles `wrap.style.display` to hide the sibling overlay when slopsmith's canvas is hidden.

**Docs (`CLAUDE.md`):**
- Added `highway:visibility` event + `setVisible` API to the setRenderer contract section, parallel to the existing `highway:canvas-replaced` paragraph.

## Test plan

- [x] `npm run test:js` — 54/54 (48 existing + 6 new in `tests/js/highway_visibility.test.js`).
- [x] Codex preflight against main — 0 issues (caught the splitscreen canvas-filter bug + the not-ready emit-suppression bug during dev).
- [ ] **Manual smoke** (before merging):
  - Open a song with 3D Highway viz, activate splitscreen → confirm the main `.h3d-wrap` overlay no longer bleeds through panels.
  - DevTools Performance: confirm the hidden renderer's WebGL draw calls drop to zero (only the visible panels render).
  - From console: `window.highway.setVisible(false)` → highway hides + render loop pauses. `setVisible(null)` resumes DOM-based detection.

## Trade-offs

- **`offsetParent === null`**: doesn't catch `visibility:hidden` / `opacity:0` / off-screen transforms. Mitigated by `setVisible()` for hosts that need those.
- **Per-frame layout query**: in a steady-state render loop browsers cache `offsetParent` between mutations — cost is negligible compared to the draw it prevents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)