### PR TITLE
fix(splitscreen): don't flash the library in pop-out windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Demucs stem split failing on Windows desktop with `OSError: Could not load this library: libtorchcodec_core4.dll` or `ImportError: TorchCodec is required for save_with_torchcodec`. The demucs subprocess now bootstraps a `torchaudio.save` → `soundfile.write` shim before importing demucs, sidestepping the torchcodec dependency entirely. The override stays in place across torchaudio versions — soundfile's WAV writes are behaviorally equivalent for demucs's float32 outputs.
+- Splitscreen pop-out windows briefly flashed the library/song grid before showing the popped panel. A popup loads the full app (whose default screen, `#home`, is the library) and only swaps to the player once the splitscreen plugin loads; app init now detects `?ssFollower=1` and switches to the player screen up front, so the popup shows player chrome the whole time.
 
 ### Migration notes
 - The library filters depend on three new columns (`stem_ids`, `tuning_name`, `tuning_sort_key`) that are populated as songs are scanned. If filters look empty after upgrading, run **Settings → Full Rescan** to repopulate; alternatively the periodic background rescan picks them up over time.

--- a/static/app.js
+++ b/static/app.js
@@ -5407,9 +5407,11 @@ async function bootstrapPluginsAndUi() {
     let _isFollowerWindow = false;
     try { _isFollowerWindow = new URLSearchParams(location.search).get('ssFollower') === '1'; } catch (_) {}
     if (_isFollowerWindow) {
-        // Don't swallow showScreen failures silently — if `#player` ever went
-        // missing/renamed this guard would otherwise hide the flash regression.
-        try { showScreen('player'); }
+        // Await it — showScreen is async, so a bare call would turn even a
+        // synchronous DOM error into an unhandled rejection that this try
+        // couldn't catch. Surface failures (e.g. `#player` missing/renamed)
+        // instead of silently bringing the library flash back.
+        try { await showScreen('player'); }
         catch (e) { console.warn('[slopsmith] follower-window: showScreen("player") failed:', e); }
     }
     // Restore library-filter UI state from localStorage before the first

--- a/static/app.js
+++ b/static/app.js
@@ -5404,9 +5404,11 @@ async function bootstrapPluginsAndUi() {
     // (empty, then populated by the plugin) the whole time. The wasted
     // library fetch below is negligible next to the whole-app + every-plugin
     // re-load a popup already does.
-    let _isFollowerWindow = false;
-    try { _isFollowerWindow = new URLSearchParams(location.search).get('ssFollower') === '1'; } catch (_) {}
-    if (_isFollowerWindow) {
+    const isFollowerWindow = (() => {
+        try { return new URLSearchParams(location.search).get('ssFollower') === '1'; }
+        catch (_) { return false; }
+    })();
+    if (isFollowerWindow) {
         // Await it — showScreen is async, so a bare call would turn even a
         // synchronous DOM error into an unhandled rejection that this try
         // couldn't catch. Surface failures (e.g. `#player` missing/renamed)

--- a/static/app.js
+++ b/static/app.js
@@ -5404,9 +5404,14 @@ async function bootstrapPluginsAndUi() {
     // (empty, then populated by the plugin) the whole time. The wasted
     // library fetch below is negligible next to the whole-app + every-plugin
     // re-load a popup already does.
-    try {
-        if (new URLSearchParams(location.search).get('ssFollower') === '1') showScreen('player');
-    } catch (_) {}
+    let _isFollowerWindow = false;
+    try { _isFollowerWindow = new URLSearchParams(location.search).get('ssFollower') === '1'; } catch (_) {}
+    if (_isFollowerWindow) {
+        // Don't swallow showScreen failures silently — if `#player` ever went
+        // missing/renamed this guard would otherwise hide the flash regression.
+        try { showScreen('player'); }
+        catch (e) { console.warn('[slopsmith] follower-window: showScreen("player") failed:', e); }
+    }
     // Restore library-filter UI state from localStorage before the first
     // grid fetch so the badge/chips are accurate immediately
     // (slopsmith#129).

--- a/static/app.js
+++ b/static/app.js
@@ -5395,6 +5395,18 @@ async function bootstrapPluginsAndUi() {
 // before any playSong runs — otherwise a fast click could start
 // playback with stale settings before /api/settings returned.
 (async () => {
+    // Splitscreen pop-out windows (`?ssFollower=1`) load this same app but
+    // get driven into "follower mode" by the splitscreen plugin once it
+    // loads — which is *after* this init runs. Without this, the library
+    // (`#home`, marked `active` in index.html) renders and paints first, so
+    // the popup briefly flashes the song grid before swapping to the player.
+    // Switch to the player screen up front so the popup shows player chrome
+    // (empty, then populated by the plugin) the whole time. The wasted
+    // library fetch below is negligible next to the whole-app + every-plugin
+    // re-load a popup already does.
+    try {
+        if (new URLSearchParams(location.search).get('ssFollower') === '1') showScreen('player');
+    } catch (_) {}
     // Restore library-filter UI state from localStorage before the first
     // grid fetch so the badge/chips are accurate immediately
     // (slopsmith#129).


### PR DESCRIPTION
## Summary

Splitscreen pop-out (follower) windows load this same app with `?ssFollower=1`; the splitscreen plugin then drives them into follower mode (`showScreen('player')` + builds the panel layout). But the plugin loads *after* app init runs, and `index.html` ships `#home` (the library) as the `active` screen — so the library renders and paints first, giving a brief flash of the song grid before the popup swaps to the player. The plugin can't beat this from its side (it can only act once its script has loaded, by which point the library's already painted).

Fix: app init checks for `?ssFollower=1` and calls `showScreen('player')` up front, so the popup shows player chrome (empty, then plugin-populated) the whole time. `?ssFollower` is a splitscreen-plugin convention; this is the only place core needs to know about it. The wasted library fetch this leaves in the popup is negligible next to the whole-app + every-plugin re-load a popup already does.

12-line addition in `static/app.js` (the init IIFE), plus a CHANGELOG entry.

## Test plan

- Hard-reload the main window, pop a panel out → the popped window shows player chrome the whole time, no song-grid flash. (There may still be a brief moment of empty player *with the full controls bar* before the splitscreen plugin's `body.ss-follower` CSS hides it — that's player chrome, not the library, and not fixable from core.)
- Normal (non-popup) load → unchanged: library shows as before.
- `node --check static/app.js` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)