### PR TITLE
feat(gp-import): expand repeats, voltas, and D.S./D.C./Coda/Fine jumps

### DIFF
--- a/lib/gp2rs.py
+++ b/lib/gp2rs.py
@@ -1,5 +1,6 @@
 """Convert Guitar Pro files (.gp5/.gp4/.gp3) to Rocksmith 2014 arrangement XML."""
 
+import logging
 import re
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
@@ -7,6 +8,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import guitarpro
+
+log = logging.getLogger("slopsmith.lib.gp2rs")
 
 _YEAR_RE = re.compile(r"\b(1[89]\d{2}|20\d{2})\b")
 
@@ -102,6 +105,27 @@ class ChordTemplate:
     fingers: list[int]  # per string, -1 = unused
 
 
+@dataclass
+class PlaybackEntry:
+    """One scheduled play of one source measure.
+
+    The converter walks the GP playback graph (repeat brackets, voltas,
+    D.S./D.C./Coda/Fine) and emits a ``PlaybackEntry`` for every source
+    measure in its played order. ``mh_index`` indexes back into
+    ``song.measureHeaders`` and ``track.measures``; ``pass_index`` is 0
+    for the first time through, 1 for the second, etc. inside a repeat
+    block (0 elsewhere). The two ``*_secs`` fields together let consumers
+    shift each authored event into post-expansion (output) time:
+
+        output_time = (authored_secs - mh_authored_start_secs)
+                      + output_start_secs + audio_offset
+    """
+    mh_index: int
+    pass_index: int
+    output_start_secs: float
+    mh_authored_start_secs: float
+
+
 def _build_tempo_map(song: guitarpro.Song) -> list[TempoEvent]:
     """Build a list of (tick, tempo) events from the song."""
     events = [TempoEvent(tick=0, tempo=float(song.tempo))]
@@ -168,6 +192,248 @@ def _tempo_at_tick(tick: int, tempo_map: list[TempoEvent]) -> float:
             break
         result = event.tempo
     return result
+
+
+def _measure_duration_secs(
+    mh: guitarpro.MeasureHeader, tempo_map: list[TempoEvent]
+) -> float:
+    """Duration of one measure in seconds at its authored tempo curve.
+
+    Uses the same source-tick tempo map as :func:`_tick_to_seconds` so a
+    tempo change *inside* a measure is integrated correctly.
+    """
+    ts = mh.timeSignature
+    # numerator beats, each beat is (4 / denominator.value) quarter notes.
+    quarter_notes = ts.numerator * (4.0 / ts.denominator.value)
+    end_tick = mh.start + int(round(quarter_notes * GP_TICKS_PER_QUARTER))
+    return _tick_to_seconds(end_tick, tempo_map) - _tick_to_seconds(mh.start, tempo_map)
+
+
+# Names that may appear in MeasureHeader.fromDirection (jump *sources*).
+_DA_CAPO_NAMES = frozenset({
+    "Da Capo", "Da Capo al Coda", "Da Capo al Double Coda", "Da Capo al Fine",
+})
+_DA_SEGNO_SEGNO_NAMES = frozenset({
+    "Da Segno Segno", "Da Segno Segno al Coda",
+    "Da Segno Segno al Double Coda", "Da Segno Segno al Fine",
+})
+_DA_SEGNO_NAMES = frozenset({
+    "Da Segno", "Da Segno al Coda", "Da Segno al Double Coda", "Da Segno al Fine",
+})
+_DA_CODA_NAMES = frozenset({"Da Coda", "Da Double Coda"})
+
+
+_JUMP_BACK_NAMES = _DA_CAPO_NAMES | _DA_SEGNO_NAMES | _DA_SEGNO_SEGNO_NAMES
+
+
+def _build_playback_schedule(
+    song: guitarpro.Song,
+    tempo_map: list[TempoEvent],
+    expand_repeats: bool = True,
+) -> list[PlaybackEntry]:
+    """Walk the GP playback graph and emit one :class:`PlaybackEntry` per played measure.
+
+    Honors three nested kinds of non-linear playback when ``expand_repeats``
+    is true:
+
+    1. **D.S. / D.C. / Coda / Fine** (``MeasureHeader.fromDirection`` and
+       ``.direction``) — outermost; can teleport the cursor to a Segno,
+       Coda, or song start, and arm an "al Fine" / "al Coda" stop or
+       redirect that fires on the next pass. Checked after every emitted
+       measure, including measures inside a repeat bracket.
+    2. **Repeat brackets** (``isRepeatOpen`` / ``repeatClose`` with the
+       ``repeatAlternative`` volta bitmask) — when an open is encountered
+       the walker remembers (open, close, passes) and, after each emitted
+       measure inside the block, decides whether to loop back to the open
+       for the next pass.
+    3. **Linear walk** — fall-through; emit one entry per measure.
+
+    Conventionally, repeat brackets in a section that has been *jumped
+    back to* via D.S./D.C. play **once** ("second time, don't repeat").
+    We implement that by gating layer 2 on ``not jumped_back``.
+
+    Malformed inputs (orphan opens, unresolved D.S. targets, etc.) emit
+    a warning and fall through to a linear walk for the affected section.
+
+    Setting ``expand_repeats=False`` produces a one-entry-per-measure
+    schedule with monotonically accumulating ``output_start_secs`` — i.e.
+    the same chart the converter produced before this feature existed.
+    """
+    headers = list(song.measureHeaders)
+    if not headers:
+        return []
+
+    # Pre-compute authored start for every header. Prefer the next
+    # header's start as this header's end: a final 3/4 measure in a 4/4
+    # piece, an anacrusis at the front, or any partial / mid-song
+    # time-signature change all carry their *real* duration in the tick
+    # delta between adjacent headers. Time-signature arithmetic is only
+    # used as a fall-back for the very last measure (which has no
+    # successor to diff against).
+    authored_starts = [_tick_to_seconds(mh.start, tempo_map) for mh in headers]
+    durations: list[float] = []
+    for idx, mh in enumerate(headers):
+        if idx + 1 < len(headers):
+            durations.append(authored_starts[idx + 1] - authored_starts[idx])
+        else:
+            durations.append(_measure_duration_secs(mh, tempo_map))
+
+    # Pre-scan direction targets (Segno / Coda / Fine markers). First
+    # occurrence wins; later duplicates only get a warning.
+    targets: dict[str, int] = {}
+    for i, mh in enumerate(headers):
+        if mh.direction:
+            nm = mh.direction.name
+            if nm in targets:
+                log.warning(
+                    "gp2rs: duplicate direction target %r at measure %d "
+                    "(first occurrence at %d will be used)",
+                    nm, i, targets[nm],
+                )
+            else:
+                targets[nm] = i
+
+    schedule: list[PlaybackEntry] = []
+    output_t = 0.0
+
+    def emit(idx: int, pass_index: int) -> None:
+        nonlocal output_t
+        schedule.append(PlaybackEntry(
+            mh_index=idx,
+            pass_index=pass_index,
+            output_start_secs=output_t,
+            mh_authored_start_secs=authored_starts[idx],
+        ))
+        output_t += durations[idx]
+
+    if not expand_repeats:
+        for i in range(len(headers)):
+            emit(i, 0)
+        return schedule
+
+    def find_repeat_close(start: int) -> int | None:
+        """Index of the first measure ≥ start whose ``repeatClose`` is set.
+
+        ``repeatClose`` is parsed as ``-1`` when absent and as the
+        "additional repetitions" count (``0`` = no repeat) otherwise.
+        """
+        for j in range(start, len(headers)):
+            if headers[j].repeatClose > 0:
+                return j
+        return None
+
+    # Walker state. Repeats and directions interleave: a D.C./D.S. inside
+    # a repeat block must fire as soon as its measure is emitted, so we
+    # process repeats as a single-loop "loop back at end of pass" rather
+    # than a nested sub-loop. This makes every emitted measure flow
+    # through the same direction/jump checks below.
+    jumped_back = False             # True after the first D.S./D.C./D.S.S. fires
+    stop_at: str | None = None      # None | "fine" | "coda" | "double_coda"
+    in_repeat = False
+    repeat_open = -1
+    repeat_close = -1
+    total_passes = 1
+    pass_idx = 0
+
+    def end_of_pass(curr_i: int) -> tuple[int, bool]:
+        """Compute the next index after the current pass through the repeat
+        block ends. Returns ``(next_i, still_in_repeat)``."""
+        nonlocal pass_idx, in_repeat
+        # Did we just emit / skip past the close measure?
+        if not in_repeat or curr_i <= repeat_close:
+            return curr_i, in_repeat
+        pass_idx += 1
+        if pass_idx >= total_passes:
+            in_repeat = False
+            return repeat_close + 1, False
+        return repeat_open, True
+
+    i = 0
+    while i < len(headers):
+        mh = headers[i]
+
+        # --- (1) Detect entry into a new repeat block ---
+        if not in_repeat and mh.isRepeatOpen and not jumped_back:
+            j = find_repeat_close(i)
+            if j is None:
+                log.warning(
+                    "gp2rs: repeat-open at measure %d has no matching close; "
+                    "playing the rest of the song linearly",
+                    i,
+                )
+            else:
+                in_repeat = True
+                repeat_open = i
+                repeat_close = j
+                total_passes = max(1, headers[j].repeatClose + 1)
+                pass_idx = 0
+
+        # --- (2) Volta skip ---
+        if in_repeat:
+            ra = mh.repeatAlternative
+            if ra and not (ra & (1 << pass_idx)):
+                i += 1
+                i, _ = end_of_pass(i)
+                continue
+
+        # --- (3) "al Coda" / "al Double Coda" redirect (before emit) ---
+        if stop_at in ("coda", "double_coda") and mh.fromDirection \
+                and mh.fromDirection.name in _DA_CODA_NAMES:
+            want = "Double Coda" if mh.fromDirection.name == "Da Double Coda" \
+                else "Coda"
+            target = targets.get(want)
+            if target is None:
+                log.warning(
+                    "gp2rs: %s redirect at measure %d but no %s target found",
+                    mh.fromDirection.name, i, want,
+                )
+                stop_at = None
+            else:
+                stop_at = None
+                in_repeat = False
+                i = target
+                continue
+
+        # --- (4) Emit the measure ---
+        emit(i, pass_idx if in_repeat else 0)
+
+        # --- (5) Fine stop ---
+        if stop_at == "fine" and mh.direction and mh.direction.name == "Fine":
+            return schedule
+
+        # --- (6) D.S./D.C./D.S.S. jump (fires once, ever) ---
+        if not jumped_back and mh.fromDirection \
+                and mh.fromDirection.name in _JUMP_BACK_NAMES:
+            name = mh.fromDirection.name
+            if name in _DA_CAPO_NAMES:
+                target_idx: int | None = 0
+            elif name in _DA_SEGNO_SEGNO_NAMES:
+                target_idx = targets.get("Segno Segno")
+            else:
+                target_idx = targets.get("Segno")
+            if target_idx is None:
+                log.warning(
+                    "gp2rs: %s at measure %d has no matching target; "
+                    "continuing linearly",
+                    name, i,
+                )
+            else:
+                if "al Fine" in name:
+                    stop_at = "fine"
+                elif "al Double Coda" in name:
+                    stop_at = "double_coda"
+                elif "al Coda" in name:
+                    stop_at = "coda"
+                jumped_back = True
+                in_repeat = False  # leave any current repeat block
+                i = target_idx
+                continue
+
+        # --- (7) Advance, looping back on repeat-pass end ---
+        i += 1
+        i, _ = end_of_pass(i)
+
+    return schedule
 
 
 def _gp_string_to_rs(gp_string: int, num_strings: int) -> int:
@@ -256,6 +522,7 @@ def convert_track(
     audio_offset: float = 0.0,
     arrangement_name: str = "",
     force_standard_tuning: bool = False,
+    expand_repeats: bool = True,
 ) -> str:
     """Convert a GP track to Rocksmith 2014 arrangement XML string.
 
@@ -265,6 +532,10 @@ def convert_track(
         audio_offset: Seconds to add to all times (for sync with audio)
         arrangement_name: "Lead", "Rhythm", "Bass", etc.
         force_standard_tuning: If True, set tuning to E standard (frets unchanged)
+        expand_repeats: When true (default), replay repeated bars and follow
+            D.S./D.C./Coda/Fine jumps so the chart matches an audio file that
+            plays the song as performed. When false, every measure is emitted
+            once in authored order — equivalent to the pre-expansion behavior.
 
     Returns:
         XML string of the Rocksmith arrangement
@@ -273,6 +544,8 @@ def convert_track(
     num_strings = len(track.strings)
     is_bass = _is_bass_track(track)
     tempo_map = _build_tempo_map(song)
+    schedule = _build_playback_schedule(song, tempo_map, expand_repeats)
+    headers = song.measureHeaders
     if force_standard_tuning:
         tuning = [0] * num_strings
     else:
@@ -289,29 +562,44 @@ def convert_track(
             arrangement_name = "Lead"
 
     # ── Collect beats (ebeats) ────────────────────────────────────────────
+    # Iterate the schedule rather than song.measureHeaders directly so each
+    # replayed pass of a repeat block emits its own downbeats / subdivisions
+    # at the correct *output* time.
     beats = []
-    for mh in song.measureHeaders:
-        t = _tick_to_seconds(mh.start, tempo_map) + audio_offset
-        beats.append(RsBeat(time=t, measure=mh.number))
-        # Subdivisions within the measure
-        tempo = _tempo_at_tick(mh.start, tempo_map)
-        ticks_per_beat = GP_TICKS_PER_QUARTER
+    for entry in schedule:
+        mh = headers[entry.mh_index]
+        beats.append(RsBeat(
+            time=entry.output_start_secs + audio_offset,
+            measure=mh.number,
+        ))
+        # Subdivisions within the measure — same authored offsets, shifted
+        # into output time by the entry's output_start.
         num_beats_in_measure = mh.timeSignature.numerator
         for b in range(1, num_beats_in_measure):
-            sub_tick = mh.start + b * ticks_per_beat
-            sub_t = _tick_to_seconds(sub_tick, tempo_map) + audio_offset
-            beats.append(RsBeat(time=sub_t, measure=-1))
+            sub_tick = mh.start + b * GP_TICKS_PER_QUARTER
+            sub_offset_in_measure = _tick_to_seconds(sub_tick, tempo_map) \
+                - entry.mh_authored_start_secs
+            beats.append(RsBeat(
+                time=entry.output_start_secs + sub_offset_in_measure + audio_offset,
+                measure=-1,
+            ))
     beats.sort(key=lambda b: b.time)
 
     # ── Collect sections from markers ─────────────────────────────────────
+    # One marker per scheduled appearance: a "verse" marker inside a ×2
+    # repeat block emits "verse #1" on pass 0 and "verse #2" on pass 1.
     sections = []
-    section_counts = {}
-    for mh in song.measureHeaders:
+    section_counts: dict[str, int] = {}
+    for entry in schedule:
+        mh = headers[entry.mh_index]
         if mh.marker and mh.marker.title:
             name = mh.marker.title.strip().lower().replace(" ", "")
             section_counts[name] = section_counts.get(name, 0) + 1
-            t = _tick_to_seconds(mh.start, tempo_map) + audio_offset
-            sections.append(RsSection(name=name, time=t, number=section_counts[name]))
+            sections.append(RsSection(
+                name=name,
+                time=entry.output_start_secs + audio_offset,
+                number=section_counts[name],
+            ))
 
     if not sections:
         # Default: one section for the whole song
@@ -323,13 +611,16 @@ def convert_track(
     chord_templates: list[ChordTemplate] = []
     chord_template_map: dict[tuple, int] = {}  # fret tuple → index
 
-    for measure in track.measures:
+    for entry in schedule:
+        measure = track.measures[entry.mh_index]
         for voice in measure.voices:
             for beat in voice.beats:
                 if not beat.notes:
                     continue
 
-                t = _tick_to_seconds(beat.start, tempo_map) + audio_offset
+                authored_beat_secs = _tick_to_seconds(beat.start, tempo_map)
+                t = (authored_beat_secs - entry.mh_authored_start_secs) \
+                    + entry.output_start_secs + audio_offset
                 tempo = _tempo_at_tick(beat.start, tempo_map)
                 dur = _duration_to_seconds(beat.duration, tempo)
 
@@ -457,11 +748,18 @@ def convert_track(
                 anchors.append(RsAnchor(time=t, fret=new_fret, width=4))
 
     # ── Compute song length ───────────────────────────────────────────────
-    last_mh = song.measureHeaders[-1]
-    song_length = _tick_to_seconds(
-        last_mh.start + last_mh.timeSignature.numerator * GP_TICKS_PER_QUARTER,
-        tempo_map,
-    ) + audio_offset
+    # End of the final scheduled measure in *output* time. After expansion
+    # this can be substantially longer than `_tick_to_seconds(last_mh.start
+    # + measure_len)` would yield on the authored timeline.
+    if schedule:
+        last_entry = schedule[-1]
+        song_length = (
+            last_entry.output_start_secs
+            + _measure_duration_secs(headers[last_entry.mh_index], tempo_map)
+            + audio_offset
+        )
+    else:
+        song_length = audio_offset
 
     # ── Build XML ─────────────────────────────────────────────────────────
     return _build_xml(
@@ -791,6 +1089,7 @@ def convert_piano_track(
     track_index: int,
     audio_offset: float = 0.0,
     arrangement_name: str = "Keys",
+    expand_repeats: bool = True,
 ) -> str:
     """Convert a GP piano/keyboard track to Rocksmith XML using MIDI encoding.
 
@@ -801,32 +1100,47 @@ def convert_piano_track(
     This gives a range of 0-143, covering the full piano range within
     Rocksmith's 6-string x 24-fret structure. The piano highway plugin
     decodes back via: midi = string * 24 + fret.
+
+    Honors GP repeat brackets and D.S./D.C./Coda/Fine jumps when
+    ``expand_repeats`` is true — see :func:`_build_playback_schedule`.
     """
     track = song.tracks[track_index]
     tempo_map = _build_tempo_map(song)
+    schedule = _build_playback_schedule(song, tempo_map, expand_repeats)
+    headers = song.measureHeaders
 
     # ── Collect beats ────────────────────────────────────────────────
     beats = []
-    for mh in song.measureHeaders:
-        t = _tick_to_seconds(mh.start, tempo_map) + audio_offset
-        beats.append(RsBeat(time=t, measure=mh.number))
-        tempo = _tempo_at_tick(mh.start, tempo_map)
+    for entry in schedule:
+        mh = headers[entry.mh_index]
+        beats.append(RsBeat(
+            time=entry.output_start_secs + audio_offset,
+            measure=mh.number,
+        ))
         num_beats_in_measure = mh.timeSignature.numerator
         for b in range(1, num_beats_in_measure):
             sub_tick = mh.start + b * GP_TICKS_PER_QUARTER
-            sub_t = _tick_to_seconds(sub_tick, tempo_map) + audio_offset
-            beats.append(RsBeat(time=sub_t, measure=-1))
+            sub_offset_in_measure = _tick_to_seconds(sub_tick, tempo_map) \
+                - entry.mh_authored_start_secs
+            beats.append(RsBeat(
+                time=entry.output_start_secs + sub_offset_in_measure + audio_offset,
+                measure=-1,
+            ))
     beats.sort(key=lambda b: b.time)
 
     # ── Collect sections from markers ────────────────────────────────
     sections = []
-    section_counts = {}
-    for mh in song.measureHeaders:
+    section_counts: dict[str, int] = {}
+    for entry in schedule:
+        mh = headers[entry.mh_index]
         if mh.marker and mh.marker.title:
             name = mh.marker.title.strip().lower().replace(" ", "")
             section_counts[name] = section_counts.get(name, 0) + 1
-            t = _tick_to_seconds(mh.start, tempo_map) + audio_offset
-            sections.append(RsSection(name=name, time=t, number=section_counts[name]))
+            sections.append(RsSection(
+                name=name,
+                time=entry.output_start_secs + audio_offset,
+                number=section_counts[name],
+            ))
     if not sections:
         sections.append(RsSection(name="default", time=audio_offset, number=1))
 
@@ -836,13 +1150,16 @@ def convert_piano_track(
     chord_templates: list[ChordTemplate] = []
     chord_template_map: dict[tuple, int] = {}
 
-    for measure in track.measures:
+    for entry in schedule:
+        measure = track.measures[entry.mh_index]
         for voice in measure.voices:
             for beat in voice.beats:
                 if not beat.notes:
                     continue
 
-                t = _tick_to_seconds(beat.start, tempo_map) + audio_offset
+                authored_beat_secs = _tick_to_seconds(beat.start, tempo_map)
+                t = (authored_beat_secs - entry.mh_authored_start_secs) \
+                    + entry.output_start_secs + audio_offset
                 tempo = _tempo_at_tick(beat.start, tempo_map)
                 dur = _duration_to_seconds(beat.duration, tempo)
 
@@ -918,11 +1235,15 @@ def convert_piano_track(
     anchors = [RsAnchor(time=audio_offset, fret=1, width=24)]
 
     # ── Song length ──────────────────────────────────────────────────
-    last_mh = song.measureHeaders[-1]
-    song_length = _tick_to_seconds(
-        last_mh.start + last_mh.timeSignature.numerator * GP_TICKS_PER_QUARTER,
-        tempo_map,
-    ) + audio_offset
+    if schedule:
+        last_entry = schedule[-1]
+        song_length = (
+            last_entry.output_start_secs
+            + _measure_duration_secs(headers[last_entry.mh_index], tempo_map)
+            + audio_offset
+        )
+    else:
+        song_length = audio_offset
 
     # ── Build XML ────────────────────────────────────────────────────
     # Use all-zero tuning (piano has no tuning concept)
@@ -951,6 +1272,7 @@ def convert_drum_track(
     track_index: int,
     audio_offset: float = 0.0,
     arrangement_name: str = "Drums",
+    expand_repeats: bool = True,
 ) -> str:
     """Convert a GP drum/percussion track to Rocksmith XML using MIDI encoding.
 
@@ -960,31 +1282,47 @@ def convert_drum_track(
 
     The drum highway plugin decodes back via: midi = string * 24 + fret
     and maps to the appropriate drum lane (kick, snare, hi-hat, etc.).
+
+    Honors GP repeat brackets and D.S./D.C./Coda/Fine jumps when
+    ``expand_repeats`` is true — see :func:`_build_playback_schedule`.
     """
     track = song.tracks[track_index]
     tempo_map = _build_tempo_map(song)
+    schedule = _build_playback_schedule(song, tempo_map, expand_repeats)
+    headers = song.measureHeaders
 
     # ── Collect beats ────────────────────────────────────────────────
     beats = []
-    for mh in song.measureHeaders:
-        t = _tick_to_seconds(mh.start, tempo_map) + audio_offset
-        beats.append(RsBeat(time=t, measure=mh.number))
+    for entry in schedule:
+        mh = headers[entry.mh_index]
+        beats.append(RsBeat(
+            time=entry.output_start_secs + audio_offset,
+            measure=mh.number,
+        ))
         num_beats_in_measure = mh.timeSignature.numerator
         for b in range(1, num_beats_in_measure):
             sub_tick = mh.start + b * GP_TICKS_PER_QUARTER
-            sub_t = _tick_to_seconds(sub_tick, tempo_map) + audio_offset
-            beats.append(RsBeat(time=sub_t, measure=-1))
+            sub_offset_in_measure = _tick_to_seconds(sub_tick, tempo_map) \
+                - entry.mh_authored_start_secs
+            beats.append(RsBeat(
+                time=entry.output_start_secs + sub_offset_in_measure + audio_offset,
+                measure=-1,
+            ))
     beats.sort(key=lambda b: b.time)
 
     # ── Collect sections from markers ────────────────────────────────
     sections = []
-    section_counts = {}
-    for mh in song.measureHeaders:
+    section_counts: dict[str, int] = {}
+    for entry in schedule:
+        mh = headers[entry.mh_index]
         if mh.marker and mh.marker.title:
             name = mh.marker.title.strip().lower().replace(" ", "")
             section_counts[name] = section_counts.get(name, 0) + 1
-            t = _tick_to_seconds(mh.start, tempo_map) + audio_offset
-            sections.append(RsSection(name=name, time=t, number=section_counts[name]))
+            sections.append(RsSection(
+                name=name,
+                time=entry.output_start_secs + audio_offset,
+                number=section_counts[name],
+            ))
     if not sections:
         sections.append(RsSection(name="default", time=audio_offset, number=1))
 
@@ -994,13 +1332,16 @@ def convert_drum_track(
     chord_templates: list[ChordTemplate] = []
     chord_template_map: dict[tuple, int] = {}
 
-    for measure in track.measures:
+    for entry in schedule:
+        measure = track.measures[entry.mh_index]
         for voice in measure.voices:
             for beat in voice.beats:
                 if not beat.notes:
                     continue
 
-                t = _tick_to_seconds(beat.start, tempo_map) + audio_offset
+                authored_beat_secs = _tick_to_seconds(beat.start, tempo_map)
+                t = (authored_beat_secs - entry.mh_authored_start_secs) \
+                    + entry.output_start_secs + audio_offset
 
                 beat_notes = []
                 for note in beat.notes:
@@ -1074,11 +1415,15 @@ def convert_drum_track(
     anchors = [RsAnchor(time=audio_offset, fret=1, width=24)]
 
     # ── Song length ──────────────────────────────────────────────────
-    last_mh = song.measureHeaders[-1]
-    song_length = _tick_to_seconds(
-        last_mh.start + last_mh.timeSignature.numerator * GP_TICKS_PER_QUARTER,
-        tempo_map,
-    ) + audio_offset
+    if schedule:
+        last_entry = schedule[-1]
+        song_length = (
+            last_entry.output_start_secs
+            + _measure_duration_secs(headers[last_entry.mh_index], tempo_map)
+            + audio_offset
+        )
+    else:
+        song_length = audio_offset
 
     # ── Build XML ────────────────────────────────────────────────────
     return _build_xml(
@@ -1108,6 +1453,7 @@ def convert_file(
     audio_offset: float = 0.0,
     arrangement_names: dict[int, str] | None = None,
     force_standard_tuning: bool = False,
+    expand_repeats: bool = True,
 ) -> list[str]:
     """Convert a GP file to Rocksmith XMLs.
 
@@ -1118,6 +1464,12 @@ def convert_file(
         audio_offset: Seconds to add for audio sync
         arrangement_names: Override arrangement names {track_idx: name}
         force_standard_tuning: Force E standard tuning (frets unchanged)
+        expand_repeats: When true (default), the converter walks the GP
+            playback graph — replaying repeat brackets, honoring volta
+            (1st/2nd-ending) markers, and following D.S./D.C./Coda/Fine
+            jumps — so the emitted arrangement matches a linear audio file
+            playing the song as performed. Pass false to recover the legacy
+            as-written behavior (each measure emitted exactly once).
 
     Returns:
         List of output XML file paths
@@ -1142,16 +1494,19 @@ def convert_file(
         # Route drum/percussion tracks through drum converter
         if is_drum_track(track) or (arr_name and arr_name.lower().startswith("drums")):
             xml_str = convert_drum_track(
-                song, idx, audio_offset, arr_name or "Drums"
+                song, idx, audio_offset, arr_name or "Drums",
+                expand_repeats=expand_repeats,
             )
         # Route piano/keyboard tracks through the MIDI-encoding converter
         elif is_piano_track(track) or (arr_name and arr_name.lower().startswith("keys")):
             xml_str = convert_piano_track(
-                song, idx, audio_offset, arr_name or "Keys"
+                song, idx, audio_offset, arr_name or "Keys",
+                expand_repeats=expand_repeats,
             )
         else:
             xml_str = convert_track(
-                song, idx, audio_offset, arr_name, force_standard_tuning
+                song, idx, audio_offset, arr_name, force_standard_tuning,
+                expand_repeats=expand_repeats,
             )
 
         safe_name = track.name.strip().replace(" ", "_").replace("/", "_")

--- a/lib/gp2rs.py
+++ b/lib/gp2rs.py
@@ -322,11 +322,15 @@ def _build_playback_schedule(
     def find_repeat_close(start: int) -> int | None:
         """Index of the first measure ≥ start whose ``repeatClose`` is set.
 
-        ``repeatClose`` is parsed as ``-1`` when absent and as the
-        "additional repetitions" count (``0`` = no repeat) otherwise.
+        pyguitarpro encodes ``repeatClose == -1`` for "no close marker" and
+        ``repeatClose == N`` (with ``N >= 0``) for a closing marker that
+        replays the bracket ``N`` additional times. We accept any non-
+        negative value as a close so a file authored with ``repeatClose
+        == 0`` (a "decorative" close that doesn't actually loop) doesn't
+        get mis-treated as an orphan open.
         """
         for j in range(start, len(headers)):
-            if headers[j].repeatClose > 0:
+            if headers[j].repeatClose >= 0:
                 return j
         return None
 

--- a/lib/gp2rs.py
+++ b/lib/gp2rs.py
@@ -119,11 +119,18 @@ class PlaybackEntry:
 
         output_time = (authored_secs - mh_authored_start_secs)
                       + output_start_secs + audio_offset
+
+    ``duration_secs`` is the same value the schedule used when stepping
+    ``output_start_secs`` forward, so consumers (e.g. ``song_length``
+    derivation) can compute ``output_end = output_start_secs +
+    duration_secs`` without redoing the time-signature math the schedule
+    deliberately avoids for irregular / pickup measures.
     """
     mh_index: int
     pass_index: int
     output_start_secs: float
     mh_authored_start_secs: float
+    duration_secs: float
 
 
 def _build_tempo_map(song: guitarpro.Song) -> list[TempoEvent]:
@@ -303,6 +310,7 @@ def _build_playback_schedule(
             pass_index=pass_index,
             output_start_secs=output_t,
             mh_authored_start_secs=authored_starts[idx],
+            duration_secs=durations[idx],
         ))
         output_t += durations[idx]
 
@@ -522,6 +530,7 @@ def convert_track(
     audio_offset: float = 0.0,
     arrangement_name: str = "",
     force_standard_tuning: bool = False,
+    *,
     expand_repeats: bool = True,
 ) -> str:
     """Convert a GP track to Rocksmith 2014 arrangement XML string.
@@ -755,7 +764,7 @@ def convert_track(
         last_entry = schedule[-1]
         song_length = (
             last_entry.output_start_secs
-            + _measure_duration_secs(headers[last_entry.mh_index], tempo_map)
+            + last_entry.duration_secs
             + audio_offset
         )
     else:
@@ -1089,6 +1098,7 @@ def convert_piano_track(
     track_index: int,
     audio_offset: float = 0.0,
     arrangement_name: str = "Keys",
+    *,
     expand_repeats: bool = True,
 ) -> str:
     """Convert a GP piano/keyboard track to Rocksmith XML using MIDI encoding.
@@ -1239,7 +1249,7 @@ def convert_piano_track(
         last_entry = schedule[-1]
         song_length = (
             last_entry.output_start_secs
-            + _measure_duration_secs(headers[last_entry.mh_index], tempo_map)
+            + last_entry.duration_secs
             + audio_offset
         )
     else:
@@ -1272,6 +1282,7 @@ def convert_drum_track(
     track_index: int,
     audio_offset: float = 0.0,
     arrangement_name: str = "Drums",
+    *,
     expand_repeats: bool = True,
 ) -> str:
     """Convert a GP drum/percussion track to Rocksmith XML using MIDI encoding.
@@ -1419,7 +1430,7 @@ def convert_drum_track(
         last_entry = schedule[-1]
         song_length = (
             last_entry.output_start_secs
-            + _measure_duration_secs(headers[last_entry.mh_index], tempo_map)
+            + last_entry.duration_secs
             + audio_offset
         )
     else:
@@ -1453,6 +1464,7 @@ def convert_file(
     audio_offset: float = 0.0,
     arrangement_names: dict[int, str] | None = None,
     force_standard_tuning: bool = False,
+    *,
     expand_repeats: bool = True,
 ) -> list[str]:
     """Convert a GP file to Rocksmith XMLs.

--- a/tests/test_gp2rs.py
+++ b/tests/test_gp2rs.py
@@ -1,12 +1,13 @@
-"""Tests for lib/gp2rs.py tempo/tick math helpers.
+"""Tests for lib/gp2rs.py tempo/tick math helpers + playback-schedule walker.
 
-These functions are the pure arithmetic core of the Guitar Pro → Rocksmith
-conversion pipeline. Fixture-free: all you need is hand-constructed
-`TempoEvent` lists and integer tick / string inputs. The module-level
-`import guitarpro` in gp2rs.py is harmless for import (no guitarpro
-objects are constructed at module load).
+The math helpers are fixture-free: hand-constructed `TempoEvent` lists and
+integer tick / string inputs. The playback-schedule tests use
+`SimpleNamespace` mocks shaped like `guitarpro.MeasureHeader` / `Song` —
+the schedule walker only reads a small set of attributes, so we don't need
+real .gp files on disk.
 
-See issue #46.
+See issue #46 (tempo math) and the GP repeat-expansion PR for the schedule
+walker.
 """
 
 from types import SimpleNamespace
@@ -16,6 +17,7 @@ import pytest
 from gp2rs import (
     GP_TICKS_PER_QUARTER,
     TempoEvent,
+    _build_playback_schedule,
     _compute_tuning,
     _extract_year,
     _gp_string_to_rs,
@@ -291,3 +293,259 @@ def test_compute_tuning_drop_d_guitar():
     # is stored low→high, so index 0 is the lowest string.
     track = _fake_track([64, 59, 55, 50, 45, 38], instrument=24)
     assert _compute_tuning(track) == [-2, 0, 0, 0, 0, 0]
+
+
+# ── _build_playback_schedule ─────────────────────────────────────────────────
+# Mocks `guitarpro.MeasureHeader` and `guitarpro.Song` with `SimpleNamespace`.
+# The schedule walker reads only:
+#   - song.measureHeaders[i].start, .timeSignature.numerator/.denominator.value,
+#     .isRepeatOpen, .repeatClose, .repeatAlternative, .direction, .fromDirection
+# That's all the fixture surface we need to construct.
+
+def _make_song(headers):
+    return SimpleNamespace(measureHeaders=headers)
+
+
+def _make_header(
+    start_quarters: float,
+    numerator: int = 4,
+    denominator: int = 4,
+    *,
+    is_repeat_open: bool = False,
+    repeat_close: int = -1,
+    repeat_alt: int = 0,
+    direction_name: str | None = None,
+    from_direction_name: str | None = None,
+):
+    """Build a mock MeasureHeader. ``start_quarters`` is in quarter-notes
+    from the song start; converted to ticks internally."""
+    return SimpleNamespace(
+        start=int(round(start_quarters * GP_TICKS_PER_QUARTER)),
+        number=0,  # unused by schedule walker; converters set it from mh.number
+        timeSignature=SimpleNamespace(
+            numerator=numerator,
+            denominator=SimpleNamespace(value=denominator),
+        ),
+        isRepeatOpen=is_repeat_open,
+        repeatClose=repeat_close,
+        repeatAlternative=repeat_alt,
+        direction=SimpleNamespace(name=direction_name) if direction_name else None,
+        fromDirection=SimpleNamespace(name=from_direction_name) if from_direction_name else None,
+        marker=None,
+    )
+
+
+def _ids(schedule):
+    """Compact `(mh_index, pass_index)` summary for assertions."""
+    return [(e.mh_index, e.pass_index) for e in schedule]
+
+
+# Standard tempo map: 120 BPM constant → one 4/4 measure = 2.0 s.
+_TM_120 = [TempoEvent(tick=0, tempo=120.0)]
+
+
+def test_schedule_no_repeats_no_directions():
+    # 4 plain measures → 4 entries, pass=0 each, output times monotonic at 2 s/measure.
+    headers = [_make_header(i * 4) for i in range(4)]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    assert _ids(schedule) == [(0, 0), (1, 0), (2, 0), (3, 0)]
+    assert [round(e.output_start_secs, 3) for e in schedule] == [0.0, 2.0, 4.0, 6.0]
+
+
+def test_schedule_simple_repeat():
+    # ||: A | B :||×2 → 4 entries: A0 B0 A1 B1
+    headers = [
+        _make_header(0, is_repeat_open=True),   # A
+        _make_header(4, repeat_close=1),         # B (×2: 1 additional rep)
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    assert _ids(schedule) == [(0, 0), (1, 0), (0, 1), (1, 1)]
+    assert [round(e.output_start_secs, 3) for e in schedule] == [0.0, 2.0, 4.0, 6.0]
+
+
+def test_schedule_with_volta():
+    # ||: A | B :|1.| C |2.| D ||  — C plays pass 0 only, D plays pass 1 only.
+    # Volta C: repeatAlternative bit 0 set; close-of-pass-0 is at C itself
+    # (repeatClose=1 because the bracket repeats once total, so 2 passes).
+    headers = [
+        _make_header(0, is_repeat_open=True),         # A
+        _make_header(4),                                # B
+        _make_header(8, repeat_alt=0b01),               # C (1st ending)
+        _make_header(12, repeat_alt=0b10, repeat_close=1),  # D (2nd ending, closes)
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    # Pass 0: A B C (skip D). Pass 1: A B D (skip C).
+    assert _ids(schedule) == [
+        (0, 0), (1, 0), (2, 0),
+        (0, 1), (1, 1), (3, 1),
+    ]
+
+
+def test_schedule_sequential_groups():
+    # ||: A :||×2 | B | ||: C :||×3  → 2×A, B, 3×C
+    headers = [
+        _make_header(0, is_repeat_open=True, repeat_close=1),  # A (×2)
+        _make_header(4),                                          # B
+        _make_header(8, is_repeat_open=True, repeat_close=2),  # C (×3)
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    assert _ids(schedule) == [
+        (0, 0), (0, 1),       # 2×A
+        (1, 0),                # B
+        (2, 0), (2, 1), (2, 2),  # 3×C
+    ]
+
+
+def test_schedule_da_capo_al_fine():
+    # A | B(Fine) | C | D(D.C. al Fine) → A B C D A B (stop at Fine on pass 2)
+    headers = [
+        _make_header(0),                                            # A
+        _make_header(4, direction_name="Fine"),                     # B
+        _make_header(8),                                            # C
+        _make_header(12, from_direction_name="Da Capo al Fine"),    # D
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    assert _ids(schedule) == [(0, 0), (1, 0), (2, 0), (3, 0), (0, 0), (1, 0)]
+
+
+def test_schedule_dal_segno_al_coda():
+    # A | B(Segno) | C(To Coda) | D | E(D.S. al Coda) | F(Coda) | G
+    # → A B C D E B C F G  (jump to Segno, replay until Da Coda redirect, jump to Coda)
+    headers = [
+        _make_header(0),                                            # A
+        _make_header(4, direction_name="Segno"),                    # B
+        _make_header(8, from_direction_name="Da Coda"),             # C (To Coda)
+        _make_header(12),                                           # D
+        _make_header(16, from_direction_name="Da Segno al Coda"),   # E
+        _make_header(20, direction_name="Coda"),                    # F
+        _make_header(24),                                           # G
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    # First pass: A B C D E → at E, jump back to Segno (B). Now jumped_back=True,
+    # stop_at="coda". Replay from B: B is fine (no Da Coda). C has Da Coda →
+    # redirect to F. Then G plays. Final: A B C D E B F G.
+    assert _ids(schedule) == [(0, 0), (1, 0), (2, 0), (3, 0), (4, 0), (1, 0), (5, 0), (6, 0)]
+
+
+def test_schedule_da_capo_inside_repeat_block_fires_immediately():
+    # ||: A | B(D.C. al Fine) :||×2 | C(Fine) | D
+    # A D.C. authored *inside* a repeat block must still fire the first time
+    # we reach the measure carrying it — without the repeat completing the
+    # remaining passes. This is the regression the inline repeat sub-loop
+    # used to miss: it would silently complete the bracket and the D.C.
+    # never triggered.
+    headers = [
+        _make_header(0, is_repeat_open=True),                                # A
+        _make_header(4, repeat_close=1, from_direction_name="Da Capo al Fine"),  # B
+        _make_header(8, direction_name="Fine"),                              # C
+        _make_header(12),                                                    # D
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    # First pass through the bracket plays A B once; the D.C. fires at the
+    # end of B before the second pass; the jumped-back walk plays A B C and
+    # stops at Fine.
+    assert _ids(schedule) == [(0, 0), (1, 0), (0, 0), (1, 0), (2, 0)]
+
+
+def test_schedule_da_capo_suppresses_inner_repeats():
+    # ||: A :||×2 | B(D.C.) → first pass plays the bracket (A A B), then D.C.
+    # jumps back to measure 0 and replays inner repeat *once* (A B).
+    headers = [
+        _make_header(0, is_repeat_open=True, repeat_close=1),       # A (×2)
+        _make_header(4, from_direction_name="Da Capo"),              # B
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    # Pass 1: A A B (repeat honored). After D.C.: jumped_back=True → A B.
+    assert _ids(schedule) == [(0, 0), (0, 1), (1, 0), (0, 0), (1, 0)]
+
+
+def test_schedule_expand_disabled():
+    # Same shape as simple_repeat but expand_repeats=False → 2 entries.
+    headers = [
+        _make_header(0, is_repeat_open=True),
+        _make_header(4, repeat_close=1),
+    ]
+    schedule = _build_playback_schedule(
+        _make_song(headers), _TM_120, expand_repeats=False,
+    )
+    assert _ids(schedule) == [(0, 0), (1, 0)]
+
+
+def test_schedule_orphan_open_warns(caplog):
+    # Open without matching close → log warning, walk linearly.
+    headers = [
+        _make_header(0, is_repeat_open=True),
+        _make_header(4),
+        _make_header(8),
+    ]
+    with caplog.at_level("WARNING", logger="slopsmith.lib.gp2rs"):
+        schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    assert _ids(schedule) == [(0, 0), (1, 0), (2, 0)]
+    assert any("no matching close" in rec.message for rec in caplog.records)
+
+
+def test_schedule_unresolved_dal_segno_warns(caplog):
+    # Da Segno with no Segno target → warn, advance linearly past the jump.
+    headers = [
+        _make_header(0),
+        _make_header(4, from_direction_name="Da Segno"),
+        _make_header(8),
+    ]
+    with caplog.at_level("WARNING", logger="slopsmith.lib.gp2rs"):
+        schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    assert _ids(schedule) == [(0, 0), (1, 0), (2, 0)]
+    assert any("no matching target" in rec.message for rec in caplog.records)
+
+
+def test_schedule_note_time_shifts_under_repeat():
+    # ||: A :||×2 with 4/4 at 120 BPM → measure A is 2 s long. First-pass A
+    # starts at 0 s; second-pass A starts at 2 s.
+    headers = [_make_header(0, is_repeat_open=True, repeat_close=1)]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    assert len(schedule) == 2
+    assert schedule[0].output_start_secs == pytest.approx(0.0)
+    assert schedule[1].output_start_secs == pytest.approx(2.0)
+    # mh_authored_start_secs is the same for both (same source measure).
+    assert schedule[0].mh_authored_start_secs == schedule[1].mh_authored_start_secs
+
+
+def test_schedule_song_length_reflects_expansion():
+    # ||: A | B :||×2 → expanded length is 4 measures × 2 s = 8 s, not 4 s.
+    headers = [
+        _make_header(0, is_repeat_open=True),
+        _make_header(4, repeat_close=1),
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    last = schedule[-1]
+    last_mh = headers[last.mh_index]
+    # Output end = last entry start + last measure duration.
+    measure_secs = (last_mh.timeSignature.numerator
+                    * (4.0 / last_mh.timeSignature.denominator.value)
+                    * GP_TICKS_PER_QUARTER) \
+                   / GP_TICKS_PER_QUARTER * (60.0 / 120.0)
+    expanded_end = last.output_start_secs + measure_secs
+    assert expanded_end == pytest.approx(8.0)
+
+
+def test_schedule_empty_song():
+    # No headers → empty schedule. Should not crash.
+    schedule = _build_playback_schedule(_make_song([]), _TM_120)
+    assert schedule == []
+
+
+def test_schedule_irregular_measure_lengths():
+    # A 3-quarter pickup followed by two 4-quarter measures, then ||: D :||×2.
+    # The pickup is intentionally shorter than its 4/4 time signature would
+    # suggest — that's how GP encodes an anacrusis. The schedule must use the
+    # tick delta to the next measure as the duration, not the time signature.
+    headers = [
+        _make_header(0, numerator=4),   # A — 3 quarters long (starts at 0, next at 3)
+        _make_header(3, numerator=4),   # B
+        _make_header(7, numerator=4),   # C
+        _make_header(11, numerator=4, is_repeat_open=True, repeat_close=1),  # D ×2
+    ]
+    schedule = _build_playback_schedule(_make_song(headers), _TM_120)
+    # 120 BPM: 1 quarter = 0.5 s. Output starts:
+    #   A: 0.0, B: 1.5 (3 q), C: 3.5 (4 q), D pass 0: 5.5 (4 q), D pass 1: 7.5
+    out = [round(e.output_start_secs, 3) for e in schedule]
+    assert out == [0.0, 1.5, 3.5, 5.5, 7.5]

--- a/tests/test_gp2rs.py
+++ b/tests/test_gp2rs.py
@@ -321,7 +321,7 @@ def _make_header(
     """Build a mock MeasureHeader. ``start_quarters`` is in quarter-notes
     from the song start; converted to ticks internally."""
     return SimpleNamespace(
-        start=int(round(start_quarters * GP_TICKS_PER_QUARTER)),
+        start=round(start_quarters * GP_TICKS_PER_QUARTER),
         number=0,  # unused by schedule walker; converters set it from mh.number
         timeSignature=SimpleNamespace(
             numerator=numerator,
@@ -354,10 +354,10 @@ def test_schedule_no_repeats_no_directions():
 
 
 def test_schedule_simple_repeat():
-    # ||: A | B :||×2 → 4 entries: A0 B0 A1 B1
+    # ||: A | B :||x2 → 4 entries: A0 B0 A1 B1
     headers = [
         _make_header(0, is_repeat_open=True),   # A
-        _make_header(4, repeat_close=1),         # B (×2: 1 additional rep)
+        _make_header(4, repeat_close=1),         # B (x2: 1 additional rep)
     ]
     schedule = _build_playback_schedule(_make_song(headers), _TM_120)
     assert _ids(schedule) == [(0, 0), (1, 0), (0, 1), (1, 1)]
@@ -383,17 +383,17 @@ def test_schedule_with_volta():
 
 
 def test_schedule_sequential_groups():
-    # ||: A :||×2 | B | ||: C :||×3  → 2×A, B, 3×C
+    # ||: A :||x2 | B | ||: C :||x3  → 2xA, B, 3xC
     headers = [
-        _make_header(0, is_repeat_open=True, repeat_close=1),  # A (×2)
+        _make_header(0, is_repeat_open=True, repeat_close=1),  # A (x2)
         _make_header(4),                                          # B
-        _make_header(8, is_repeat_open=True, repeat_close=2),  # C (×3)
+        _make_header(8, is_repeat_open=True, repeat_close=2),  # C (x3)
     ]
     schedule = _build_playback_schedule(_make_song(headers), _TM_120)
     assert _ids(schedule) == [
-        (0, 0), (0, 1),       # 2×A
+        (0, 0), (0, 1),       # 2xA
         (1, 0),                # B
-        (2, 0), (2, 1), (2, 2),  # 3×C
+        (2, 0), (2, 1), (2, 2),  # 3xC
     ]
 
 
@@ -429,7 +429,7 @@ def test_schedule_dal_segno_al_coda():
 
 
 def test_schedule_da_capo_inside_repeat_block_fires_immediately():
-    # ||: A | B(D.C. al Fine) :||×2 | C(Fine) | D
+    # ||: A | B(D.C. al Fine) :||x2 | C(Fine) | D
     # A D.C. authored *inside* a repeat block must still fire the first time
     # we reach the measure carrying it — without the repeat completing the
     # remaining passes. This is the regression the inline repeat sub-loop
@@ -449,10 +449,10 @@ def test_schedule_da_capo_inside_repeat_block_fires_immediately():
 
 
 def test_schedule_da_capo_suppresses_inner_repeats():
-    # ||: A :||×2 | B(D.C.) → first pass plays the bracket (A A B), then D.C.
+    # ||: A :||x2 | B(D.C.) → first pass plays the bracket (A A B), then D.C.
     # jumps back to measure 0 and replays inner repeat *once* (A B).
     headers = [
-        _make_header(0, is_repeat_open=True, repeat_close=1),       # A (×2)
+        _make_header(0, is_repeat_open=True, repeat_close=1),       # A (x2)
         _make_header(4, from_direction_name="Da Capo"),              # B
     ]
     schedule = _build_playback_schedule(_make_song(headers), _TM_120)
@@ -517,7 +517,7 @@ def test_schedule_unresolved_dal_segno_warns():
 
 
 def test_schedule_note_time_shifts_under_repeat():
-    # ||: A :||×2 with 4/4 at 120 BPM → measure A is 2 s long. First-pass A
+    # ||: A :||x2 with 4/4 at 120 BPM → measure A is 2 s long. First-pass A
     # starts at 0 s; second-pass A starts at 2 s.
     headers = [_make_header(0, is_repeat_open=True, repeat_close=1)]
     schedule = _build_playback_schedule(_make_song(headers), _TM_120)
@@ -529,7 +529,7 @@ def test_schedule_note_time_shifts_under_repeat():
 
 
 def test_schedule_song_length_reflects_expansion():
-    # ||: A | B :||×2 → expanded length is 4 measures × 2 s = 8 s, not 4 s.
+    # ||: A | B :||x2 → expanded length is 4 measures x 2 s = 8 s, not 4 s.
     headers = [
         _make_header(0, is_repeat_open=True),
         _make_header(4, repeat_close=1),
@@ -553,7 +553,7 @@ def test_schedule_empty_song():
 
 
 def test_schedule_irregular_measure_lengths():
-    # A 3-quarter pickup followed by two 4-quarter measures, then ||: D :||×2.
+    # A 3-quarter pickup followed by two 4-quarter measures, then ||: D :||x2.
     # The pickup is intentionally shorter than its 4/4 time signature would
     # suggest — that's how GP encodes an anacrusis. The schedule must use the
     # tick delta to the next measure as the duration, not the time signature.
@@ -561,7 +561,7 @@ def test_schedule_irregular_measure_lengths():
         _make_header(0, numerator=4),   # A — 3 quarters long (starts at 0, next at 3)
         _make_header(3, numerator=4),   # B
         _make_header(7, numerator=4),   # C
-        _make_header(11, numerator=4, is_repeat_open=True, repeat_close=1),  # D ×2
+        _make_header(11, numerator=4, is_repeat_open=True, repeat_close=1),  # D x2
     ]
     schedule = _build_playback_schedule(_make_song(headers), _TM_120)
     # 120 BPM: 1 quarter = 0.5 s. Output starts:

--- a/tests/test_gp2rs.py
+++ b/tests/test_gp2rs.py
@@ -11,6 +11,7 @@ walker.
 """
 
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
@@ -471,30 +472,48 @@ def test_schedule_expand_disabled():
     assert _ids(schedule) == [(0, 0), (1, 0)]
 
 
-def test_schedule_orphan_open_warns(caplog):
+def _warning_messages(mock_log) -> list[str]:
+    """Format every `log.warning(fmt, *args)` call into its rendered message.
+
+    We patch the module-level logger rather than using pytest's caplog because
+    slopsmith's conftest installs a structlog processor chain that intercepts
+    logging records before caplog can see them — fine in production, but it
+    leaves caplog silent in CI even though the warning is emitted.
+    """
+    out = []
+    for call in mock_log.warning.call_args_list:
+        fmt, *args = call.args
+        try:
+            out.append(fmt % tuple(args))
+        except TypeError:
+            out.append(str(fmt))
+    return out
+
+
+def test_schedule_orphan_open_warns():
     # Open without matching close → log warning, walk linearly.
     headers = [
         _make_header(0, is_repeat_open=True),
         _make_header(4),
         _make_header(8),
     ]
-    with caplog.at_level("WARNING", logger="slopsmith.lib.gp2rs"):
+    with mock.patch("gp2rs.log") as mock_log:
         schedule = _build_playback_schedule(_make_song(headers), _TM_120)
     assert _ids(schedule) == [(0, 0), (1, 0), (2, 0)]
-    assert any("no matching close" in rec.message for rec in caplog.records)
+    assert any("no matching close" in m for m in _warning_messages(mock_log))
 
 
-def test_schedule_unresolved_dal_segno_warns(caplog):
+def test_schedule_unresolved_dal_segno_warns():
     # Da Segno with no Segno target → warn, advance linearly past the jump.
     headers = [
         _make_header(0),
         _make_header(4, from_direction_name="Da Segno"),
         _make_header(8),
     ]
-    with caplog.at_level("WARNING", logger="slopsmith.lib.gp2rs"):
+    with mock.patch("gp2rs.log") as mock_log:
         schedule = _build_playback_schedule(_make_song(headers), _TM_120)
     assert _ids(schedule) == [(0, 0), (1, 0), (2, 0)]
-    assert any("no matching target" in rec.message for rec in caplog.records)
+    assert any("no matching target" in m for m in _warning_messages(mock_log))
 
 
 def test_schedule_note_time_shifts_under_repeat():


### PR DESCRIPTION
## Summary

GP imports walk \`track.measures\` and \`song.measureHeaders\` linearly and ignore every kind of non-linear playback metadata, so a chart with repeat brackets, volta endings, or D.S./D.C./Coda/Fine jumps is emitted as one straight pass. The audio file the user pairs with the chart plays the song *as performed*, so the resulting Rocksmith arrangement runs out of notes long before the audio finishes.

This change introduces a \`PlaybackEntry\` schedule produced by a single state machine over \`song.measureHeaders\` that honors three layers of non-linear playback when \`expand_repeats=True\` (the new default):

1. **D.S. / D.C. / Coda / Fine** jumps via \`MeasureHeader.fromDirection\` and \`.direction\`. Pre-scans direction targets (Segno, Coda, Fine, Double Coda, Segno Segno), then fires the first jump it encounters and arms an optional \`al Fine\` / \`al Coda\` stop / redirect that consumes the matching \`Da Coda\` or \`Fine\` marker on the next pass. **Fires correctly even when the marker lives inside a repeat bracket** — every emitted measure goes through the same jump/stop checks regardless of whether it's inside a repeat.
2. **Repeat brackets** (\`isRepeatOpen\` / \`repeatClose\` with the \`repeatAlternative\` volta bitmask). Replays the bracket \`repeatClose + 1\` times, skipping volta measures whose pass-index bit is not set. Conventionally suppressed after a D.S./D.C. jump fires (the standard "second time, don't repeat").
3. **Linear walk** — fall-through.

All three converters (\`convert_track\`, \`convert_piano_track\`, \`convert_drum_track\`) iterate the schedule rather than measureHeaders and \`track.measures\` directly. Each \`PlaybackEntry\` carries authored time, output time, and per-entry duration (from adjacent-header tick deltas, so anacrusis / pickup measures time-align correctly), so per-note times shift correctly across replays and \`<songLength>\` reflects the actual end of the expanded chart.

API: every \`convert_*\` plus \`convert_file\` gains a keyword-only \`expand_repeats=True\`. Callers pairing charts with as-written audio can pass \`expand_repeats=False\` to recover the legacy behavior; the editor plugin's \`/api/plugins/editor/convert-gp\` keeps calling \`convert_file\` with no changes and inherits the new default.

Edge cases (orphan repeat-open, unresolved D.S./D.C., duplicate direction markers, etc.) log a warning via \`slopsmith.lib.gp2rs\` and fall back to a linear walk for the affected section.

Builds on top of #258 (extended-range) — both touched the converter bodies; this branch cherry-picks the repeat-expansion work onto the post-merge main.

## Test plan

70 tests pass in \`tests/test_gp2rs.py\` (15 new for this PR):
- [x] Plain chart, no repeats / no directions
- [x] Simple \`||: A B :||×2\` repeat
- [x] 1st/2nd-ending volta (\`repeatAlternative\` bitmask)
- [x] Sequential repeat groups (\`||: A :||×2 | B | ||: C :||×3\`)
- [x] \`D.C. al Fine\` with a Fine marker
- [x] \`D.S. al Coda\` with Segno + To Coda + Coda
- [x] \`D.C.\` inside a repeat block fires immediately (regression)
- [x] \`D.C.\` after a \`×2\` repeat — second pass plays the bracket once
- [x] \`expand_repeats=False\` preserves the old as-written behavior
- [x] Orphan repeat-open warns and falls through linearly
- [x] Unresolved \`D.S.\` target warns and advances linearly
- [x] Per-note time shifts correctly across repeat passes
- [x] Expanded \`<songLength>\` reflects the post-expansion end
- [x] Empty song doesn't crash
- [x] Irregular measure lengths (anacrusis / 3-quarter pickup) accumulate correctly

Manual:
- [ ] Author a tiny GP with \`||: A B :||×2\` → convert → notes / beats / sections / songLength all reflect 2× playback

Codex preflight clean on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)