### PR TITLE
Fix missing arpeggio notes inside 3D highway frame boxes

### DIFF
--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -6132,11 +6132,15 @@
                     const hsTimeWinFrame = hsHintFrame.hs
                         ? { tLo: hsStart(hsHintFrame.hs) - 0.06, tHi: hsEnd(hsHintFrame.hs) + 0.06 }
                         : null;
+                    const chordOnsetTimeWinFrame = {
+                        tLo: ch.t - ARP_FRAME_ONSET_PAD_S,
+                        tHi: ch.t + ARP_FRAME_ONSET_CLUSTER_S,
+                    };
                     const noteStreamCoversArpShape = chordShapeCoveredByStandaloneNotes(
                         ch,
                         chShape,
                         notes,
-                        hsTimeWinFrame,
+                        chordOnsetTimeWinFrame,
                     );
                     const inferredArpPattern = (!hsHintFrame.hs
                         || handShapeChartSpanSec(hsHintFrame.hs) >= ARP_INFER_MIN_HAND_SHAPE_SPAN_S)

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -5142,6 +5142,29 @@
         }
 
         /**
+         * True when standalone note rows already cover every string/fret in the
+         * arpeggio shape, so drawing the chord gems too would duplicate the same
+         * authored passage.
+         */
+        function chordShapeCoveredByStandaloneNotes(ch, shape, notesArr, timeWin) {
+            if (!notesArr || notesArr.length === 0 || !shape || shape.size === 0) return false;
+            const tLo = (timeWin ? timeWin.tLo : ch.t - ARP_FRAME_ONSET_PAD_S) - NEXT_ON_STRING_T_EPS;
+            const tHi = (timeWin ? timeWin.tHi : ch.t + ARP_FRAME_ONSET_CLUSTER_S) + NEXT_ON_STRING_T_EPS;
+            let i2 = lowerBoundT(notesArr, tLo);
+            const matchedStrings = new Set();
+            for (; i2 < notesArr.length; i2++) {
+                const n = notesArr[i2];
+                if (n.t > tHi) break;
+                if (!validString(n.s) || matchedStrings.has(n.s)) continue;
+                const ef = shape.get(n.s);
+                if (ef === undefined || ef !== n.f) continue;
+                matchedStrings.add(n.s);
+                if (matchedStrings.size >= shape.size) return true;
+            }
+            return false;
+        }
+
+        /**
          * Notes in an inferred arpeggio passage are charted in ``notes[]`` with
          * staggered times; treat them like chord-cluster notes for Rocksmith-style
          * board-ghost fret digits (``fromChord`` + template column).
@@ -6109,19 +6132,23 @@
                     const hsTimeWinFrame = hsHintFrame.hs
                         ? { tLo: hsStart(hsHintFrame.hs) - 0.06, tHi: hsEnd(hsHintFrame.hs) + 0.06 }
                         : null;
+                    const noteStreamCoversArpShape = chordShapeCoveredByStandaloneNotes(
+                        ch,
+                        chShape,
+                        notes,
+                        hsTimeWinFrame,
+                    );
                     const inferredArpPattern = (!hsHintFrame.hs
                         || handShapeChartSpanSec(hsHintFrame.hs) >= ARP_INFER_MIN_HAND_SHAPE_SPAN_S)
                         && inferArpeggioFromNotePattern(
                             ch, chShape, notes, hsTimeWinFrame);
-                    // h3dSynth chords are added for the *frame* (the chart
-                    // authored no chord row), so defer the gem strum
-                    // unconditionally — otherwise a full chord strum can show
-                    // up at the hand-shape start when arp inference / explicit
-                    // marker fails, on top of the single notes the chart
-                    // already authored.
-                    const deferChordGems = ch.h3dSynth
+                    // Only suppress the chord gems when standalone notes really
+                    // cover the arpeggio shape; otherwise explicit/synth hand
+                    // shapes can produce an empty lavender frame with no notes
+                    // inside (e.g. template-marked `-arp` chord rows).
+                    const deferChordGems = (ch.h3dSynth && noteStreamCoversArpShape)
                         || inferredArpPattern
-                        || (hsHintFrame.explicit && hsHintFrame.covered);
+                        || (hsHintFrame.explicit && hsHintFrame.covered && noteStreamCoversArpShape);
                     /**
                      * Lavender chord frame + purple highway rails: authored
                      * arpeggio metadata only. RS ``highDensity`` marks gallops /
@@ -7228,7 +7255,7 @@
                         } else if (_st === 'hit' || _st === 'active') {
                             _ndState = _st;
                             _ndGood = true;
-                            _ndOutline = mGlow[s];        // bright string-tinted edge (no green)
+                            _ndOutline = mGlow[s];
                             // Carry the provider's alpha (and optional color)
                             // through to the sizzle so a struck-note fade or a
                             // custom palette comes through (#254 review).

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -6132,16 +6132,22 @@
                     const hsTimeWinFrame = hsHintFrame.hs
                         ? { tLo: hsStart(hsHintFrame.hs) - 0.06, tHi: hsEnd(hsHintFrame.hs) + 0.06 }
                         : null;
-                    const chordOnsetTimeWinFrame = {
-                        tLo: ch.t - ARP_FRAME_ONSET_PAD_S,
-                        tHi: ch.t + ARP_FRAME_ONSET_CLUSTER_S,
+                    // Lazy: the coverage scan walks the note stream and is only
+                    // consumed by the h3dSynth and explicit+covered branches of
+                    // `deferChordGems`; computing it eagerly for every chord
+                    // every frame regresses dense charts.
+                    let _arpCoverMemo;
+                    const noteStreamCoversArpShape = () => {
+                        if (_arpCoverMemo === undefined) {
+                            _arpCoverMemo = chordShapeCoveredByStandaloneNotes(
+                                ch,
+                                chShape,
+                                notes,
+                                { tLo: ch.t - ARP_FRAME_ONSET_PAD_S, tHi: ch.t + ARP_FRAME_ONSET_CLUSTER_S },
+                            );
+                        }
+                        return _arpCoverMemo;
                     };
-                    const noteStreamCoversArpShape = chordShapeCoveredByStandaloneNotes(
-                        ch,
-                        chShape,
-                        notes,
-                        chordOnsetTimeWinFrame,
-                    );
                     const inferredArpPattern = (!hsHintFrame.hs
                         || handShapeChartSpanSec(hsHintFrame.hs) >= ARP_INFER_MIN_HAND_SHAPE_SPAN_S)
                         && inferArpeggioFromNotePattern(
@@ -6150,9 +6156,9 @@
                     // cover the arpeggio shape; otherwise explicit/synth hand
                     // shapes can produce an empty lavender frame with no notes
                     // inside (e.g. template-marked `-arp` chord rows).
-                    const deferChordGems = (ch.h3dSynth && noteStreamCoversArpShape)
+                    const deferChordGems = (ch.h3dSynth && noteStreamCoversArpShape())
                         || inferredArpPattern
-                        || (hsHintFrame.explicit && hsHintFrame.covered && noteStreamCoversArpShape);
+                        || (hsHintFrame.explicit && hsHintFrame.covered && noteStreamCoversArpShape());
                     /**
                      * Lavender chord frame + purple highway rails: authored
                      * arpeggio metadata only. RS ``highDensity`` marks gallops /

--- a/tests/js/highway_3d_arp_deferral.test.js
+++ b/tests/js/highway_3d_arp_deferral.test.js
@@ -40,7 +40,7 @@ test('noteStreamCoversArpShape is computed lazily (called, not eagerly bound)', 
     const src = fs.readFileSync(SCREEN_JS, 'utf8');
     assert.match(
         src,
-        /const\s+noteStreamCoversArpShape\s*=\s*\(\s*\)\s*=>/,
+        /const\s+noteStreamCoversArpShape\s*=\s*(?:\(\s*\)\s*=>|function(?:\s+\w+)?\s*\(\s*\))/,
         'noteStreamCoversArpShape must be an arrow/function so the scan is lazy',
     );
     assert.doesNotMatch(

--- a/tests/js/highway_3d_arp_deferral.test.js
+++ b/tests/js/highway_3d_arp_deferral.test.js
@@ -1,0 +1,51 @@
+// Pins the arpeggio chord-gem deferral gating in plugins/highway_3d/screen.js
+// (slopsmith#262). Without these guards, an over-eager `deferChordGems` makes
+// arpeggio frames empty when standalone notes don't actually cover the shape,
+// and an under-eager one duplicates gems on top of the standalone passage.
+//
+// Source-level only — same strategy as the other tests/js/ files.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+test('chordShapeCoveredByStandaloneNotes helper exists with the expected signature', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /function\s+chordShapeCoveredByStandaloneNotes\s*\(\s*ch\s*,\s*shape\s*,\s*notesArr\s*,\s*timeWin\s*\)/,
+        'helper that scans the note stream for shape coverage must remain on screen.js',
+    );
+});
+
+test('deferChordGems gates both synth and explicit+covered branches on note-stream coverage', () => {
+    // Either branch firing without coverage produces the empty-lavender-frame
+    // regression PR #262 fixed. Pin both predicates so a refactor that drops
+    // one gate fails the test.
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /const\s+deferChordGems\s*=\s*\(\s*ch\.h3dSynth\s*&&\s*noteStreamCoversArpShape\(\)\s*\)\s*\|\|\s*inferredArpPattern\s*\|\|\s*\(\s*hsHintFrame\.explicit\s*&&\s*hsHintFrame\.covered\s*&&\s*noteStreamCoversArpShape\(\)\s*\)/,
+        'deferChordGems must guard the h3dSynth and explicit+covered branches with the coverage check',
+    );
+});
+
+test('noteStreamCoversArpShape is computed lazily (called, not eagerly bound)', () => {
+    // Eager allocation regressed perf on dense charts (Copilot review on PR
+    // #262). The shape must be a callable so short-circuit evaluation skips
+    // the note-stream scan when neither gating branch needs it.
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /const\s+noteStreamCoversArpShape\s*=\s*\(\s*\)\s*=>/,
+        'noteStreamCoversArpShape must be an arrow/function so the scan is lazy',
+    );
+    assert.doesNotMatch(
+        src,
+        /const\s+noteStreamCoversArpShape\s*=\s*chordShapeCoveredByStandaloneNotes\(/,
+        'noteStreamCoversArpShape must not eagerly invoke the coverage helper',
+    );
+});


### PR DESCRIPTION
## Summary
- Fix 3D highway arpeggio rendering so notes inside arpeggio frame boxes remain visible while approaching the hit line and at the hit moment.
- Only suppress chord gems when standalone note rows actually cover the full arpeggio shape, preventing empty arpeggio boxes on template-marked chord events.
- Preserve the original per-string note colors while keeping the arpeggio frame box styling intact.

## Test plan
- Load a chart with arpeggio frame boxes in the 3D highway.
- Confirm the notes inside the arpeggio frame box are visible both before and at the hit line.
- Confirm the notes keep their original string colors instead of using the arpeggio frame color.
- Confirm charts with standalone arpeggio note rows still avoid duplicate gem rendering.

## Exemple:
- Before:
<img width="476" height="488" alt="image" src="https://github.com/user-attachments/assets/f41a034d-a11c-4d4c-968c-7bee2869e6a0" />

- After:
<img width="419" height="554" alt="image" src="https://github.com/user-attachments/assets/54a9cfb9-f5f9-49ac-87d4-022c1d1acfd4" />
