### PR TITLE
Add random sort option

### DIFF
--- a/server.py
+++ b/server.py
@@ -512,6 +512,7 @@ class MetadataDB:
             # '2005' rather than alphabetic.
             "year": "(year = '') ASC, CAST(year AS INTEGER) ASC",
             "year-desc": "(year = '') ASC, CAST(year AS INTEGER) DESC",
+            "random": "RANDOM() ASC",
         }
         order = sort_map.get(sort, "artist COLLATE NOCASE")
         # Legacy `dir=desc` toggle: only safe to append on simple sort

--- a/static/index.html
+++ b/static/index.html
@@ -102,6 +102,7 @@
                         <option value="year-desc">Year (newest)</option>
                         <option value="year">Year (oldest)</option>
                         <option value="tuning">Tuning</option>
+                        <option value="random">Random</option>
                     </select>
                     <!-- Format filter (shared) -->
                     <select id="lib-format" onchange="sortLibrary()"


### PR DESCRIPTION
# Summary

Adds random as a sort option in the library, using SQLite's RANDOM() function.

# Changes

- Add `"random": "RANDOM() ASC"` to sort_map in query_page
- Add option to sort dropdown in `index.html`

# Verification

Tested via the library sort dropdown locally - songs shuffled as expected