### PR TITLE
fix(ffmpeg): prefer bundled binary + libvorbis fallback for sloppak conversion

### DIFF
--- a/lib/audio.py
+++ b/lib/audio.py
@@ -60,16 +60,18 @@ def convert_wem(wem_path: str, output_base: str) -> str:
     Returns path to the converted audio file.
     """
     # Try vgmstream-cli → WAV → MP3 (best browser compatibility)
-    if shutil.which("vgmstream-cli"):
+    vgmstream = _vgmstream_cmd()
+    if vgmstream:
         wav = output_base + ".wav"
         r = subprocess.run(
-            ["vgmstream-cli", "-o", wav, wem_path], capture_output=True
+            [vgmstream, "-o", wav, wem_path], capture_output=True
         )
         if r.returncode == 0 and os.path.exists(wav) and os.path.getsize(wav) > 0:
-            if shutil.which("ffmpeg"):
+            ffmpeg = _ffmpeg_cmd()
+            if ffmpeg:
                 mp3 = output_base + ".mp3"
                 r2 = subprocess.run(
-                    ["ffmpeg", "-y", "-i", wav, "-b:a", "192k", mp3],
+                    [ffmpeg, "-y", "-i", wav, "-b:a", "192k", mp3],
                     capture_output=True,
                 )
                 if r2.returncode == 0 and os.path.exists(mp3):
@@ -78,10 +80,11 @@ def convert_wem(wem_path: str, output_base: str) -> str:
             return wav
 
     # Try ffmpeg directly (some builds handle Wwise)
-    if shutil.which("ffmpeg"):
+    ffmpeg = _ffmpeg_cmd()
+    if ffmpeg:
         mp3 = output_base + ".mp3"
         r = subprocess.run(
-            ["ffmpeg", "-y", "-i", wem_path, "-b:a", "192k", mp3],
+            [ffmpeg, "-y", "-i", wem_path, "-b:a", "192k", mp3],
             capture_output=True,
         )
         if r.returncode == 0 and os.path.exists(mp3) and os.path.getsize(mp3) > 0:
@@ -90,7 +93,7 @@ def convert_wem(wem_path: str, output_base: str) -> str:
         # Try WAV output as fallback
         wav = output_base + ".wav"
         r = subprocess.run(
-            ["ffmpeg", "-y", "-i", wem_path, wav],
+            [ffmpeg, "-y", "-i", wem_path, wav],
             capture_output=True,
         )
         if r.returncode == 0 and os.path.exists(wav) and os.path.getsize(wav) > 0:

--- a/lib/audio.py
+++ b/lib/audio.py
@@ -6,14 +6,45 @@ import subprocess
 from pathlib import Path
 
 
+def _bundled_bin_dir() -> Path | None:
+    """Resolve the desktop bundle's resources/bin/ directory if we're
+    running inside one. Layout: resources/slopsmith/lib/audio.py →
+    resources/bin/. Gate on vgmstream-cli's presence so we don't
+    misidentify random parent dirs (e.g. Docker's `/bin`, dev
+    layouts where parents[2] resolves to the repo root) — vgmstream-cli
+    is bundled on every desktop platform and isn't a typical system
+    binary, so it's a precise signature for the desktop layout."""
+    bundled = Path(__file__).resolve().parents[2] / "bin"
+    if any((bundled / n).is_file() for n in ("vgmstream-cli", "vgmstream-cli.exe")):
+        return bundled
+    return None
+
+
+def _bundled_or_path(name: str) -> str | None:
+    """Prefer the bundled binary on desktop, fall back to PATH lookup.
+
+    Necessary because Electron's child PATH on macOS / Linux puts
+    user-installed binaries (Homebrew `/opt/homebrew/bin`, /usr/local)
+    before our `resources/bin`, so `shutil.which` alone picks up the
+    user's binary — which may have been built without the features
+    we rely on (e.g. Homebrew ffmpeg formulas that omit libvorbis)."""
+    bundled = _bundled_bin_dir()
+    if bundled is not None:
+        for fname in (name, f"{name}.exe"):
+            cand = bundled / fname
+            if cand.is_file():
+                return str(cand)
+    return shutil.which(name)
+
+
 def _vgmstream_cmd() -> str | None:
-    """Return the path to vgmstream-cli if available."""
-    return shutil.which("vgmstream-cli")
+    """Return the path to vgmstream-cli, preferring the bundled binary."""
+    return _bundled_or_path("vgmstream-cli")
 
 
 def _ffmpeg_cmd() -> str | None:
-    """Return the path to ffmpeg if available."""
-    return shutil.which("ffmpeg")
+    """Return the path to ffmpeg, preferring the bundled binary."""
+    return _bundled_or_path("ffmpeg")
 
 
 def find_wem_files(extracted_dir: str) -> list[str]:

--- a/lib/audio.py
+++ b/lib/audio.py
@@ -47,6 +47,27 @@ def _ffmpeg_cmd() -> str | None:
     return _bundled_or_path("ffmpeg")
 
 
+def _ffmpeg_wav_to_ogg(ffmpeg: str, wav: Path, out_ogg: Path) -> subprocess.CompletedProcess:
+    """Encode WAV → Ogg Vorbis. Prefers libvorbis (external, full quality);
+    if the ffmpeg build lacks it (some Homebrew formulas no longer set
+    --enable-libvorbis), retries with ffmpeg's built-in `vorbis` encoder
+    under `-strict experimental`. Same .ogg container either way; the
+    built-in path produces a lower-quality file but always works."""
+    r = subprocess.run(
+        [ffmpeg, "-y", "-i", str(wav), "-c:a", "libvorbis", "-q:a", "5", str(out_ogg)],
+        capture_output=True,
+    )
+    if r.returncode == 0 and out_ogg.exists() and out_ogg.stat().st_size >= 100:
+        return r
+    if b"Unknown encoder 'libvorbis'" not in (r.stderr or b""):
+        return r
+    return subprocess.run(
+        [ffmpeg, "-y", "-i", str(wav),
+         "-c:a", "vorbis", "-strict", "experimental", "-q:a", "5", str(out_ogg)],
+        capture_output=True,
+    )
+
+
 def find_wem_files(extracted_dir: str) -> list[str]:
     """Find WEM audio files, sorted largest first (full song before preview)."""
     wem_files = list(Path(extracted_dir).rglob("*.wem"))

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -31,7 +31,7 @@ import yaml
 
 from patcher import unpack_psarc
 from song import load_song, arrangement_to_wire
-from audio import find_wem_files, _vgmstream_cmd, _ffmpeg_cmd
+from audio import find_wem_files, _vgmstream_cmd, _ffmpeg_cmd, _ffmpeg_wav_to_ogg
 
 
 ProgressCB = Optional[Callable[[float, str, str], None]]
@@ -62,27 +62,6 @@ def _arrangement_id(name: str, used: set[str]) -> str:
         i += 1
     used.add(candidate)
     return candidate
-
-
-def _ffmpeg_wav_to_ogg(ffmpeg: str, wav: Path, out_ogg: Path) -> subprocess.CompletedProcess:
-    """Encode WAV → Ogg Vorbis. Prefers libvorbis (external, full quality);
-    if the ffmpeg build lacks it (some Homebrew formulas no longer set
-    --enable-libvorbis), retries with ffmpeg's built-in `vorbis` encoder
-    under `-strict experimental`. Same .ogg container either way; the
-    built-in path produces a lower-quality file but always works."""
-    r = subprocess.run(
-        [ffmpeg, "-y", "-i", str(wav), "-c:a", "libvorbis", "-q:a", "5", str(out_ogg)],
-        capture_output=True,
-    )
-    if r.returncode == 0 and out_ogg.exists() and out_ogg.stat().st_size >= 100:
-        return r
-    if b"Unknown encoder 'libvorbis'" not in (r.stderr or b""):
-        return r
-    return subprocess.run(
-        [ffmpeg, "-y", "-i", str(wav),
-         "-c:a", "vorbis", "-strict", "experimental", "-q:a", "5", str(out_ogg)],
-        capture_output=True,
-    )
 
 
 def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -64,6 +64,27 @@ def _arrangement_id(name: str, used: set[str]) -> str:
     return candidate
 
 
+def _ffmpeg_wav_to_ogg(ffmpeg: str, wav: Path, out_ogg: Path) -> subprocess.CompletedProcess:
+    """Encode WAV → Ogg Vorbis. Prefers libvorbis (external, full quality);
+    if the ffmpeg build lacks it (some Homebrew formulas no longer set
+    --enable-libvorbis), retries with ffmpeg's built-in `vorbis` encoder
+    under `-strict experimental`. Same .ogg container either way; the
+    built-in path produces a lower-quality file but always works."""
+    r = subprocess.run(
+        [ffmpeg, "-y", "-i", str(wav), "-c:a", "libvorbis", "-q:a", "5", str(out_ogg)],
+        capture_output=True,
+    )
+    if r.returncode == 0 and out_ogg.exists() and out_ogg.stat().st_size >= 100:
+        return r
+    if b"Unknown encoder 'libvorbis'" not in (r.stderr or b""):
+        return r
+    return subprocess.run(
+        [ffmpeg, "-y", "-i", str(wav),
+         "-c:a", "vorbis", "-strict", "experimental", "-q:a", "5", str(out_ogg)],
+        capture_output=True,
+    )
+
+
 def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
     vgmstream = _vgmstream_cmd()
     ffmpeg = _ffmpeg_cmd()
@@ -80,10 +101,7 @@ def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
                 f"vgmstream-cli failed: {r.stderr.decode(errors='replace')}"
             )
         out_ogg.parent.mkdir(parents=True, exist_ok=True)
-        r2 = subprocess.run(
-            [ffmpeg, "-y", "-i", str(wav), "-c:a", "libvorbis", "-q:a", "5", str(out_ogg)],
-            capture_output=True,
-        )
+        r2 = _ffmpeg_wav_to_ogg(ffmpeg, wav, out_ogg)
         if r2.returncode != 0 or not out_ogg.exists() or out_ogg.stat().st_size < 100:
             raise RuntimeError(
                 f"ffmpeg OGG encode failed: {r2.stderr.decode(errors='replace')}"
@@ -455,11 +473,7 @@ def _run_demucs(full_ogg: Path, out_dir: Path, model: str) -> Path:
 def _encode_ogg(wav_path: Path, ogg_path: Path) -> None:
     ffmpeg = _ffmpeg_cmd() or "ffmpeg"
     ogg_path.parent.mkdir(parents=True, exist_ok=True)
-    r = subprocess.run(
-        [ffmpeg, "-y", "-i", str(wav_path),
-         "-c:a", "libvorbis", "-q:a", "5", str(ogg_path)],
-        capture_output=True,
-    )
+    r = _ffmpeg_wav_to_ogg(ffmpeg, wav_path, ogg_path)
     if r.returncode != 0 or not ogg_path.exists():
         raise RuntimeError(
             f"ffmpeg OGG encode failed for {wav_path.name}: "

--- a/scripts/psarc_to_sloppak.py
+++ b/scripts/psarc_to_sloppak.py
@@ -41,6 +41,7 @@ import yaml  # noqa: E402
 from patcher import unpack_psarc  # noqa: E402
 from song import load_song, arrangement_to_wire  # noqa: E402
 from audio import find_wem_files, _vgmstream_cmd, _ffmpeg_cmd  # noqa: E402
+from sloppak_convert import _ffmpeg_wav_to_ogg  # noqa: E402
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -84,10 +85,9 @@ def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
             )
 
         out_ogg.parent.mkdir(parents=True, exist_ok=True)
-        r2 = subprocess.run(
-            [ffmpeg, "-y", "-i", str(wav), "-c:a", "libvorbis", "-q:a", "5", str(out_ogg)],
-            capture_output=True,
-        )
+        # Shared helper handles the libvorbis → built-in vorbis fallback
+        # when the host ffmpeg was built without --enable-libvorbis.
+        r2 = _ffmpeg_wav_to_ogg(ffmpeg, wav, out_ogg)
         if r2.returncode != 0 or not out_ogg.exists() or out_ogg.stat().st_size < 100:
             raise RuntimeError(
                 f"ffmpeg OGG encode failed: {r2.stderr.decode(errors='replace')}"

--- a/scripts/psarc_to_sloppak.py
+++ b/scripts/psarc_to_sloppak.py
@@ -40,8 +40,7 @@ import yaml  # noqa: E402
 
 from patcher import unpack_psarc  # noqa: E402
 from song import load_song, arrangement_to_wire  # noqa: E402
-from audio import find_wem_files, _vgmstream_cmd, _ffmpeg_cmd  # noqa: E402
-from sloppak_convert import _ffmpeg_wav_to_ogg  # noqa: E402
+from audio import find_wem_files, _vgmstream_cmd, _ffmpeg_cmd, _ffmpeg_wav_to_ogg  # noqa: E402
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────

--- a/scripts/split_stems.py
+++ b/scripts/split_stems.py
@@ -33,14 +33,13 @@ from pathlib import Path
 
 import yaml
 
-# Make `lib/` importable regardless of CWD so we can share the ffmpeg
-# encode helper with lib/sloppak_convert.py (libvorbis fallback lives there).
+# Make `lib/` importable regardless of CWD so we can share ffmpeg
+# helpers (including the libvorbis → built-in vorbis fallback).
 _HERE = Path(__file__).resolve().parent
 _ROOT = _HERE.parent
 sys.path.insert(0, str(_ROOT / "lib"))
 
-from audio import _ffmpeg_cmd  # noqa: E402
-from sloppak_convert import _ffmpeg_wav_to_ogg  # noqa: E402
+from audio import _ffmpeg_cmd, _ffmpeg_wav_to_ogg  # noqa: E402
 
 
 # Demucs outputs WAVs named {stem}.wav in a per-track subfolder. We re-encode

--- a/scripts/split_stems.py
+++ b/scripts/split_stems.py
@@ -33,6 +33,15 @@ from pathlib import Path
 
 import yaml
 
+# Make `lib/` importable regardless of CWD so we can share the ffmpeg
+# encode helper with lib/sloppak_convert.py (libvorbis fallback lives there).
+_HERE = Path(__file__).resolve().parent
+_ROOT = _HERE.parent
+sys.path.insert(0, str(_ROOT / "lib"))
+
+from audio import _ffmpeg_cmd  # noqa: E402
+from sloppak_convert import _ffmpeg_wav_to_ogg  # noqa: E402
+
 
 # Demucs outputs WAVs named {stem}.wav in a per-track subfolder. We re-encode
 # them to OGG/Vorbis with ffmpeg to match the rest of the sloppak format.
@@ -67,12 +76,11 @@ def _run_demucs(full_ogg: Path, out_dir: Path, model: str) -> Path:
 
 
 def _encode_ogg(wav_path: Path, ogg_path: Path) -> None:
+    ffmpeg = _ffmpeg_cmd() or "ffmpeg"
     ogg_path.parent.mkdir(parents=True, exist_ok=True)
-    r = subprocess.run(
-        ["ffmpeg", "-y", "-i", str(wav_path),
-         "-c:a", "libvorbis", "-q:a", "5", str(ogg_path)],
-        capture_output=True,
-    )
+    # Shared helper handles the libvorbis → built-in vorbis fallback
+    # when the host ffmpeg was built without --enable-libvorbis.
+    r = _ffmpeg_wav_to_ogg(ffmpeg, wav_path, ogg_path)
     if r.returncode != 0 or not ogg_path.exists():
         raise RuntimeError(
             f"ffmpeg OGG encode failed for {wav_path.name}: "

--- a/tests/test_audio_bundled.py
+++ b/tests/test_audio_bundled.py
@@ -1,0 +1,129 @@
+"""Tests for the desktop-bundle binary resolution in lib/audio.py.
+
+Desktop builds ship `resources/bin/ffmpeg` (and vgmstream-cli, ffprobe).
+Electron's child PATH on macOS / Linux puts user-installed binaries
+(Homebrew `/opt/homebrew/bin`, `/usr/local`) before our `resources/bin`,
+so a plain `shutil.which` would pick up the user's binary — which may
+have been built without the features we rely on (e.g. Homebrew ffmpeg
+formulas that omit libvorbis). `_bundled_bin_dir()` + `_bundled_or_path()`
+detect the desktop layout via the vgmstream-cli marker and prefer the
+bundled binary; outside the bundle, `shutil.which` is used unchanged.
+"""
+
+import shutil
+
+import audio
+
+
+def _set_audio_file(monkeypatch, fake_lib_dir):
+    """Point lib/audio.py's __file__ at a fake location so parents[2] resolves
+    to the test's fake resources root."""
+    monkeypatch.setattr(audio, "__file__", str(fake_lib_dir / "audio.py"))
+
+
+def test_bundled_bin_dir_returns_path_when_vgmstream_marker_present(tmp_path, monkeypatch):
+    """Desktop-bundle layout: resources/slopsmith/lib/audio.py with a
+    vgmstream-cli marker file in resources/bin/."""
+    fake_resources = tmp_path / "resources"
+    fake_lib = fake_resources / "slopsmith" / "lib"
+    fake_lib.mkdir(parents=True)
+    fake_bin = fake_resources / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "vgmstream-cli").write_text("")  # marker
+
+    _set_audio_file(monkeypatch, fake_lib)
+
+    assert audio._bundled_bin_dir() == fake_bin
+
+
+def test_bundled_bin_dir_returns_none_without_marker(tmp_path, monkeypatch):
+    """When parents[2]/bin/ exists but lacks the vgmstream-cli marker
+    (e.g. Docker's /bin, dev layouts where parents[2] is the repo root),
+    we must NOT treat it as a desktop bundle — otherwise we'd shell out
+    to whatever ffmpeg/etc. lives there."""
+    fake_resources = tmp_path / "resources"
+    fake_lib = fake_resources / "slopsmith" / "lib"
+    fake_lib.mkdir(parents=True)
+    fake_bin = fake_resources / "bin"
+    fake_bin.mkdir()
+    # No vgmstream-cli marker. Drop an ffmpeg there to make sure absence
+    # of the marker still wins over presence of the target binary.
+    (fake_bin / "ffmpeg").write_text("")
+
+    _set_audio_file(monkeypatch, fake_lib)
+
+    assert audio._bundled_bin_dir() is None
+
+
+def test_bundled_bin_dir_returns_none_when_bin_dir_missing(tmp_path, monkeypatch):
+    fake_resources = tmp_path / "resources"
+    fake_lib = fake_resources / "slopsmith" / "lib"
+    fake_lib.mkdir(parents=True)
+    # no bin/ dir at all
+
+    _set_audio_file(monkeypatch, fake_lib)
+
+    assert audio._bundled_bin_dir() is None
+
+
+def test_bundled_or_path_prefers_bundled_when_marker_present(tmp_path, monkeypatch):
+    """When the desktop layout is detected, the bundled binary wins over
+    whatever shutil.which would find on PATH."""
+    fake_resources = tmp_path / "resources"
+    fake_lib = fake_resources / "slopsmith" / "lib"
+    fake_lib.mkdir(parents=True)
+    fake_bin = fake_resources / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "vgmstream-cli").write_text("")
+    (fake_bin / "ffmpeg").write_text("")
+
+    _set_audio_file(monkeypatch, fake_lib)
+
+    # Pretend shutil.which would have returned a Homebrew ffmpeg — bundled
+    # must still win.
+    monkeypatch.setattr(shutil, "which", lambda name: "/opt/homebrew/bin/ffmpeg")
+
+    assert audio._bundled_or_path("ffmpeg") == str(fake_bin / "ffmpeg")
+
+
+def test_bundled_or_path_falls_back_to_which_outside_bundle(tmp_path, monkeypatch):
+    """No marker → no bundle → shutil.which result is returned verbatim."""
+    fake_resources = tmp_path / "resources"
+    fake_lib = fake_resources / "slopsmith" / "lib"
+    fake_lib.mkdir(parents=True)
+    # No bin/ dir → no marker → not a bundle.
+
+    _set_audio_file(monkeypatch, fake_lib)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+    assert audio._bundled_or_path("ffmpeg") == "/usr/bin/ffmpeg"
+
+
+def test_bundled_or_path_returns_none_when_neither_available(tmp_path, monkeypatch):
+    fake_resources = tmp_path / "resources"
+    fake_lib = fake_resources / "slopsmith" / "lib"
+    fake_lib.mkdir(parents=True)
+
+    _set_audio_file(monkeypatch, fake_lib)
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+
+    assert audio._bundled_or_path("ffmpeg") is None
+
+
+def test_bundled_or_path_falls_through_to_which_when_bundle_has_marker_but_not_target(tmp_path, monkeypatch):
+    """If the bundle is detected (vgmstream-cli marker present) but the
+    *requested* binary isn't actually in resources/bin/, we should still
+    fall through to PATH rather than returning None — otherwise a partial
+    desktop bundle would silently disable any binary it forgot to ship."""
+    fake_resources = tmp_path / "resources"
+    fake_lib = fake_resources / "slopsmith" / "lib"
+    fake_lib.mkdir(parents=True)
+    fake_bin = fake_resources / "bin"
+    fake_bin.mkdir()
+    (fake_bin / "vgmstream-cli").write_text("")  # marker present
+    # ffmpeg deliberately NOT in fake_bin
+
+    _set_audio_file(monkeypatch, fake_lib)
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+    assert audio._bundled_or_path("ffmpeg") == "/usr/bin/ffmpeg"

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -395,3 +395,102 @@ def test_run_demucs_bootstrap_runs_demucs_main(tmp_path, monkeypatch):
     assert "runpy.run_module" in bootstrap
     assert "demucs" in bootstrap
     assert "run_name='__main__'" in bootstrap or 'run_name="__main__"' in bootstrap
+
+
+# ── _ffmpeg_wav_to_ogg libvorbis → built-in fallback ────────────────────────
+# Tester report: ffmpeg builds without --enable-libvorbis emit
+# "Unknown encoder 'libvorbis'". The helper retries with ffmpeg's built-in
+# `vorbis -strict experimental` so .ogg encoding still works.
+
+def _stub_ffmpeg_run(responses: list, captured_cmds: list):
+    """Stub subprocess.run that returns successive SimpleNamespace responses
+    and records each cmd invocation. responses are dicts forwarded as kwargs
+    to SimpleNamespace (returncode/stdout/stderr)."""
+    def fake_run(cmd, capture_output=False, **kwargs):
+        captured_cmds.append(list(cmd))
+        if not responses:
+            raise AssertionError(f"unexpected subprocess.run call: {cmd}")
+        resp = responses.pop(0)
+        # Side effect: emulate ffmpeg writing the output file on success
+        # so the helper's exists()/stat() check passes.
+        if resp.get("returncode") == 0 and resp.get("write_output"):
+            out_path = cmd[-1]
+            from pathlib import Path as _P
+            p = _P(out_path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_bytes(b"\x00" * 200)  # > 100-byte size guard
+        return SimpleNamespace(
+            returncode=resp.get("returncode", 0),
+            stdout=resp.get("stdout", b""),
+            stderr=resp.get("stderr", b""),
+        )
+    return fake_run
+
+
+def test_ffmpeg_wav_to_ogg_libvorbis_first_succeeds(tmp_path, monkeypatch):
+    """libvorbis succeeds → no retry, only one subprocess call."""
+    wav = tmp_path / "in.wav"
+    wav.write_bytes(b"\x00" * 200)
+    out_ogg = tmp_path / "out.ogg"
+    cmds: list = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        _stub_ffmpeg_run([{"returncode": 0, "write_output": True}], cmds),
+    )
+
+    r = sloppak_convert._ffmpeg_wav_to_ogg("ffmpeg", wav, out_ogg)
+
+    assert r.returncode == 0
+    assert len(cmds) == 1
+    assert "libvorbis" in cmds[0]
+    assert "experimental" not in cmds[0]
+
+
+def test_ffmpeg_wav_to_ogg_falls_back_on_unknown_libvorbis(tmp_path, monkeypatch):
+    """libvorbis missing → retry with built-in vorbis -strict experimental."""
+    wav = tmp_path / "in.wav"
+    wav.write_bytes(b"\x00" * 200)
+    out_ogg = tmp_path / "out.ogg"
+    cmds: list = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        _stub_ffmpeg_run(
+            [
+                {"returncode": 1, "stderr": b"Unknown encoder 'libvorbis'\n"},
+                {"returncode": 0, "write_output": True},
+            ],
+            cmds,
+        ),
+    )
+
+    r = sloppak_convert._ffmpeg_wav_to_ogg("ffmpeg", wav, out_ogg)
+
+    assert r.returncode == 0
+    assert len(cmds) == 2
+    assert "libvorbis" in cmds[0]
+    # Retry uses the built-in encoder under -strict experimental.
+    assert "vorbis" in cmds[1]
+    assert "libvorbis" not in cmds[1]
+    assert "experimental" in cmds[1]
+
+
+def test_ffmpeg_wav_to_ogg_does_not_retry_on_unrelated_error(tmp_path, monkeypatch):
+    """If ffmpeg fails for a reason other than missing libvorbis, return the
+    original failure instead of masking it with a built-in retry."""
+    wav = tmp_path / "in.wav"
+    wav.write_bytes(b"\x00" * 200)
+    out_ogg = tmp_path / "out.ogg"
+    cmds: list = []
+    monkeypatch.setattr(
+        subprocess, "run",
+        _stub_ffmpeg_run(
+            [{"returncode": 1, "stderr": b"No such file or directory\n"}],
+            cmds,
+        ),
+    )
+
+    r = sloppak_convert._ffmpeg_wav_to_ogg("ffmpeg", wav, out_ogg)
+
+    assert r.returncode == 1
+    assert b"No such file or directory" in r.stderr
+    assert len(cmds) == 1  # no retry


### PR DESCRIPTION
## Summary

Fixes a macOS tester report: sloppak conversion failed with `ffmpeg OGG encode failed: ... Unknown encoder 'libvorbis'`. The error log header showed `/opt/homebrew/Cellar/ffmpeg/8.1_1` — the tester's system Homebrew ffmpeg was being invoked instead of our bundled `resources/bin/ffmpeg`, and that build of ffmpeg was missing `--enable-libvorbis`.

Two stacked fixes:

1. **`lib/audio.py`** — `_ffmpeg_cmd()` and `_vgmstream_cmd()` now prefer the bundled binary via the same `parents[2] / "bin"` resolution and `vgmstream-cli` sentinel that the demucs subprocess PATH-prepend already uses (`lib/sloppak_convert.py:358-378`). Outside the desktop bundle (dev, Docker, CI), `_bundled_bin_dir()` returns `None` and `shutil.which` behaviour is unchanged. Root cause: Electron's child PATH on macOS / Linux puts user-installed binaries (Homebrew `/opt/homebrew/bin`, `/usr/local`) before our `resources/bin`, so `shutil.which("ffmpeg")` alone picks up the user's binary.

2. **`lib/sloppak_convert.py`** — new helper `_ffmpeg_wav_to_ogg()` tries `-c:a libvorbis` first and, if ffmpeg returns `Unknown encoder 'libvorbis'`, retries with the built-in `-c:a vorbis -strict experimental` encoder. Same `.ogg` container, lower quality but always available. Used by both `_wem_to_ogg()` (PSARC → sloppak) and `_encode_ogg()` (demucs stems → ogg).

A companion PR on `slopsmith-desktop` will add a build-time `ffmpeg -encoders | grep libvorbis` check so we never ship a libvorbis-less ffmpeg in the first place.

## Test plan
- [x] `pytest tests/ -k "audio or sloppak_convert"` — 52 passed (no regressions on existing audio + sloppak tests)
- [x] Sanity check outside bundle: `_bundled_bin_dir()` returns `None`, `_ffmpeg_cmd()` falls back to `shutil.which` (`/usr/bin/ffmpeg`) — confirms dev / Docker paths unaffected
- [x] Codex pre-flight review clean — no findings
- [ ] On the macOS desktop bundle: verify `_ffmpeg_cmd()` resolves to `resources/bin/ffmpeg`, not `/opt/homebrew/bin/ffmpeg`
- [ ] Confirm the original tester's PSARC → sloppak conversion completes (either via bundled libvorbis or the built-in fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)