### PR TITLE
feat(highway_3d): frethand-mute chord strum indicator, sustain bloom, technique marker overhaul (v3.17.0)

### DIFF
--- a/plugins/highway_3d/plugin.json
+++ b/plugins/highway_3d/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "highway_3d",
     "name": "3D Highway",
-    "version": "3.16.0",
+    "version": "3.17.0",
     "type": "visualization",
     "bundled": true,
     "script": "screen.js",

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -563,7 +563,15 @@
     const fretX = f => _h3dFretUniform ? _fretXUni(f) : _fretXLog(f);
 
     window.h3dSetFretSpacing = mode => {
-        try { localStorage.setItem('highway_3d.fretSpacing', mode); } catch (_) {}
+        // Validate against the two supported modes before persisting so an
+        // unexpected input can't leave an invalid value in localStorage
+        // (mirrors h3dBgSetFretNumberGhostScope's allowlist guard). No-op
+        // when the stored mode is already what was requested.
+        const m = mode === 'logarithmic' ? 'logarithmic' : 'uniform';
+        try {
+            if (localStorage.getItem('highway_3d.fretSpacing') === m) return;
+            localStorage.setItem('highway_3d.fretSpacing', m);
+        } catch (_) {}
         location.reload();
     };
 
@@ -5742,10 +5750,15 @@
             }
 
             // ── Slide-target gem-suppression pre-pass (chart-static) ──────
-            // Detects notes in bundle.notes that are the "linkNext" destination
+            // Detects notes in bundle.notes that are the slide/link destination
             // of a preceding note. The gem (outline+core) is suppressed via
             // skipBody=true, but the sustain/slide trail still renders because
             // the trail block is now outside the !skipBody gate in drawNote().
+            //
+            // NOTE: an authored `linkNext` flag is NOT present in bundle.notes —
+            // note_to_wire() in lib/song.py emits only t, s, f, sus, sl, slu,
+            // bn, ho, po, hm, hp, pm, mt, vb, tr, ac, tp. So this is an
+            // intentional timing/fret heuristic, not a link-flag lookup.
             //
             // Two source patterns (source has sus > 0):
             //   Case 1 — source has sl/slu: destination.f === source's slide target
@@ -5759,12 +5772,15 @@
                     const checkSrc = (srcT, srcS, srcF, srcSus, srcSl) => {
                         if (!(srcSus > 0)) return;
                         const endT = srcT + srcSus;
+                        // Reuse the renderer's shared next-on-string tolerance
+                        // rather than a separate hardcoded literal.
+                        const EPS = NEXT_ON_STRING_T_EPS;
                         let lo = 0, hi = notes.length;
-                        while (lo < hi) { const m = (lo + hi) >> 1; if (notes[m].t < endT - 0.06) lo = m + 1; else hi = m; }
+                        while (lo < hi) { const m = (lo + hi) >> 1; if (notes[m].t < endT - EPS) lo = m + 1; else hi = m; }
                         for (let j = lo; j < notes.length; j++) {
                             const q = notes[j];
-                            if (q.t > endT + 0.06) break;
-                            if (q.s !== srcS || Math.abs(q.t - endT) >= 0.06) continue;
+                            if (q.t > endT + EPS) break;
+                            if (q.s !== srcS || Math.abs(q.t - endT) >= EPS) continue;
                             const qSl = (Number.isFinite(q.sl) && q.sl >= 0) ? q.sl
                                       : (Number.isFinite(q.slu) && q.slu >= 0) ? q.slu : -1;
                             if (srcSl >= 0 && q.f === srcSl) { stSet.add(`${q.t}_${q.s}`); break; } // case 1

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -7675,9 +7675,32 @@
             const PROJ_WIN_G = 0.6;
             const projFactorG = Math.max(0, Math.min(1, 1 - Math.max(dt, 0) / PROJ_WIN_G));
             const inGhostWin = n.f > 0 && isNextOnString && dt > -ghostHold && dt < PROJ_WIN_G && projFactorG > 0.001;
-            let _ndGood = false;   // set to true inside !skipBody if note_detect confirms hit/active
-            let _ndState = null;   // set inside !skipBody; null → fall back to hit heuristic
-            let _showHit = hit;    // default; overridden inside !skipBody when provider has verdict
+            // slopsmith#254 — query the provider once per note, before both !skipBody
+            // blocks, so _showHit can be a const and _ndGood is available for the
+            // sustain trail (which renders even when skipBody=true for slide targets).
+            let _ndGood = false;    // true when provider confirms hit/active
+            let _ndState = null;    // 'hit'|'active'|'miss'|null; null → fall back to proximity heuristic
+            let _ndCs = null;       // raw provider response kept for alpha/color in _ndSizzle
+            let _ndCsIsObj = false; // typeof _ndCs === 'object'
+            if (_ndGetNoteState) {
+                let _raw = null;
+                try { _raw = _ndGetNoteState(n, n.t); } catch (e) { _raw = null; }
+                if (_raw) {
+                    _ndCsIsObj = typeof _raw === 'object';
+                    const _st = _ndCsIsObj ? _raw.state : _raw;
+                    if (_st === 'miss') {
+                        _ndState = 'miss';
+                        _ndCs = _raw;
+                    } else if (_st === 'hit' || _st === 'active') {
+                        _ndState = _st;
+                        _ndGood = true;
+                        _ndCs = _raw;
+                    }
+                }
+            }
+            // Provider verdict wins when present; otherwise fall back to the
+            // proximity heuristic, including the pre-hit ghost window preview.
+            const _showHit = (_ndState === 'miss') ? false : (_ndState ? _ndGood : (hit || (n.f > 0 && inGhostWin)));
 
             if (!skipBody) {
 
@@ -7727,59 +7750,29 @@
                 const rimXY = n.ac ? ACCENT_RIM_XY_SCALE_MUL : 1;
                 const rimZ = n.ac ? ACCENT_RIM_Z_SCALE_MUL : 1;
 
-                // slopsmith#254 — core's per-note judgment provider is
-                // authoritative over the event-driven marks above (and over
-                // the proximity-based `hit` heuristic). 'active' (a sustained
-                // note currently being held on-pitch) reads the same as
-                // 'hit': bright string-tinted outline (mGlow[s]) + bright
-                // body + bright sustain trail + the contained sparkle/sizzle
-                // overlay (drawNotedetectSizzle). 'miss' → red outline AND
-                // suppress the bright body even if the note is near the line.
-                // Called with the note's chart time, not `now`: note_detect
-                // keys its noteResults map by chart time, so `n.t` is the key
-                // (it reads the live time internally for the fade window).
-                // _ndState declared above; reset for this note
-                _ndState = null;
-                if (_ndGetNoteState) {
-                    let _cs = null;
-                    try { _cs = _ndGetNoteState(n, n.t); } catch (e) { _cs = null; }
-                    if (_cs) {
-                        const _isObj = typeof _cs === 'object';
-                        const _st = _isObj ? _cs.state : _cs;
-                        if (_st === 'miss') {
-                            _ndState = 'miss';
-                            _ndOutline = mMissOutline;
-                        } else if (_st === 'hit' || _st === 'active') {
-                            _ndState = _st;
-                            _ndGood = true;
-                            _ndOutline = mGlow[s];
-                            // Carry the provider's alpha (and optional color)
-                            // through to the sizzle so a struck-note fade or
-                            // a custom palette comes through (#254 review).
-                            // _noteState already clamps alpha to [0,1] and only
-                            // returns the object when alpha > 0.
-                            //
-                            // Skip sizzle on chord constituents: chord plays
-                            // already get rich feedback from the chord-rim
-                            // color (green for a clean grab, red otherwise)
-                            // plus the bright string-tinted gem. The 2D sparkle particles are
-                            // per-note and chord-heavy songs would spawn 4-6×
-                            // sparkles per chord every frame, which became a
-                            // measurable framerate hit once Rocksmith-style
-                            // lenient chord scoring flagged every chord
-                            // constituent as a hit. Standalone single notes
-                            // still sparkle.
-                            if (!fromChord && _ndSizzle.length < 40) {
-                                const _a = (_isObj && Number.isFinite(_cs.alpha)) ? Math.max(0, Math.min(1, _cs.alpha)) : 1;
-                                const _col = (_isObj && typeof _cs.color === 'string') ? _cs.color : null;
-                                _ndSizzle.push({ x, y: y + techniqueYNow, z: noteZ, s, alpha: _a, color: _col });
-                            }
+                // slopsmith#254 — apply visual overrides from the provider verdict
+                // (_ndState/_ndGood/_ndCs computed in the hoisted block above).
+                // 'miss' → red outline; 'hit'/'active' → string-tinted outline + sizzle.
+                // The authoritative _showHit (body brightness, sustain glow) is
+                // already a const from the hoisted block — no reassignment needed here.
+                if (_ndCs) {
+                    if (_ndState === 'miss') {
+                        _ndOutline = mMissOutline;
+                    } else if (_ndGood) {
+                        _ndOutline = mGlow[s];
+                        // Carry the provider's alpha (and optional color) through
+                        // to the sizzle so a struck-note fade or custom palette
+                        // comes through (#254 review).
+                        // Skip sizzle on chord constituents — per-note sparkles
+                        // on every chord note at lenient scoring rates became a
+                        // measurable framerate hit; standalone notes still sparkle.
+                        if (!fromChord && _ndSizzle.length < 40) {
+                            const _a = (_ndCsIsObj && Number.isFinite(_ndCs.alpha)) ? Math.max(0, Math.min(1, _ndCs.alpha)) : 1;
+                            const _col = (_ndCsIsObj && typeof _ndCs.color === 'string') ? _ndCs.color : null;
+                            _ndSizzle.push({ x, y: y + techniqueYNow, z: noteZ, s, alpha: _a, color: _col });
                         }
                     }
                 }
-                // Provider verdict wins when present; otherwise fall back to
-                // the proximity heuristic, including the pre-hit ghost window.
-                _showHit = (_ndState === 'miss') ? false : (_ndState ? _ndGood : (hit || (n.f > 0 && inGhostWin)));
 
                 // Accent: soft neon outer glow (reference: diffused halo fading out).
                 // Three additive shells drawn behind outline/core; colour = string hue.

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -2680,6 +2680,16 @@
                 });
                 sm.userData.h3dTechMeshMat = base;
             }
+            // First conversion for this mesh: the pTechPlane pool factory gave
+            // it a placeholder MeshBasicMaterial that the caller is about to
+            // overwrite with the clone below. Dispose it now — once
+            // mesh.material is reassigned the placeholder is orphaned and
+            // teardown's scene.traverse() pass can no longer reach it, so it
+            // would leak one GPU material per pooled mesh for the renderer's
+            // lifetime.
+            if (!cached && mesh.material && mesh.material !== base) {
+                mesh.material.dispose?.();
+            }
             const clone = base.clone();
             mesh.userData.h3dTechMeshMatClone = clone;
             _techMeshMatClones.add(clone);

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -7924,7 +7924,10 @@
             // Rendered for ALL notes with sustain, including skipBody=true
             // slide-target notes (e.g. linkNext hold→slide: gem suppressed,
             // slide trail stays visible as the continuation of the sustain).
-            // _ndGood is false for skipBody notes → trail uses dim mSus[s].
+            // _ndGetNoteState is queried for every note (skipBody slide
+            // targets included), so the trail picks bright mGlow[s] when the
+            // provider confirms hit/active and dim mSus[s] otherwise — a
+            // slide-target trail is not forced dim.
             // Chord-member open strings (fromChord && f === 0) skip the
             // sustain trail entirely — fretted constituents already carry
             // the chord's sustains; an extra ribbon under the wide open

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -3935,8 +3935,8 @@
                 }),
             ));
 
-            // PM strum X fill — 4 cantos + centro; as 4 asas (esq,dir,topo,base) ficam vazias.
-            // 16 vértices, 14 triângulos.
+            // PM strum X fill — 4 corner regions + centre; the 4 arms (L,R,T,B) are left empty.
+            // 16 vertices, 14 triangles.
             //  0=A(-1,1)  1=TLC(-0.48,1)  2=T(-0.012,0.257)  3=TRC(0.5,1)
             //  4=BR(1,1)  5=REB(1,0.5)   6=R(0.476,-0.011)  7=RET(1,-0.5)
             //  8=C(1,-1)  9=BRC(0.48,-1) 10=B(-0.003,-0.276) 11=BLC(-0.48,-1)
@@ -3963,22 +3963,22 @@
                 ]);
                 // prettier-ignore
                 const idx = new Uint16Array([
-                    // canto topo-esq: A,TLC,T,L,LEB
+                    // top-left corner: A,TLC,T,L,LEB
                      0,  1,  2,
                      0,  2, 14,
                      0, 14, 15,
-                    // canto topo-dir: TRC,BR,REB,R,T
+                    // top-right corner: TRC,BR,REB,R,T
                      3,  4,  5,
                      3,  5,  6,
                      3,  6,  2,
-                    // centro: T,R,B,L
+                    // centre: T,R,B,L
                      2,  6, 10,
                      2, 10, 14,
-                    // canto base-dir: RET,C,BRC,B,R
+                    // bottom-right corner: RET,C,BRC,B,R
                      7,  8,  9,
                      7,  9, 10,
                      7, 10,  6,
-                    // canto base-esq: LET,L,B,BLC,D
+                    // bottom-left corner: LET,L,B,BLC,D
                     13, 14, 10,
                     13, 10, 11,
                     13, 11, 12,
@@ -4000,8 +4000,8 @@
                 }),
             ));
 
-            // FH (frethand mute) strum X fill — 5 regiões: 4 cantos + centro.
-            // 12 vértices, 10 triângulos. Asas esq/dir só vão até fx=±0.50 (sem blocos laterais).
+            // FH (frethand mute) strum X fill — 5 regions: 4 corner quadrants + centre diamond.
+            // 12 vertices, 10 triangles. L/R wings stop at fx=±0.50 (no solid lateral blocks).
             //  0=LET(-0.50,+1)  1=TLC(-0.15,+1)  2=T(0,+0.42)   3=TRC(+0.15,+1)
             //  4=RET(+0.50,+1)  5=REB(+0.50,-1)  6=R(+0.28,0)   7=B(0,-0.42)
             //  8=BRC(+0.15,-1)  9=BLC(-0.15,-1) 10=LEB(-0.50,-1) 11=L(-0.28,0)
@@ -4023,19 +4023,19 @@
                 ]);
                 // prettier-ignore
                 const idx = new Uint16Array([
-                    // canto topo-esq: LET,TLC,T,L
+                    // top-left corner: LET,TLC,T,L
                      0,  1,  2,
                      0,  2, 11,
-                    // canto topo-dir: TRC,RET,R,T
+                    // top-right corner: TRC,RET,R,T
                      3,  4,  6,
                      3,  6,  2,
-                    // canto base-dir: REB,R,B,BRC
+                    // bottom-right corner: REB,R,B,BRC
                      5,  6,  7,
                      5,  7,  8,
-                    // canto base-esq: LEB,L,B,BLC
+                    // bottom-left corner: LEB,L,B,BLC
                     10, 11,  7,
                     10,  7,  9,
-                    // centro: L,T,R,B
+                    // centre diamond: L,T,R,B
                     11,  2,  6,
                     11,  6,  7,
                 ]);
@@ -6753,10 +6753,10 @@
                         if (isRepeat && chordNotes.some(cn => cn.pm)) {
                             // Fill (dark, transparent) — renderOrder 10 = below lines
                             const pmf = pPMXFill.get();
-                            pmf.renderOrder = 10.5; // acima do pChordFrameFill (10), abaixo das linhas X (11)
+                            pmf.renderOrder = 10.5; // above pChordFrameFill (10), below X lines (11)
                             pmf.rotation.set(0, 0, 0);
                             pmf.position.set(cx, cY, z - 0.0045 * K);
-                            pmf.scale.set(innerW * 0.5, -innerH * 0.5, 1); // Y negado: espelha o sistema do XLINES (ay = cY - fya*hH)
+                            pmf.scale.set(innerW * 0.5, -innerH * 0.5, 1); // Y negated: mirrors XLINES convention (ay = cY - fya*hH)
                             pmf.material.opacity = edgeOp;
 
                             const lw  = ft * 0.55;      // line visual thickness
@@ -6790,15 +6790,15 @@
                         }
 
                         // ── Frethand-mute strum indicator — FH X outline + dark fill ───
-                        // 4 nós de convergência (L,R,T,B) + 8 terminais nas bordas sup/inf.
-                        // Asas esq/dir vão até fx=±0.50 (não preenchem as laterais do box).
+                        // 4 convergence nodes (L,R,T,B) + 8 terminals on top/bottom borders.
+                        // L/R wings stop at fx=±0.50 — no solid lateral fill blocks.
                         if (isRepeat && chordNotes.some(cn => cn.mt)) {
-                            // Fill (dark) — renderOrder 10.5 = acima do frame fill, abaixo das linhas
+                            // Fill (dark) — renderOrder 10.5 = above frame fill, below X lines
                             const fhf = pFHXFill.get();
                             fhf.renderOrder = 10.5;
                             fhf.rotation.set(0, 0, 0);
                             fhf.position.set(cx, cY, z - 0.0045 * K);
-                            fhf.scale.set(innerW * 0.5, -innerH * 0.5, 1); // Y negado: fy+ = cima na geometria
+                            fhf.scale.set(innerW * 0.5, -innerH * 0.5, 1); // Y negated: fy+ = up in geometry space
                             fhf.material.opacity = edgeOp;
 
                             const lw = ft * 0.55;

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -554,11 +554,12 @@
     const _fretXUniStep = _fretXLog(NFRETS) / NFRETS;
     const _fretXUni = f => f <= 0 ? 0 : f * _fretXUniStep;
 
-    let _h3dFretUniform = localStorage.getItem('h3dFretSpacing') !== 'logarithmic';
+    let _h3dFretUniform = true;
+    try { _h3dFretUniform = localStorage.getItem('highway_3d.fretSpacing') !== 'logarithmic'; } catch (_) {}
     const fretX = f => _h3dFretUniform ? _fretXUni(f) : _fretXLog(f);
 
     window.h3dSetFretSpacing = mode => {
-        localStorage.setItem('h3dFretSpacing', mode);
+        try { localStorage.setItem('highway_3d.fretSpacing', mode); } catch (_) {}
         location.reload();
     };
 
@@ -2642,18 +2643,26 @@
          * mesh instead of a billboard Sprite. Cached on userData to avoid allocations.
          */
         function _spriteMat2MeshMat(sm) {
-            let mb = sm.userData.h3dTechMeshMat;
-            if (!mb) {
-                mb = new T.MeshBasicMaterial({
+            // Always return a fresh clone so each consumer can mutate
+            // opacity independently without affecting other meshes that
+            // share the same underlying sprite (and therefore the same
+            // cached MeshBasicMaterial). The clone shares the CanvasTexture
+            // map (no extra GPU upload), so the only cost is a small JS
+            // object per call — acceptable for technique markers (~2/frame max).
+            let base = sm.userData.h3dTechMeshMat;
+            if (!base) {
+                base = new T.MeshBasicMaterial({
                     map: sm.map,
                     transparent: true,
                     depthTest: false,
                     depthWrite: false,
                     side: T.DoubleSide,
                 });
-                sm.userData.h3dTechMeshMat = mb;
+                sm.userData.h3dTechMeshMat = base;
             }
-            return mb;
+            const clone = base.clone();
+            _ownedClonedMats.push(clone);
+            return clone;
         }
 
         function _disposeOpenStringPitchSprites() {
@@ -8420,6 +8429,8 @@
                 const tm = txtCache[k];
                 tm.userData.h3dGhostFretMeshMat?.dispose?.();
                 tm.userData.h3dGhostFretMeshMat = null;
+                tm.userData.h3dTechMeshMat?.dispose?.();
+                tm.userData.h3dTechMeshMat = null;
                 tm.map?.dispose();
                 tm.dispose();
             }

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -2410,7 +2410,7 @@
             //   1. black outer border  rx=0.430h ry=0.255h
             //   2. string-color body   rx=0.418h ry=0.232h
             //   3. black inner ring    rx=0.407h ry=0.218h
-            //   4. string-color inner  rx=0.295h ry=0.218h
+            //   4. string-color inner  rx=0.264h ry=0.218h
             //   5. black center dot    rx=0.134h ry=0.120h
             const k = 'technique|pinchHarmonicIcon|rs2014-v5b|' + baseCol.getHexString();
             if (txtCache[k]) return txtCache[k];
@@ -2533,7 +2533,7 @@
             const h = 512;
             const outerW = 132, innerW = 114;
             // pad must satisfy: pad ≥ outerW / Math.SQRT2  (≈ outerW × 0.707)
-            const pad = Math.ceil(outerW / Math.SQRT2) + 2; // 112
+            const pad = Math.ceil(outerW / Math.SQRT2) + 2; // 96
             const c = document.createElement('canvas');
             c.width = h; c.height = h;
             const x = c.getContext('2d');

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -541,13 +541,27 @@
      *  Pure helpers
      * ====================================================================== */
 
-    const fretX = f => {
+    // Logarithmic spacing — mirrors real guitar fret geometry (12th root of 2).
+    const _fretXLog = f => {
         if (f <= 0) return 0;
         const raw = SCALE - SCALE / Math.pow(2, f / 12);
         if (f <= FRET_SPACING_ANCHOR_F) return raw;
         const rawAnchor = SCALE - SCALE / Math.pow(2, FRET_SPACING_ANCHOR_F / 12);
         return rawAnchor + (raw - rawAnchor) * FRET_SPACING_STRETCH_ABOVE12;
     };
+    // Uniform spacing — same column width per fret (Rocksmith Remastered style).
+    // Total board width equals the logarithmic NFRETS position for consistency.
+    const _fretXUniStep = _fretXLog(NFRETS) / NFRETS;
+    const _fretXUni = f => f <= 0 ? 0 : f * _fretXUniStep;
+
+    let _h3dFretUniform = localStorage.getItem('h3dFretSpacing') !== 'logarithmic';
+    const fretX = f => _h3dFretUniform ? _fretXUni(f) : _fretXLog(f);
+
+    window.h3dSetFretSpacing = mode => {
+        localStorage.setItem('h3dFretSpacing', mode);
+        location.reload();
+    };
+
     const fretMid = f => (f <= 0 ? -2 * K : (fretX(f - 1) + fretX(f)) / 2);
     /** World-space width of fret column (wires f−1 .. f); used to scale row markers past ~12. */
     function fretColumnWorldW(f) {
@@ -634,6 +648,27 @@
             if (dt > 0) { sum += dt; count++; }
         }
         return count > 0 && sum > 0 ? 60 / (sum / count) : 120;
+    }
+
+    // Build a horizontal gaussian DataTexture for the sustain-rail bloom effect.
+    // Returns a W×1 RGBA texture where alpha follows exp(-0.5*(u−0.5)²/σ²),
+    // peaking at 1.0 in the centre and falling to ~0 at the edges.
+    // Power-of-two width keeps WebGL mipmapping happy.
+    function _makeGaussTex(ThreeLib, w = 128, sigma = 0.28) {
+        const data = new Uint8Array(w * 4);
+        for (let i = 0; i < w; i++) {
+            const u = i / (w - 1);
+            const d = (u - 0.5) / sigma;
+            const v = Math.exp(-0.5 * d * d);
+            const a = Math.round(v * 255);
+            data[i * 4]     = 255;
+            data[i * 4 + 1] = 255;
+            data[i * 4 + 2] = 255;
+            data[i * 4 + 3] = a;
+        }
+        const tex = new ThreeLib.DataTexture(data, w, 1, ThreeLib.RGBAFormat);
+        tex.needsUpdate = true;
+        return tex;
     }
 
     /* ======================================================================
@@ -1763,6 +1798,8 @@
         let lyricsCanvas = null, lyricsCtx = null;
         let _diagChord            = null;
         let pSusRail = null, gSusRail = null, mSusRailBase = null;
+        let pSusRailBloom = null, gSusRailBloom = null, mSusRailBloomBase = null, _bloomGaussTex = null;
+        let pTechPlane = null, gTechPlane = null;
         let _diagPrev             = null;
         let _diagPrevOpacity      = 0;
         let _diagPrevStartOpacity = 0;
@@ -1800,6 +1837,14 @@
         let _arpGhostInferRefHs = null;
         let _arpGhostInferRefNotes = null;
         let _arpGhostInferRefTpl = null;
+
+        // Slide-target gem suppression. A Set of "t_s" keys for notes in
+        // bundle.notes that are the linkNext destination of a preceding note
+        // (single or chord). The gem is suppressed (skipBody=true) but the
+        // sustain/slide trail still renders so the slide motion stays visible.
+        let _slideTargetSet = null;
+        let _slideTargetNotesRef = null;
+        let _slideTargetChordsRef = null;
 
         let _laneRailFlagsRefHs = null;
         let _laneRailFlagsRefTpl = null;
@@ -1998,8 +2043,11 @@
         const _laneSegTHi = [];
         const _laneSegArp = [];
         let _laneSegLen = 0;
-        let pChordBox, pChordFrameFill, pChordLbl, pBarreLine;
+        let pChordBox, pChordFrameFill, pChordLbl, pBarreLine, pPMXFill, pFHXFill;
+        let gPMXFill = null; // shared geometry for PM X fill — disposed in teardown
+        let gFHXFill = null; // shared geometry for FH X fill — disposed in teardown
         let pNoteFretLabel, pConnectorLine, pDropLine, pTapChevron, pAccentHalo;
+        let pChordAccentHalo = null; // per-instance cloned mats so opacity differs per shell
         let pSusRibbon = null, pSusRibbonOl = null;
         let pFretColMarker;
         /** Horizontal gradient for chord box interior fill. */
@@ -2345,179 +2393,45 @@
 
         function pinchHarmonicMat(col) {
             const baseCol = new T.Color(col != null ? col : '#ffd84d');
-            // Versioned cache key so icon-shape tweaks take effect even in
-            // long-lived panels that already cached an older PH sprite.
-            const k = 'technique|pinchHarmonicIcon|rs2014-v2|' + baseCol.getHexString();
+            // v5 — compact concentric ellipses:
+            //   1. black outer border  rx=0.430h ry=0.255h
+            //   2. string-color body   rx=0.418h ry=0.232h
+            //   3. black inner ring    rx=0.407h ry=0.218h
+            //   4. string-color inner  rx=0.295h ry=0.218h
+            //   5. black center dot    rx=0.134h ry=0.120h
+            const k = 'technique|pinchHarmonicIcon|rs2014-v5b|' + baseCol.getHexString();
             if (txtCache[k]) return txtCache[k];
 
-            const h = 256;
+            const h = 512;
             const c = document.createElement('canvas');
             c.width = h; c.height = h;
             const x = c.getContext('2d');
-            const cx = h / 2;
-            const cy = h / 2;
-            const r = Math.round(baseCol.r * 255);
-            const g = Math.round(baseCol.g * 255);
-            const b = Math.round(baseCol.b * 255);
-            const hiR = Math.min(255, Math.round(r + (255 - r) * 0.28));
-            const hiG = Math.min(255, Math.round(g + (255 - g) * 0.28));
-            const hiB = Math.min(255, Math.round(b + (255 - b) * 0.28));
-            const dkR = Math.max(0, Math.round(r * 0.38));
-            const dkG = Math.max(0, Math.round(g * 0.38));
-            const dkB = Math.max(0, Math.round(b * 0.38));
-            const midR = Math.min(255, Math.round(r * 0.82 + 22));
-            const midG = Math.min(255, Math.round(g * 0.82 + 18));
-            const midB = Math.min(255, Math.round(b * 0.82 + 10));
-            const rgba = (rr, gg, bb, a) => `rgba(${rr},${gg},${bb},${a})`;
             const TAU = Math.PI * 2;
-            const outerRx = h * 0.39;
-            const outerRy = h * 0.23;
-            const ringRx = h * 0.245;
-            const ringRy = h * 0.155;
-            const irisRx = h * 0.145;
-            const irisRy = h * 0.145;
-            const pupilRx = h * 0.062;
-            const pupilRy = h * 0.062;
-            const black = rgba(0, 0, 0, 1);
-            const white = rgba(255, 255, 255, 1);
-            const sideWing = (dir, sx = 1, sy = 1) => {
-                const s = dir < 0 ? -1 : 1;
-                x.beginPath();
-                x.moveTo(s * outerRx * 0.88 * sx, -outerRy * 0.13 * sy);
-                x.bezierCurveTo(
-                    s * outerRx * 1.18 * sx, -outerRy * 0.52 * sy,
-                    s * outerRx * 1.34 * sx, -outerRy * 0.2 * sy,
-                    s * outerRx * 1.28 * sx, 0
-                );
-                x.bezierCurveTo(
-                    s * outerRx * 1.34 * sx, outerRy * 0.2 * sy,
-                    s * outerRx * 1.18 * sx, outerRy * 0.52 * sy,
-                    s * outerRx * 0.88 * sx, outerRy * 0.13 * sy
-                );
-                x.closePath();
-            };
-            const innerSide = (dir) => {
-                const s = dir < 0 ? -1 : 1;
-                x.beginPath();
-                x.moveTo(s * outerRx * 0.71, -outerRy * 0.03);
-                x.bezierCurveTo(
-                    s * outerRx * 0.58, -outerRy * 0.54,
-                    s * outerRx * 0.33, -outerRy * 0.58,
-                    s * outerRx * 0.16, 0
-                );
-                x.bezierCurveTo(
-                    s * outerRx * 0.33, outerRy * 0.58,
-                    s * outerRx * 0.58, outerRy * 0.54,
-                    s * outerRx * 0.71, outerRy * 0.03
-                );
-                x.closePath();
-            };
+            const colStr = `rgb(${Math.round(baseCol.r * 255)},${Math.round(baseCol.g * 255)},${Math.round(baseCol.b * 255)})`;
 
             x.clearRect(0, 0, h, h);
             x.save();
-            x.translate(cx, cy);
+            x.translate(h / 2, h / 2);
 
-            const glow = x.createRadialGradient(0, 0, h * 0.04, 0, 0, h * 0.48);
-            glow.addColorStop(0, rgba(hiR, hiG, hiB, 0.24));
-            glow.addColorStop(0.56, rgba(r, g, b, 0.13));
-            glow.addColorStop(1, 'rgba(0,0,0,0)');
-            x.fillStyle = glow;
-            x.beginPath();
-            x.ellipse(0, 0, h * 0.47, h * 0.29, 0, 0, TAU);
-            x.fill();
+            // Form 1 — black outer border
+            x.fillStyle = '#000000';
+            x.beginPath(); x.ellipse(0, 0, h * 0.430, h * 0.255, 0, 0, TAU); x.fill();
 
-            x.lineCap = 'round';
-            x.fillStyle = black;
-            sideWing(-1, 1.06, 1.08);
-            x.fill();
-            sideWing(1, 1.06, 1.08);
-            x.fill();
-            x.beginPath();
-            x.ellipse(0, 0, outerRx * 1.05, outerRy * 1.08, 0, 0, TAU);
-            x.fill();
+            // Form 2 — string-color main body
+            x.fillStyle = colStr;
+            x.beginPath(); x.ellipse(0, 0, h * 0.418, h * 0.232, 0, 0, TAU); x.fill();
 
-            x.shadowColor = rgba(r, g, b, 0.28);
-            x.shadowBlur = 10;
-            x.fillStyle = rgba(midR, midG, midB, 0.98);
-            sideWing(-1);
-            x.fill();
-            sideWing(1);
-            x.fill();
-            x.beginPath();
-            x.ellipse(0, 0, outerRx * 0.96, outerRy * 0.94, 0, 0, TAU);
-            x.fill();
+            // Form 3 — black inner ring
+            x.fillStyle = '#000000';
+            x.beginPath(); x.ellipse(0, 0, h * 0.407, h * 0.218, 0, 0, TAU); x.fill();
 
-            x.shadowBlur = 0;
-            x.fillStyle = rgba(dkR, dkG, dkB, 0.82);
-            x.beginPath();
-            x.ellipse(0, 0, outerRx * 0.84, outerRy * 0.79, 0, 0, TAU);
-            x.fill();
+            // Form 4 — string-color inner spot (narrower)
+            x.fillStyle = colStr;
+            x.beginPath(); x.ellipse(0, 0, h * 0.2637, h * 0.218, 0, 0, TAU); x.fill();
 
-            x.fillStyle = rgba(255, 255, 255, 0.96);
-            x.beginPath();
-            x.ellipse(0, 0, outerRx * 0.69, outerRy * 0.63, 0, 0, TAU);
-            x.fill();
-
-            x.fillStyle = black;
-            innerSide(-1);
-            x.fill();
-            innerSide(1);
-            x.fill();
-
-            x.fillStyle = rgba(midR, midG, midB, 0.96);
-            x.beginPath();
-            x.ellipse(0, 0, ringRx, ringRy, 0, 0, TAU);
-            x.fill();
-
-            x.strokeStyle = black;
-            x.lineWidth = 7;
-            x.beginPath();
-            x.ellipse(0, 0, ringRx * 1.02, ringRy * 1.02, 0, 0, TAU);
-            x.stroke();
-
-            x.strokeStyle = white;
-            x.lineWidth = 6;
-            x.beginPath();
-            x.ellipse(0, 0, ringRx, ringRy, 0, 0, TAU);
-            x.stroke();
-
-            x.fillStyle = rgba(r, g, b, 0.94);
-            x.beginPath();
-            x.ellipse(0, 0, irisRx, irisRy, 0, 0, TAU);
-            x.fill();
-
-            x.strokeStyle = black;
-            x.lineWidth = 5;
-            x.beginPath();
-            x.ellipse(0, 0, irisRx, irisRy, 0, 0, TAU);
-            x.stroke();
-
-            x.strokeStyle = white;
-            x.lineWidth = 2.5;
-            x.beginPath();
-            x.ellipse(0, 0, irisRx, irisRy, 0, 0, TAU);
-            x.stroke();
-
-            x.shadowColor = rgba(r, g, b, 0.24);
-            x.shadowBlur = 6;
-            x.fillStyle = black;
-            x.beginPath();
-            x.ellipse(0, 0, pupilRx, pupilRy, 0, 0, TAU);
-            x.fill();
-
-            x.shadowBlur = 0;
-            x.strokeStyle = white;
-            x.lineWidth = 3;
-            x.beginPath();
-            x.ellipse(0, 0, pupilRx * 1.28, pupilRy * 1.28, 0, 0, TAU);
-            x.stroke();
-
-            x.strokeStyle = black;
-            x.lineWidth = 4;
-            sideWing(-1);
-            x.stroke();
-            sideWing(1);
-            x.stroke();
+            // Form 5 — black center dot
+            x.fillStyle = '#000000';
+            x.beginPath(); x.ellipse(0, 0, h * 0.134, h * 0.120, 0, 0, TAU); x.fill();
 
             x.restore();
 
@@ -2526,7 +2440,6 @@
                 transparent: true,
                 depthTest: false,
                 depthWrite: false,
-                opacity: 0.9,
             });
             txtCache[k] = mat;
             return mat;
@@ -2596,27 +2509,37 @@
         }
 
         function muteXMat(fillCol, strokeCol) {
-            const k = 'technique|muteX|v1|' + String(fillCol) + '|' + String(strokeCol);
+            const k = 'technique|muteX|v2|' + String(fillCol) + '|' + String(strokeCol);
             if (txtCache[k]) return txtCache[k];
 
-            const h = 256;
+            // lineCap:'square' gives flat tips. For a 45° diagonal the square-cap
+            // corners sit at ±outerW/2 rotated 45° from the endpoint — they land
+            // outside the canvas unless pad ≥ outerW/√2 (the common mistake is
+            // using outerW/2, which is too small). With the correct pad the white
+            // cap is fully inside the canvas and the border is visible at every tip.
+            const h = 512;
+            const outerW = 132, innerW = 114;
+            // pad must satisfy: pad ≥ outerW / Math.SQRT2  (≈ outerW × 0.707)
+            const pad = Math.ceil(outerW / Math.SQRT2) + 2; // 112
             const c = document.createElement('canvas');
             c.width = h; c.height = h;
             const x = c.getContext('2d');
-            const str = 'X';
-            const font = '900 180px "Arial Black", "Helvetica Neue", Arial, sans-serif';
 
             x.clearRect(0, 0, h, h);
-            x.font = font;
-            x.textAlign = 'center';
-            x.textBaseline = 'middle';
-            x.lineJoin = 'round';
-            x.miterLimit = 2;
-            x.lineWidth = 18;
+            x.lineCap = 'square';
+
+            // Draw each diagonal in its own stroke() call — caps of the two
+            // diagonals don't interact, and the white outer is drawn before the
+            // black inner so the border is clean at every edge and tip.
             x.strokeStyle = strokeCol;
-            x.strokeText(str, h / 2, h / 2);
-            x.fillStyle = fillCol;
-            x.fillText(str, h / 2, h / 2);
+            x.lineWidth = outerW;
+            x.beginPath(); x.moveTo(pad, pad); x.lineTo(h - pad, h - pad); x.stroke();
+            x.beginPath(); x.moveTo(h - pad, pad); x.lineTo(pad, h - pad); x.stroke();
+
+            x.strokeStyle = fillCol;
+            x.lineWidth = innerW;
+            x.beginPath(); x.moveTo(pad, pad); x.lineTo(h - pad, h - pad); x.stroke();
+            x.beginPath(); x.moveTo(h - pad, pad); x.lineTo(pad, h - pad); x.stroke();
 
             const mat = new T.SpriteMaterial({
                 map: new T.CanvasTexture(c),
@@ -2654,7 +2577,7 @@
             g.lineJoin = 'round';
             g.fillStyle = '#ffffff';
             g.fill();
-            g.lineWidth = S * 0.15;
+            g.lineWidth = S * 0.122;
             g.strokeStyle = '#' + (hex >>> 0).toString(16).padStart(6, '0');
             g.stroke();
             const mat = new T.SpriteMaterial({
@@ -2709,6 +2632,26 @@
                     depthWrite: false,
                 });
                 spriteMat.userData.h3dGhostFretMeshMat = mb;
+            }
+            return mb;
+        }
+
+        /**
+         * Convert any SpriteMaterial to a MeshBasicMaterial that shares its canvas
+         * texture, so technique markers can be applied to a rotatable PlaneGeometry
+         * mesh instead of a billboard Sprite. Cached on userData to avoid allocations.
+         */
+        function _spriteMat2MeshMat(sm) {
+            let mb = sm.userData.h3dTechMeshMat;
+            if (!mb) {
+                mb = new T.MeshBasicMaterial({
+                    map: sm.map,
+                    transparent: true,
+                    depthTest: false,
+                    depthWrite: false,
+                    side: T.DoubleSide,
+                });
+                sm.userData.h3dTechMeshMat = mb;
             }
             return mb;
         }
@@ -3714,6 +3657,15 @@
             mAccentHaloNear = mkAccentHaloMats(ACCENT_HALO_OP_NEAR);
             mAccentHaloMid = mkAccentHaloMats(ACCENT_HALO_OP_MID);
             mAccentHaloFar = mkAccentHaloMats(ACCENT_HALO_OP_FAR);
+            // Chord/arpeggio frame accent bloom — per-instance cloned materials
+            // so near/far shells can have independent opacity values.
+            pChordAccentHalo = pool(noteG, () => new T.Mesh(
+                new T.BoxGeometry(1, 1, 1),
+                new T.MeshBasicMaterial({
+                    transparent: true, opacity: 0.8, depthWrite: false,
+                    blending: T.AdditiveBlending, side: T.DoubleSide, fog: true,
+                }),
+            ));
             // Notedetect feedback (issue #9): bright green / red outline
             // tints. Note rendering swaps its outline.material between
             // mWhiteOutline / mHitOutline / mMissOutline based on
@@ -3840,6 +3792,40 @@
                 return m;
             });
 
+            // Bloom glow for chord sustain rails — wider plane with a gaussian
+            // falloff texture (bright centre → transparent edges in X direction)
+            // and additive blending, so it brightens whatever is behind it.
+            // renderOrder 14 places it behind the core rail (16).
+            _bloomGaussTex = _makeGaussTex(T);
+            gSusRailBloom = new T.PlaneGeometry(1, 1);
+            gSusRailBloom.rotateX(-Math.PI / 2);
+            mSusRailBloomBase = new T.MeshBasicMaterial({
+                color: CHORD_BOX_TEAL_HEX,
+                map: _bloomGaussTex,
+                transparent: true, opacity: 0.55,
+                blending: T.AdditiveBlending,
+                depthTest: false, depthWrite: false,
+                fog: false, side: T.DoubleSide,
+            });
+            pSusRailBloom = pool(noteG, () => {
+                const m = new T.Mesh(gSusRailBloom, mSusRailBloomBase.clone());
+                m.renderOrder = 14;
+                return m;
+            });
+
+            // Rotatable plane pool for technique markers (pm, mt, hm, hp, H/P, bend).
+            // Unlike T.Sprite, a PlaneGeometry mesh accepts rotation.z = approachRot
+            // so markers stay coplanar with the gem as it tilts from vertical to flat.
+            gTechPlane = new T.PlaneGeometry(1, 1);
+            pTechPlane = pool(noteG, () => {
+                const m = new T.Mesh(gTechPlane, new T.MeshBasicMaterial({
+                    transparent: true, depthTest: false, depthWrite: false, side: T.DoubleSide,
+                }));
+                m.renderOrder = 1000;
+                return m;
+            });
+
+
             // Dynamic fret number labels (heat-coloured, updated each frame)
             pFretLbl = pool(lblG, () => new T.Sprite(txtMat('0', '#888', false, 'fretRow')));
 
@@ -3942,6 +3928,127 @@
                     color: CHORD_BOX_TEAL_HEX,
                     transparent: true,
                     opacity: CHORD_BOX_EDGE_ALPHA,
+                    depthWrite: false,
+                    depthTest: false,
+                    fog: false,
+                    side: T.DoubleSide,
+                }),
+            ));
+
+            // PM strum X fill — 4 cantos + centro; as 4 asas (esq,dir,topo,base) ficam vazias.
+            // 16 vértices, 14 triângulos.
+            //  0=A(-1,1)  1=TLC(-0.48,1)  2=T(-0.012,0.257)  3=TRC(0.5,1)
+            //  4=BR(1,1)  5=REB(1,0.5)   6=R(0.476,-0.011)  7=RET(1,-0.5)
+            //  8=C(1,-1)  9=BRC(0.48,-1) 10=B(-0.003,-0.276) 11=BLC(-0.48,-1)
+            // 12=D(-1,-1) 13=LET(-1,-0.5) 14=L(-0.494,-0.011) 15=LEB(-1,0.5)
+            {
+                // prettier-ignore
+                const pos = new Float32Array([
+                    -1,      1,      0,  //  0  A
+                    -0.480,  1,      0,  //  1  TLC
+                    -0.012,  0.257,  0,  //  2  T
+                     0.500,  1,      0,  //  3  TRC
+                     1,      1,      0,  //  4  BR
+                     1,      0.5,    0,  //  5  REB
+                     0.476, -0.011,  0,  //  6  R
+                     1,     -0.5,    0,  //  7  RET
+                     1,     -1,      0,  //  8  C
+                     0.480, -1,      0,  //  9  BRC
+                    -0.003, -0.276,  0,  // 10  B
+                    -0.480, -1,      0,  // 11  BLC
+                    -1,     -1,      0,  // 12  D
+                    -1,     -0.5,    0,  // 13  LET
+                    -0.494, -0.011,  0,  // 14  L
+                    -1,      0.5,    0,  // 15  LEB
+                ]);
+                // prettier-ignore
+                const idx = new Uint16Array([
+                    // canto topo-esq: A,TLC,T,L,LEB
+                     0,  1,  2,
+                     0,  2, 14,
+                     0, 14, 15,
+                    // canto topo-dir: TRC,BR,REB,R,T
+                     3,  4,  5,
+                     3,  5,  6,
+                     3,  6,  2,
+                    // centro: T,R,B,L
+                     2,  6, 10,
+                     2, 10, 14,
+                    // canto base-dir: RET,C,BRC,B,R
+                     7,  8,  9,
+                     7,  9, 10,
+                     7, 10,  6,
+                    // canto base-esq: LET,L,B,BLC,D
+                    13, 14, 10,
+                    13, 10, 11,
+                    13, 11, 12,
+                ]);
+                gPMXFill = new T.BufferGeometry();
+                gPMXFill.setAttribute('position', new T.BufferAttribute(pos, 3));
+                gPMXFill.setIndex(new T.BufferAttribute(idx, 1));
+            }
+            pPMXFill = pool(noteG, () => new T.Mesh(
+                gPMXFill,
+                new T.MeshBasicMaterial({
+                    color: 0x000000,
+                    transparent: true,
+                    opacity: 1.0,
+                    depthWrite: false,
+                    depthTest: false,
+                    fog: false,
+                    side: T.DoubleSide,
+                }),
+            ));
+
+            // FH (frethand mute) strum X fill — 5 regiões: 4 cantos + centro.
+            // 12 vértices, 10 triângulos. Asas esq/dir só vão até fx=±0.50 (sem blocos laterais).
+            //  0=LET(-0.50,+1)  1=TLC(-0.15,+1)  2=T(0,+0.42)   3=TRC(+0.15,+1)
+            //  4=RET(+0.50,+1)  5=REB(+0.50,-1)  6=R(+0.28,0)   7=B(0,-0.42)
+            //  8=BRC(+0.15,-1)  9=BLC(-0.15,-1) 10=LEB(-0.50,-1) 11=L(-0.28,0)
+            {
+                // prettier-ignore
+                const pos = new Float32Array([
+                    -0.50,  1,      0,  //  0  LET
+                    -0.15,  1,      0,  //  1  TLC
+                     0,     0.42,   0,  //  2  T
+                     0.15,  1,      0,  //  3  TRC
+                     0.50,  1,      0,  //  4  RET
+                     0.50, -1,      0,  //  5  REB
+                     0.28,  0,      0,  //  6  R
+                     0,    -0.42,   0,  //  7  B
+                     0.15, -1,      0,  //  8  BRC
+                    -0.15, -1,      0,  //  9  BLC
+                    -0.50, -1,      0,  // 10  LEB
+                    -0.28,  0,      0,  // 11  L
+                ]);
+                // prettier-ignore
+                const idx = new Uint16Array([
+                    // canto topo-esq: LET,TLC,T,L
+                     0,  1,  2,
+                     0,  2, 11,
+                    // canto topo-dir: TRC,RET,R,T
+                     3,  4,  6,
+                     3,  6,  2,
+                    // canto base-dir: REB,R,B,BRC
+                     5,  6,  7,
+                     5,  7,  8,
+                    // canto base-esq: LEB,L,B,BLC
+                    10, 11,  7,
+                    10,  7,  9,
+                    // centro: L,T,R,B
+                    11,  2,  6,
+                    11,  6,  7,
+                ]);
+                gFHXFill = new T.BufferGeometry();
+                gFHXFill.setAttribute('position', new T.BufferAttribute(pos, 3));
+                gFHXFill.setIndex(new T.BufferAttribute(idx, 1));
+            }
+            pFHXFill = pool(noteG, () => new T.Mesh(
+                gFHXFill,
+                new T.MeshBasicMaterial({
+                    color: 0x000000,
+                    transparent: true,
+                    opacity: 1.0,
                     depthWrite: false,
                     depthTest: false,
                     fog: false,
@@ -5527,9 +5634,9 @@
             if (projMeshArr) for (const m of projMeshArr) m.visible = false;
             pFretLbl.reset(); pLane.reset(); pLaneDivider.reset();
             if (pGhostFretLbl) pGhostFretLbl.reset();
-            pChordBox.reset(); pChordFrameFill.reset(); pChordLbl.reset(); pBarreLine.reset();
+            pChordBox.reset(); pChordFrameFill.reset(); pChordLbl.reset(); pBarreLine.reset(); pChordAccentHalo.reset(); pPMXFill.reset(); pFHXFill.reset();
             pNoteFretLabel.reset(); pConnectorLine.reset(); pDropLine.reset();
-            pFretColMarker.reset(); pSusRail.reset();
+            pFretColMarker.reset(); pSusRail.reset(); pSusRailBloom.reset(); pTechPlane.reset();
             _ndLabels = [];
             let hwyLaneArpOuterDividers = false;
             _ndSizzle = [];
@@ -5592,6 +5699,58 @@
                     _arpGhostInferRefTpl = bundle.chordTemplates;
                 }
                 arpGhostHsInfer = _arpGhostHsInferScratch;
+            }
+
+            // ── Slide-target gem-suppression pre-pass (chart-static) ──────
+            // Detects notes in bundle.notes that are the "linkNext" destination
+            // of a preceding note. The gem (outline+core) is suppressed via
+            // skipBody=true, but the sustain/slide trail still renders because
+            // the trail block is now outside the !skipBody gate in drawNote().
+            //
+            // Two source patterns (source has sus > 0):
+            //   Case 1 — source has sl/slu: destination.f === source's slide target
+            //   Case 2 — same fret (hold), destination has sl/slu (hold→slide)
+            //
+            // Sources can be single notes OR chord notes (bundle.chords).
+            if (notes !== _slideTargetNotesRef || bundle.chords !== _slideTargetChordsRef) {
+                _slideTargetSet = null;
+                if (notes && notes.length) {
+                    const stSet = new Set();
+                    const checkSrc = (srcT, srcS, srcF, srcSus, srcSl) => {
+                        if (!(srcSus > 0)) return;
+                        const endT = srcT + srcSus;
+                        let lo = 0, hi = notes.length;
+                        while (lo < hi) { const m = (lo + hi) >> 1; if (notes[m].t < endT - 0.06) lo = m + 1; else hi = m; }
+                        for (let j = lo; j < notes.length; j++) {
+                            const q = notes[j];
+                            if (q.t > endT + 0.06) break;
+                            if (q.s !== srcS || Math.abs(q.t - endT) >= 0.06) continue;
+                            const qSl = (Number.isFinite(q.sl) && q.sl >= 0) ? q.sl
+                                      : (Number.isFinite(q.slu) && q.slu >= 0) ? q.slu : -1;
+                            if (srcSl >= 0 && q.f === srcSl) { stSet.add(`${q.t}_${q.s}`); break; } // case 1
+                            if (q.f === srcF && qSl >= 0)    { stSet.add(`${q.t}_${q.s}`); break; } // case 2
+                        }
+                    };
+                    for (let i = 0; i < notes.length; i++) {
+                        const p = notes[i];
+                        checkSrc(p.t, p.s, p.f, p.sus,
+                            (Number.isFinite(p.sl) && p.sl >= 0) ? p.sl : (Number.isFinite(p.slu) && p.slu >= 0) ? p.slu : -1);
+                    }
+                    const rc = bundle.chords;
+                    if (rc && rc.length) {
+                        for (let ci = 0; ci < rc.length; ci++) {
+                            const ch = rc[ci]; if (!ch.notes) continue;
+                            for (let ni = 0; ni < ch.notes.length; ni++) {
+                                const cn = ch.notes[ni];
+                                checkSrc(ch.t, cn.s, cn.f, cn.sus,
+                                    (Number.isFinite(cn.sl) && cn.sl >= 0) ? cn.sl : (Number.isFinite(cn.slu) && cn.slu >= 0) ? cn.slu : -1);
+                            }
+                        }
+                    }
+                    if (stSet.size > 0) _slideTargetSet = stSet;
+                }
+                _slideTargetNotesRef = notes;
+                _slideTargetChordsRef = bundle.chords;
             }
 
             /** Arpeggio lane purple rails — authored-marker cache + bounds cache. */
@@ -6028,6 +6187,10 @@
                     }
                     if (n.t + (n.sus || 0) < t0 || n.t > t1) continue;
                     if (!validString(n.s)) continue;
+                    // Suppress the gem for linkNext slide-target notes (skipBody=true).
+                    // The sustain/slide trail still renders because it now lives outside
+                    // the !skipBody gate in drawNote().
+                    const _isSlideTgt = !!(_slideTargetSet && _slideTargetSet.has(`${n.t}_${n.s}`));
                     const skipLabel = lastFretForString[n.s] === n.f;
                     let singleOpenX;
                     if (n.f === 0) {
@@ -6047,7 +6210,7 @@
                         now,
                         singleOpenX,
                         skipLabel,
-                        false,
+                        _isSlideTgt,
                         GHOST_HOLD_AFTER_ONSET,
                         singleOpenLaneW,
                         arGhostCid != null,
@@ -6427,6 +6590,7 @@
                             b.material.color.setHex(rimHex);
                             b.position.set(px, py, z);
                             b.scale.set(sx, sy, thickZ);
+                            b.rotation.set(0, 0, 0);
                             b.material.opacity = edgeOp;
                         };
 
@@ -6444,18 +6608,53 @@
                         fill.material.map = isArpeggioFrame ? chordFrameGradTexArp : chordFrameGradTex;
                         fill.material.color.setRGB(1, 1, 1);
 
-                        drawFrameBox(cx, yBot + ft * 0.5, width, ft, 12);
+                        // renderOrder 17/18 — above sustain rails (16) but below note gems (20/21)
+                        drawFrameBox(cx, yBot + ft * 0.5, width, ft, 17);
                         const withTopFrame = !isRepeat;
                         if (withTopFrame) {
-                            drawFrameBox(cx, yTop - ft * 0.5, width, ft, 12);
+                            drawFrameBox(cx, yTop - ft * 0.5, width, ft, 17);
                         }
 
                         const ySideLo = yBot + ft;
                         const ySideHi = withTopFrame ? yTop - ft : yTop - ft * 0.15;
                         const sideH = Math.max(ySideHi - ySideLo, ft * 1.25);
                         const sideCy = ySideLo + sideH * 0.5;
-                        drawFrameBox(cx - width * 0.5 + ftSide * 0.5, sideCy, ftSide, sideH, 13);
-                        drawFrameBox(cx + width * 0.5 - ftSide * 0.5, sideCy, ftSide, sideH, 13);
+                        drawFrameBox(cx - width * 0.5 + ftSide * 0.5, sideCy, ftSide, sideH, 18);
+                        drawFrameBox(cx + width * 0.5 - ftSide * 0.5, sideCy, ftSide, sideH, 18);
+
+                        // Accent bloom on frame edges: 4 additive shells with
+                        // Gaussian-style falloff. Each border expands only in its
+                        // perpendicular axis so bloom never leaves the frame boundary:
+                        //   horizontal bars (top/bottom) → expand Y only
+                        //   vertical bars (left/right)   → expand X only
+                        if (chordAccent && pChordAccentHalo) {
+                            const haloHex = isArpeggioFrame ? ARPEGGIO_RIM_BLUE_HEX : CHORD_BOX_TEAL_HEX;
+                            const bloomShells = [
+                                [1.00, 0.90],
+                                [1.10, 0.65],
+                                [1.25, 0.38],
+                                [1.45, 0.18],
+                            ];
+                            // ex, ey: expand multiplier per axis
+                            const drawHalo = (px, py, sx, sy, ex, ey, op) => {
+                                const b = pChordAccentHalo.get();
+                                b.material.color.setHex(haloHex);
+                                b.material.opacity = fade * op * chordTailMul;
+                                b.renderOrder = 19;
+                                b.position.set(px, py, z - 0.001 * K);
+                                b.scale.set(sx * ex, sy * ey, thickZ * 2.0);
+                                b.rotation.set(0, 0, 0);
+                            };
+                            for (const [expand, op] of bloomShells) {
+                                // horizontal bars — expand Y only
+                                drawHalo(cx, yBot + ft * 0.5,                         width,  ft,    1.0, expand, op);
+                                if (withTopFrame)
+                                drawHalo(cx, yTop - ft * 0.5,                         width,  ft,    1.0, expand, op);
+                                // vertical bars — expand X only
+                                drawHalo(cx - width * 0.5 + ftSide * 0.5, sideCy, ftSide, sideH, expand, 1.0, op);
+                                drawHalo(cx + width * 0.5 - ftSide * 0.5, sideCy, ftSide, sideH, expand, 1.0, op);
+                            }
+                        }
 
                         const chordName = chordTemplateLabel(bundle.chordTemplates?.[ch.id]);
                         if (chordName && firstInShapeRun && !chordWireHighDensity(ch)) {
@@ -6547,6 +6746,90 @@
                             }
                         }
 
+                        // ── Palm-mute strum indicator — X outline + dark fill ──────────
+                        // Eight lines forming a star/asterisk across the inner chord box,
+                        // with a semi-transparent dark fill covering the same 5 regions.
+                        // Geometry fractions: ±1 = inner-box edge, Y-up (Three.js).
+                        if (isRepeat && chordNotes.some(cn => cn.pm)) {
+                            // Fill (dark, transparent) — renderOrder 10 = below lines
+                            const pmf = pPMXFill.get();
+                            pmf.renderOrder = 10.5; // acima do pChordFrameFill (10), abaixo das linhas X (11)
+                            pmf.rotation.set(0, 0, 0);
+                            pmf.position.set(cx, cY, z - 0.0045 * K);
+                            pmf.scale.set(innerW * 0.5, -innerH * 0.5, 1); // Y negado: espelha o sistema do XLINES (ay = cY - fya*hH)
+                            pmf.material.opacity = edgeOp;
+
+                            const lw  = ft * 0.55;      // line visual thickness
+                            const hW  = innerW * 0.5;
+                            const hH  = innerH * 0.5;
+                            // [fx_a, fy_a, fx_b, fy_b] — junction points where pairs converge
+                            const XLINES = [
+                                [-1.000, -0.500, -0.494, -0.011], // LET → L
+                                [-1.000,  0.500, -0.494, -0.011], // LEB → L
+                                [ 1.000, -0.500,  0.476, -0.011], // RET → R
+                                [ 1.000,  0.500,  0.476, -0.011], // REB → R
+                                [-0.480,  1.000, -0.012,  0.257], // BLC → B
+                                [ 0.500,  1.000, -0.012,  0.257], // BRC → B
+                                [ 0.480, -1.000,  0.000, -0.276], // TRC → T
+                                [-0.480, -1.000, -0.006, -0.276], // TLC → T
+                            ];
+                            for (const [fxa, fya, fxb, fyb] of XLINES) {
+                                const ax = cx + fxa * hW,  ay = cY - fya * hH;
+                                const bx = cx + fxb * hW,  by = cY - fyb * hH;
+                                const mx = (ax + bx) * 0.5, my = (ay + by) * 0.5;
+                                const len = Math.hypot(bx - ax, by - ay);
+                                const ang = Math.atan2(by - ay, bx - ax);
+                                const seg = pChordBox.get();
+                                seg.renderOrder = 11;
+                                seg.material.color.setHex(rimHex);
+                                seg.position.set(mx, my, z - 0.005 * K);
+                                seg.scale.set(len, lw, thickZ * 0.5);
+                                seg.rotation.set(0, 0, ang);
+                                seg.material.opacity = edgeOp * 0.85;
+                            }
+                        }
+
+                        // ── Frethand-mute strum indicator — FH X outline + dark fill ───
+                        // 4 nós de convergência (L,R,T,B) + 8 terminais nas bordas sup/inf.
+                        // Asas esq/dir vão até fx=±0.50 (não preenchem as laterais do box).
+                        if (isRepeat && chordNotes.some(cn => cn.mt)) {
+                            // Fill (dark) — renderOrder 10.5 = acima do frame fill, abaixo das linhas
+                            const fhf = pFHXFill.get();
+                            fhf.renderOrder = 10.5;
+                            fhf.rotation.set(0, 0, 0);
+                            fhf.position.set(cx, cY, z - 0.0045 * K);
+                            fhf.scale.set(innerW * 0.5, -innerH * 0.5, 1); // Y negado: fy+ = cima na geometria
+                            fhf.material.opacity = edgeOp;
+
+                            const lw = ft * 0.55;
+                            const hW = innerW * 0.5;
+                            const hH = innerH * 0.5;
+                            // [fx_a, fy_a, fx_b, fy_b]
+                            const FH_XLINES = [
+                                [-0.50,  1.00, -0.28,  0.00], // LET → L
+                                [-0.50, -1.00, -0.28,  0.00], // LEB → L
+                                [ 0.50,  1.00,  0.28,  0.00], // RET → R
+                                [ 0.50, -1.00,  0.28,  0.00], // REB → R
+                                [-0.15, -1.00,  0.00, -0.42], // BLC → B
+                                [ 0.15, -1.00,  0.00, -0.42], // BRC → B
+                                [ 0.15,  1.00,  0.00,  0.42], // TRC → T
+                                [-0.15,  1.00,  0.00,  0.42], // TLC → T
+                            ];
+                            for (const [fxa, fya, fxb, fyb] of FH_XLINES) {
+                                const ax = cx + fxa * hW,  ay = cY - fya * hH;
+                                const bx = cx + fxb * hW,  by = cY - fyb * hH;
+                                const mx = (ax + bx) * 0.5, my = (ay + by) * 0.5;
+                                const len = Math.hypot(bx - ax, by - ay);
+                                const ang = Math.atan2(by - ay, bx - ax);
+                                const seg = pChordBox.get();
+                                seg.renderOrder = 11;
+                                seg.material.color.setHex(rimHex);
+                                seg.position.set(mx, my, z - 0.005 * K);
+                                seg.scale.set(len, lw, thickZ * 0.5);
+                                seg.rotation.set(0, 0, ang);
+                                seg.material.opacity = edgeOp * 0.85;
+                            }
+                        }
 
                     }
 
@@ -6571,11 +6854,18 @@
                                 const _railW = 2.5 * K; // visual width of each rail strip
                                 const _zMid  = _zNear - _railLen * 0.5; // centre in Z
                                 for (const _rx of [chordFrameXL, chordFrameXR]) {
+                                    // Core rail
                                     const rl = pSusRail.get();
                                     rl.material.color.setHex(_hex);
                                     rl.material.opacity = _op;
                                     rl.position.set(_rx, _yBot, _zMid);
                                     rl.scale.set(_railW, 1, _railLen);
+                                    // Bloom glow — wider gaussian plane, additive blending
+                                    const bl = pSusRailBloom.get();
+                                    bl.material.color.setHex(_hex);
+                                    bl.material.opacity = _op * 0.8;
+                                    bl.position.set(_rx, _yBot + 0.001, _zMid);
+                                    bl.scale.set(4 * K, 1, _railLen);
                                 }
                             }
                         }
@@ -7368,10 +7658,19 @@
                 openWScale = Math.max(0.22, (openChordBoxWidth * 0.96) / OPEN_NOTE_WORLD_W);
             }
 
+            // Hoisted so both !skipBody blocks (gem and technique labels) and
+            // the unconditional sustain trail all share one declaration.
+            // For skipBody=true (slide targets), defaults are safe no-ops.
+            const openSlabThickMul = n.f === 0 ? 1.5 : 1;
+            const approachRot = n.f > 0 ? Math.max(0, Math.min(1, dt / AHEAD)) * Math.PI / 2 : 0;
+            const PROJ_WIN_G = 0.6;
+            const projFactorG = Math.max(0, Math.min(1, 1 - Math.max(dt, 0) / PROJ_WIN_G));
+            const inGhostWin = n.f > 0 && isNextOnString && dt > -ghostHold && dt < PROJ_WIN_G && projFactorG > 0.001;
+            let _ndGood = false;   // set to true inside !skipBody if note_detect confirms hit/active
+            let _ndState = null;   // set inside !skipBody; null → fall back to hit heuristic
+            let _showHit = hit;    // default; overridden inside !skipBody when provider has verdict
+
             if (!skipBody) {
-                // Rotate from vertical (π/2) when entering to horizontal (0) at the hit line; skip for open strings
-                const approachRot = n.f > 0 ? Math.max(0, Math.min(1, dt / AHEAD)) * Math.PI / 2 : 0;
-                const openSlabThickMul = n.f === 0 ? 1.5 : 1;
 
                 // ── Outline (slightly larger, bright emissive) ────────────
                 // Notedetect feedback (#9): if a recent hit/miss event
@@ -7414,10 +7713,7 @@
                         labels: _ndMatchedMark.labels,
                     });
                 }
-                const PROJ_WIN_G = 0.6;
-                const projFactorG = Math.max(0, Math.min(1, 1 - Math.max(dt, 0) / PROJ_WIN_G));
-                const inGhostWin = n.f > 0 && isNextOnString && dt > -ghostHold && dt < PROJ_WIN_G &&
-                    projFactorG > 0.001;
+                // (approachRot / PROJ_WIN_G / projFactorG / inGhostWin hoisted above)
 
                 const rimXY = n.ac ? ACCENT_RIM_XY_SCALE_MUL : 1;
                 const rimZ = n.ac ? ACCENT_RIM_Z_SCALE_MUL : 1;
@@ -7433,7 +7729,8 @@
                 // Called with the note's chart time, not `now`: note_detect
                 // keys its noteResults map by chart time, so `n.t` is the key
                 // (it reads the live time internally for the fade window).
-                let _ndGood = false, _ndState = null;
+                // _ndState declared above; reset for this note
+                _ndState = null;
                 if (_ndGetNoteState) {
                     let _cs = null;
                     try { _cs = _ndGetNoteState(n, n.t); } catch (e) { _cs = null; }
@@ -7473,12 +7770,12 @@
                 }
                 // Provider verdict wins when present; otherwise fall back to
                 // the proximity heuristic, including the pre-hit ghost window.
-                const _showHit = (_ndState === 'miss') ? false : (_ndState ? _ndGood : (hit || (n.f > 0 && inGhostWin)));
+                _showHit = (_ndState === 'miss') ? false : (_ndState ? _ndGood : (hit || (n.f > 0 && inGhostWin)));
 
                 // Accent: soft neon outer glow (reference: diffused halo fading out).
                 // Three additive shells drawn behind outline/core; colour = string hue.
                 if (n.ac && mAccentHaloNear[s]) {
-                    const rZ = approachRot + (isHarm ? Math.PI / 4 : 0);
+                    const rZ = approachRot;
                     const accentShells = [
                         { mat: mAccentHaloFar[s], ixy: ACCENT_HALO_XY_OUTER, iz: ACCENT_HALO_Z_OUTER, zK: 0.012 },
                         { mat: mAccentHaloMid[s], ixy: ACCENT_HALO_XY_MID, iz: ACCENT_HALO_Z_MID, zK: 0.008 },
@@ -7491,9 +7788,14 @@
                         glow.rotation.z = rZ;
                         glow.position.set(x, y + techniqueYNow, noteZ - sh.zK * K);
                         if (n.f === 0) {
-                            const slabPuff = Math.max(2.4, 1 + (sh.ixy - 1) * 3.2);
+                            // Inside a chord/arpeggio frame: bloom only vertically so the
+                            // halo doesn't burst past the chord box edges horizontally.
+                            // Outside a frame: modest horizontal cap (1.4×) so it doesn't
+                            // overflow into adjacent lane visuals.
+                            const openIxy = fromChord ? 1.0 : Math.min(sh.ixy, 1.4);
+                            const slabPuff = Math.max(1.4, sh.ixy);
                             glow.scale.set(
-                                (40 * K / NW) * rimXY * sh.ixy * openWScale,
+                                (40 * K / NW) * rimXY * openIxy * openWScale,
                                 0.1 * openSlabThickMul * slabPuff,
                                 0.6 * rimZ * sh.iz,
                             );
@@ -7507,7 +7809,7 @@
                     : (n.ac ? mAccentOutline[s] : _ndOutline);
                 outline.renderOrder = 20;
                 outline.position.set(x, y + techniqueYNow, noteZ);
-                outline.rotation.z = approachRot + (isHarm ? Math.PI / 4 : 0);
+                outline.rotation.z = approachRot;
                 if (n.f === 0) {
                     outline.scale.set(
                         (35 * K / NW) * 1.1 * rimXY * openWScale,
@@ -7523,7 +7825,7 @@
                 core.material = n.ac ? mAccentCore[s] : (_showHit ? mGlow[s] : mStr[s]);
                 core.renderOrder = 21;
                 core.position.set(x, y + techniqueYNow, noteZ + 0.001);
-                core.rotation.z = approachRot + (isHarm ? Math.PI / 4 : 0);
+                core.rotation.z = approachRot;
                 if (n.f === 0) {
                     core.scale.set(
                         (40 * K / NW) * rimXY * openWScale,
@@ -7538,9 +7840,14 @@
                 // promise digits on the fretboard ghost only, never on the
                 // gems coming down the highway. The ghost path is at
                 // pGhostFretLbl below.
+            } // end gem block — technique labels reopen !skipBody below
 
-                // ── Sustain trail ─────────────────────────────────────────
-                if (hasSus) {
+            // ── Sustain trail ─────────────────────────────────────────────
+            // Rendered for ALL notes with sustain, including skipBody=true
+            // slide-target notes (e.g. linkNext hold→slide: gem suppressed,
+            // slide trail stays visible as the continuation of the sustain).
+            // _ndGood is false for skipBody notes → trail uses dim mSus[s].
+            if (hasSus) {
                     const susStart = Math.max(n.t, now);
                     const remSus = susEnd - susStart;
                     if (remSus > 0.01) {
@@ -7636,8 +7943,9 @@
                             }
                         }
                     }
-                }
+            }
 
+            if (!skipBody) {
                 // ── Technique labels ──────────────────────────────────────
                 // Label scale = base × LBL_MULT × distFactor.
                 // distFactor compensates for perspective shrink so a
@@ -7671,80 +7979,79 @@
                     ? NH * 1.5 * sLbl * openWScale
                     : NH * 1.5 * sLbl;
                 if (n.bn > 0) {
-                    // Strength-of-bend chevron stack — one chevron per
-                    // half-step (Rocksmith bend notation), in the string
-                    // colour, pinned to the gem. Fixed world size so it
-                    // perspective-shrinks with the gem rather than being
-                    // distFactor-scaled. `n.bn` is already in semitones
-                    // (sloppak spec) — a half-step bend is bn === 1.
+                    // Bend chevron stack — PlaneGeometry mesh so it tilts with
+                    // the gem (approachRot). Fixed world size so it perspective-
+                    // shrinks naturally without distFactor compensation.
                     const steps = Math.max(1, Math.min(4, Math.round(n.bn)));
-                    const l = pLbl.get();
-                    l.material = bendChevronMat(steps, activePalette[s] || 0xffffff);
+                    const bendSm = bendChevronMat(steps, activePalette[s] || 0xffffff);
+                    const l = pTechPlane.get();
+                    l.material = _spriteMat2MeshMat(bendSm);
                     const cs = NH * 2.4;
                     l.scale.set(cs, cs, 1);
                     l.position.set(x, y + techniqueYNow + NH * 1.1, noteZ + 0.005);
+                    l.rotation.z = approachRot;
                     l.renderOrder = TECH_RO;
-                    // Reserve stack space above the chevron so a co-occurring
-                    // tremolo / label sits clear instead of overlapping it.
+                    // Reserve stack space above the chevron.
                     yo = Math.max(yo, y + techniqueYNow + NH * 2.5);
                 }
                 if (n.ho || n.po || n.tp) {
                     if (n.ho || n.po) {
-                        // Hammer-on / pull-off: a ▲ (up) / ▼ (down) triangle
-                        // marker — white fill, string-coloured border — pinned
-                        // to the gem. Fixed world size; renderOrder + the
-                        // depthTest-off material keep it above the note body.
-                        const tri = pLbl.get();
-                        tri.material = triMat(!!n.ho, activePalette[s] || 0xffffff);
-                        const triScale = NH * 1.8;
-                        tri.scale.set(triScale, triScale, 1);
-                        tri.position.set(x, y + techniqueYNow + NH * 0.7, noteZ + 0.005);
+                        // Hammer-on / pull-off: ▲/▼ triangle — PlaneGeometry mesh
+                        // so it tilts with the gem instead of billboarding.
+                        const triSm = triMat(!!n.ho, activePalette[s] || 0xffffff);
+                        const tri = pTechPlane.get();
+                        tri.material = _spriteMat2MeshMat(triSm);
+                        tri.scale.set(NH * 1.8, NH * 1.60, 1);
+                        tri.position.set(x, y + techniqueYNow, noteZ + 0.005);
+                        tri.rotation.z = approachRot;
                         tri.renderOrder = TECH_RO;
-                        // Reserve stack space above the triangle.
-                        yo = Math.max(yo, y + techniqueYNow + NH * 1.8);
+                        // Reserve stack space above the triangle for stacked labels.
+                        yo = Math.max(yo, y + techniqueYNow + NH * 1.0);
                     } else {
                         const chevron = pTapChevron.get();
-                        const chevronScale = NH * 0.8 * sLbl; // Slightly increased for readability
+                        const chevronScale = NH * 0.8 * sLbl;
                         chevron.position.set(x, y + techniqueYNow, noteZ + 1.1 * K);
-                        chevron.rotation.z = (isHarm ? Math.PI / 4 : 0);
+                        chevron.rotation.z = approachRot;
                         chevron.scale.set(chevronScale, chevronScale, 1);
                         chevron.renderOrder = TECH_RO;
                     }
                 }
-                if (n.tr) {
-                    const l = pLbl.get();
-                    l.material = txtMat('~~~', '#ff0', true, 'technique');
-                    l.scale.set(NH * 3.0 * sLbl, NH * 1.2 * sLbl, 1); l.position.set(x, yo, noteZ);
-                    l.renderOrder = TECH_RO;
-                }
+                // Tremolo label ('~~~') removed — trail shape already conveys it visually.
                 if (n.pm || n.mt) {
-                    // Muted notes: on-body X overlay. Palm mute = black X with
-                    // white border; fret-hand mute = white X with black border.
-                    const muteMark = pLbl.get();
+                    // Muted notes: on-body X overlay — PlaneGeometry mesh so it
+                    // rotates with the gem (approachRot) instead of billboarding.
+                    // Palm mute = black X / white border; fret-hand mute = inverse.
                     const fretHandMute = !!n.mt;
-                    muteMark.material = fretHandMute
+                    const muteSprite = fretHandMute
                         ? muteXMat('#ffffff', '#000000')
                         : muteXMat('#000000', '#ffffff');
-                    muteMark.position.set(x, y + techniqueYNow, noteZ + 0.1 * K);
-                    muteMark.scale.set(specialMarkerScale, specialMarkerScale, 1);
+                    const muteMark = pTechPlane.get();
+                    muteMark.material = _spriteMat2MeshMat(muteSprite);
                     muteMark.material.opacity = hit ? 1.0 : 0.8;
+                    // Arms cover 62.5% of canvas (pad=outerW/√2 for square caps).
+                    // Scale by 1/0.625 = 1.60 to map arm tips to gem corners.
+                    const muteScaleX = n.f === 0
+                        ? NW * 1.60 * openWScale
+                        : NW * 1.60;
+                    const muteScaleY = NH * 1.60;
+                    muteMark.scale.set(muteScaleX, muteScaleY, 1);
+                    muteMark.position.set(x, y + techniqueYNow, noteZ + 0.1 * K);
+                    muteMark.rotation.z = approachRot;
                     muteMark.renderOrder = TECH_RO;
                 }
-                if (n.hm) {
-                    const nhMark = pLbl.get();
-                    nhMark.material = naturalHarmonicMat();
-                    nhMark.position.set(x, y + techniqueYNow, noteZ + 0.22 * K);
-                    nhMark.scale.set(specialMarkerScale, specialMarkerScale, 1);
-                    nhMark.material.opacity = hit ? 1.0 : 0.95;
-                    nhMark.renderOrder = TECH_RO + 1;
-                }
-                if (n.hp) {
-                    const phMark = pLbl.get();
-                    phMark.material = pinchHarmonicMat(activePalette[s]);
-                    phMark.position.set(x, y + techniqueYNow, noteZ + 0.22 * K);
-                    phMark.scale.set(specialMarkerScale, specialMarkerScale, 1);
-                    phMark.material.opacity = hit ? 1.0 : 0.95;
-                    phMark.renderOrder = TECH_RO + 1;
+                // hm / hp — PlaneGeometry overlay sized like the palm-mute X,
+                // so the symbol only appears on the front face and matches
+                // the palm-mute marker proportions.
+                if (n.hm || n.hp) {
+                    const harmSprite = n.hm ? naturalHarmonicMat() : pinchHarmonicMat(activePalette[s]);
+                    const harmMark = pTechPlane.get();
+                    harmMark.material = _spriteMat2MeshMat(harmSprite);
+                    harmMark.material.opacity = _showHit ? 1.0 : 0.85;
+                    const harmScaleX = n.f === 0 ? NW * 1.90 * openWScale : NW * 1.90;
+                    harmMark.scale.set(harmScaleX, NH * 2.0, 1);
+                    harmMark.position.set(x, y + techniqueYNow, noteZ + 0.15 * K);
+                    harmMark.rotation.z = approachRot;
+                    harmMark.renderOrder = TECH_RO;
                 }
 
                 // ── Per-note fret connector label ─────────────────────────
@@ -7785,7 +8092,7 @@
             if (n.f > 0 && isNextOnString && projectionVisible && dt > -ghostHold && dt < PROJ_WIN && projFactor > 0.001 && !isBlocked) {
                 // Ghost stays at final "on the board" orientation — not the
                 // incoming approachRot sweep — so it nests with the note at impact.
-                const projRim = isHarm ? Math.PI / 4 : 0;
+                const projRim = 0; // harmonic gems now land horizontal (no diamond offset)
                 const proj = projMeshArr[s];
                 // _vibrancyProjOp (0.15..0.5) is the vibrancy-scaled idle floor;
                 // scale the whole opacity by (_vibrancyProjOp / 0.15) so the slider
@@ -8092,6 +8399,9 @@
             }
             gNote?.dispose?.(); gSus?.dispose?.(); gBeat?.dispose?.(); gSusRail?.dispose?.(); gTapChevron?.dispose?.();
             mSusRailBase?.dispose?.(); mSusRailBase = null; gSusRail = null; pSusRail = null;
+            gSusRailBloom?.dispose?.(); mSusRailBloomBase?.dispose?.(); _bloomGaussTex?.dispose?.();
+            gSusRailBloom = null; mSusRailBloomBase = null; _bloomGaussTex = null; pSusRailBloom = null;
+            gTechPlane?.dispose?.(); gTechPlane = null; pTechPlane = null;
             for (const m of mStr) m?.dispose?.();
             for (const m of mGlow) m?.dispose?.();
             for (const m of mSus) m?.dispose?.();
@@ -8164,7 +8474,9 @@
             _renderScale = 1;
             mBeatM = mBeatQ = null;
             pNote = pSus = pSusOutline = pSusRibbon = pSusRibbonOl = pLbl = pBeat = pSec = null;
-            pFretLbl = pLane = pLaneDivider = pGhostFretLbl = pChordBox = pChordFrameFill = pChordLbl = pBarreLine = pNoteFretLabel = pConnectorLine = pDropLine = pTapChevron = pAccentHalo = null;
+            pFretLbl = pLane = pLaneDivider = pGhostFretLbl = pChordBox = pChordFrameFill = pChordLbl = pBarreLine = pNoteFretLabel = pConnectorLine = pDropLine = pTapChevron = pAccentHalo = pChordAccentHalo = pPMXFill = pFHXFill = null;
+            if (gPMXFill) { gPMXFill.dispose(); gPMXFill = null; }
+            if (gFHXFill) { gFHXFill.dispose(); gFHXFill = null; }
             mLaneOdd = mLaneEven = mLaneDivider = mLaneDividerArp = gLanePlane = gGhostFretPlane = null;
             chordFrameGradTex = chordFrameGradTexArp = null;
             pFretColMarker = null;
@@ -8181,6 +8493,9 @@
             _camSnapped = false;
             _camPreScanned = false;
             _songKey = null;
+            _slideTargetSet = null;
+            _slideTargetNotesRef = null;
+            _slideTargetChordsRef = null;
         }
 
         function canvasSize(canvas) {

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -672,6 +672,10 @@
             data[i * 4 + 3] = a;
         }
         const tex = new ThreeLib.DataTexture(data, w, 1, ThreeLib.RGBAFormat);
+        // LinearFilter on both axes so the bloom plane interpolates smoothly
+        // when scaled — the default NearestFilter causes visible banding.
+        tex.magFilter = ThreeLib.LinearFilter;
+        tex.minFilter = ThreeLib.LinearFilter;
         tex.needsUpdate = true;
         return tex;
     }
@@ -1868,6 +1872,10 @@
         // by the scene.traverse-based dispose. Track them here so
         // teardown can dispose them explicitly.
         const _ownedClonedMats = [];
+        // Per-mesh technique-marker clones — keyed by mesh, disposed when
+        // the source sprite's map changes or on teardown. Replaces the old
+        // unbounded push-per-frame approach in _spriteMat2MeshMat.
+        const _techMeshMatClones = new Set();
         // Shared (non-clone) materials and geometries that pool factories
         // reference but that aren't guaranteed to be reachable via
         // scene.traverse() — e.g. mLaneEven is only reached if at least one
@@ -2646,13 +2654,21 @@
          * texture, so technique markers can be applied to a rotatable PlaneGeometry
          * mesh instead of a billboard Sprite. Cached on userData to avoid allocations.
          */
-        function _spriteMat2MeshMat(sm) {
-            // Always return a fresh clone so each consumer can mutate
-            // opacity independently without affecting other meshes that
-            // share the same underlying sprite (and therefore the same
-            // cached MeshBasicMaterial). The clone shares the CanvasTexture
-            // map (no extra GPU upload), so the only cost is a small JS
-            // object per call — acceptable for technique markers (~2/frame max).
+        function _spriteMat2MeshMat(mesh, sm) {
+            // Cache the cloned MeshBasicMaterial on the receiving mesh so the
+            // same mesh–sprite pairing reuses one material object across frames
+            // instead of allocating a new clone every frame (unbounded growth).
+            // The clone is invalidated only when the source sprite's map changes
+            // (different technique or colour). Opacity is always set by the
+            // caller immediately after, so stale-value risk is zero.
+            const cached = mesh.userData.h3dTechMeshMatClone;
+            if (cached && cached.map === sm.map) return cached;
+            // Source texture changed or first call for this mesh — dispose old.
+            if (cached) {
+                _techMeshMatClones.delete(cached);
+                cached.dispose();
+                mesh.userData.h3dTechMeshMatClone = null;
+            }
             let base = sm.userData.h3dTechMeshMat;
             if (!base) {
                 base = new T.MeshBasicMaterial({
@@ -2665,7 +2681,8 @@
                 sm.userData.h3dTechMeshMat = base;
             }
             const clone = base.clone();
-            _ownedClonedMats.push(clone);
+            mesh.userData.h3dTechMeshMatClone = clone;
+            _techMeshMatClones.add(clone);
             return clone;
         }
 
@@ -8009,7 +8026,7 @@
                     const steps = Math.max(1, Math.min(4, Math.round(n.bn)));
                     const bendSm = bendChevronMat(steps, activePalette[s] || 0xffffff);
                     const l = pTechPlane.get();
-                    l.material = _spriteMat2MeshMat(bendSm);
+                    l.material = _spriteMat2MeshMat(l, bendSm);
                     const cs = NH * 2.4;
                     l.scale.set(cs, cs, 1);
                     l.position.set(x, y + techniqueYNow + NH * 1.1, noteZ + 0.005);
@@ -8024,7 +8041,7 @@
                         // so it tilts with the gem instead of billboarding.
                         const triSm = triMat(!!n.ho, activePalette[s] || 0xffffff);
                         const tri = pTechPlane.get();
-                        tri.material = _spriteMat2MeshMat(triSm);
+                        tri.material = _spriteMat2MeshMat(tri, triSm);
                         tri.scale.set(NH * 1.8, NH * 1.60, 1);
                         tri.position.set(x, y + techniqueYNow, noteZ + 0.005);
                         tri.rotation.z = approachRot;
@@ -8050,7 +8067,7 @@
                         ? muteXMat('#ffffff', '#000000')
                         : muteXMat('#000000', '#ffffff');
                     const muteMark = pTechPlane.get();
-                    muteMark.material = _spriteMat2MeshMat(muteSprite);
+                    muteMark.material = _spriteMat2MeshMat(muteMark, muteSprite);
                     muteMark.material.opacity = hit ? 1.0 : 0.8;
                     // Arms cover 62.5% of canvas (pad=outerW/√2 for square caps).
                     // Scale by 1/0.625 = 1.60 to map arm tips to gem corners.
@@ -8069,7 +8086,7 @@
                 if (n.hm || n.hp) {
                     const harmSprite = n.hm ? naturalHarmonicMat() : pinchHarmonicMat(activePalette[s]);
                     const harmMark = pTechPlane.get();
-                    harmMark.material = _spriteMat2MeshMat(harmSprite);
+                    harmMark.material = _spriteMat2MeshMat(harmMark, harmSprite);
                     harmMark.material.opacity = _showHit ? 1.0 : 0.85;
                     const harmScaleX = n.f === 0 ? NW * 1.90 * openWScale : NW * 1.90;
                     harmMark.scale.set(harmScaleX, NH * 2.0, 1);
@@ -8462,6 +8479,11 @@
             // them at allocation time.
             for (const m of _ownedClonedMats) m?.dispose?.();
             _ownedClonedMats.length = 0;
+            // Per-mesh technique-marker clones (from _spriteMat2MeshMat).
+            // The Set tracks the live clone for each pool mesh; dispose all
+            // on teardown so no GPU material leaks between init() cycles.
+            for (const m of _techMeshMatClones) m?.dispose?.();
+            _techMeshMatClones.clear();
             // Shared pool-factory materials/geometries (mLaneOdd/Even, etc.) —
             // see _ownedSharedMats comment near the declaration. Dispose is
             // idempotent so the scene.traverse() pass above won't double-free.

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -2068,7 +2068,7 @@
         let gPMXFill = null; // shared geometry for PM X fill — disposed in teardown
         let gFHXFill = null; // shared geometry for FH X fill — disposed in teardown
         let pNoteFretLabel, pConnectorLine, pDropLine, pTapChevron, pAccentHalo;
-        let pChordAccentHalo = null; // per-instance cloned mats so opacity differs per shell
+        let pChordAccentHalo = null, gChordAccentHalo = null; // per-instance cloned mats so opacity differs per shell
         let pSusRibbon = null, pSusRibbonOl = null;
         let pFretColMarker;
         /** Horizontal gradient for chord box interior fill. */
@@ -3707,8 +3707,13 @@
             mAccentHaloFar = mkAccentHaloMats(ACCENT_HALO_OP_FAR);
             // Chord/arpeggio frame accent bloom — per-instance cloned materials
             // so near/far shells can have independent opacity values.
+            // Shared unit-box geometry — pooled halo meshes are scaled/rotated
+            // per draw, so one geometry serves the whole pool (same pattern as
+            // gNote / gSusRailBloom). Materials stay per-instance below so each
+            // accent shell can carry its own opacity.
+            gChordAccentHalo = new T.BoxGeometry(1, 1, 1);
             pChordAccentHalo = pool(noteG, () => new T.Mesh(
-                new T.BoxGeometry(1, 1, 1),
+                gChordAccentHalo,
                 new T.MeshBasicMaterial({
                     transparent: true, opacity: 0.8, depthWrite: false,
                     blending: T.AdditiveBlending, side: T.DoubleSide, fog: true,
@@ -8476,6 +8481,7 @@
             gSusRailBloom?.dispose?.(); mSusRailBloomBase?.dispose?.(); _bloomGaussTex?.dispose?.();
             gSusRailBloom = null; mSusRailBloomBase = null; _bloomGaussTex = null; pSusRailBloom = null;
             gTechPlane?.dispose?.(); gTechPlane = null; pTechPlane = null;
+            gChordAccentHalo?.dispose?.(); gChordAccentHalo = null;
             for (const m of mStr) m?.dispose?.();
             for (const m of mGlow) m?.dispose?.();
             for (const m of mSus) m?.dispose?.();

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -6380,25 +6380,17 @@
                                 fMaxCh = Math.max(fMaxCh, f);
                             }
                         }
-                        // Prefer the fretted-note span over the anchor span
-                        // when the chord has any fretted notes. The anchor
-                        // can legitimately cover a wide region (e.g. a
-                        // passage that roams frets 0–12), and using it
-                        // verbatim for the chord frame produced an
-                        // oversized box around chord shapes that mix open
-                        // and fretted strings (frame ran from the nut to
-                        // fret 12 for a chord whose only fretted notes were
-                        // at frets 2–3). The open strings in the chord
-                        // remain at the nut (drawn separately by the
-                        // open-string body); the frame just hugs the
-                        // fretted constituents now.
-                        if (anyFretted) {
-                            chordFrameXL = xFret(fMinCh - 1);
-                            chordFrameXR = xFret(Math.max(fMaxCh, fMinCh + 2));
-                        } else if (chAncB) {
+                        // Always prefer the anchor span so chord frames and
+                        // arpeggio frames align with the highway lane window.
+                        // Fretted-note span is only used when no anchor is
+                        // available (e.g. sloppak without anchor data).
+                        if (chAncB) {
                             chordFrameXL = xFret(chAncB.dMin);
                             chordFrameXR = xFret(chAncB.dMax);
                             chordFrameAnchorMatched = true;
+                        } else if (anyFretted) {
+                            chordFrameXL = xFret(fMinCh - 1);
+                            chordFrameXR = xFret(Math.max(fMaxCh, fMinCh + 2));
                         } else {
                             const wNut = openNoteLaneBoxW(ch.t);
                             chordFrameXL = chordCX - wNut * 0.5;

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -6349,7 +6349,14 @@
                     prevChordSig = runSig;
                     prevChordTime = ch.t;
 
-                    const chAncB = anchorLaneBoundsAt(anchors, ch.t);
+                    // For upcoming chords use the anchor at ch.t so the frame
+                    // previews the correct neck region. For lingering past chords
+                    // (chDt <= 0) use the anchor at `now` so the frame stays
+                    // aligned with the current lane as the song transitions between
+                    // anchor regions — otherwise a post-hit linger frame keeps its
+                    // old X while the lane has already moved to a new position.
+                    const chDtEarly = ch.t - now;
+                    const chAncB = anchorLaneBoundsAt(anchors, chDtEarly > 0 ? ch.t : now);
                     // Open-string X: chart <anchor> lane centre when present (not curX /
                     // fretted centroid), matching highway span.
                     let chordCX = curX;
@@ -6537,7 +6544,7 @@
                     }
 
                     // Chord frame-box: rim bars + interior fill gradient.
-                    const chDt = ch.t - now;
+                    const chDt = chDtEarly; // already computed above for anchor selection
                     const chordTailMul = hwyPostHitTailFadeMul(chDt, chordTailHoldS, chordNextSoon, chordTailFadeS);
                     if (chShape.size > 1 && chDt > -chordTailHoldS && chDt < AHEAD && chordOpenBoxW != null
                     ) {
@@ -6552,9 +6559,17 @@
                         const fullChordBoxH = yMaxF - yMinF;
                         let height = fullChordBoxH;
                         if (isRepeat) height *= 0.5;
-                        const cY = (yMinF + yMaxF) / 2;
-                        const yBot = cY - height * 0.5;
-                        const yTop = cY + height * 0.5;
+                        // Repeat frames use half height but anchor at yMinF (board
+                        // level) rather than centering in the string range. With the
+                        // camera tilted downward, a centered half-height frame puts
+                        // its bottom bar mid-strings — far above the board — causing
+                        // perspective-induced apparent X-misalignment with the lane
+                        // tiles (which sit at board level). Anchoring at yMinF keeps
+                        // the bottom bar near the board so both frame and lane tile
+                        // edges share the same projected screen X.
+                        const yBot = yMinF;
+                        const yTop = yMinF + height;
+                        const cY = (yBot + yTop) * 0.5;
                         const fade = Math.max(0, 1 - chDt / AHEAD);
                         const chordAccent = chordNotes.some(cn => cn.ac);
 

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -665,7 +665,9 @@
 
     // Build a horizontal gaussian DataTexture for the sustain-rail bloom effect.
     // Returns a W×1 RGBA texture where alpha follows exp(-0.5*(u−0.5)²/σ²),
-    // peaking at 1.0 in the centre and falling to ~0 at the edges.
+    // peaking at 1.0 in the centre. With the default σ=0.28 the edges retain
+    // ~0.20 alpha (not fully transparent) — a deliberately soft, wide falloff
+    // so the additive bloom fades gradually rather than cutting off sharply.
     // Power-of-two width keeps WebGL mipmapping happy.
     function _makeGaussTex(ThreeLib, w = 128, sigma = 0.28) {
         const data = new Uint8Array(w * 4);

--- a/plugins/highway_3d/settings.html
+++ b/plugins/highway_3d/settings.html
@@ -37,6 +37,29 @@
     </div>
 </div>
 
+<div role="group" aria-labelledby="h3d-fretboard-heading" class="mt-6">
+    <h3 id="h3d-fretboard-heading" class="text-sm font-medium text-gray-400 mb-2">3D Highway — Fretboard</h3>
+
+    <!-- Fret spacing -->
+    <div class="mt-3">
+        <label for="h3d-fret-spacing" class="text-xs font-medium text-gray-400 mb-1 block">Fret spacing</label>
+        <select id="h3d-fret-spacing"
+            onchange="window.h3dSetFretSpacing && window.h3dSetFretSpacing(this.value)"
+            class="w-full bg-dark-700 border border-gray-800 rounded-lg px-3 py-2 text-xs text-gray-300 outline-none">
+            <option value="uniform">Uniform (equal width per fret — Rocksmith style)</option>
+            <option value="logarithmic">Instrument (logarithmic — decreasing toward bridge)</option>
+        </select>
+        <p class="text-xs text-gray-500 mt-1">A página será recarregada ao alterar.</p>
+    </div>
+
+    <script>
+    (function () {
+        const sel = document.getElementById('h3d-fret-spacing');
+        if (sel) sel.value = localStorage.getItem('h3dFretSpacing') === 'logarithmic' ? 'logarithmic' : 'uniform';
+    })();
+    </script>
+</div>
+
 <div role="group" aria-labelledby="h3d-bg-heading" class="mt-6">
     <h3 id="h3d-bg-heading" class="text-sm font-medium text-gray-400 mb-2">3D Highway — Background</h3>
     <p class="text-xs text-gray-500 mb-3">

--- a/plugins/highway_3d/settings.html
+++ b/plugins/highway_3d/settings.html
@@ -55,7 +55,13 @@
     <script>
     (function () {
         const sel = document.getElementById('h3d-fret-spacing');
-        if (sel) sel.value = localStorage.getItem('h3dFretSpacing') === 'logarithmic' ? 'logarithmic' : 'uniform';
+        if (sel) {
+            try {
+                sel.value = localStorage.getItem('highway_3d.fretSpacing') === 'logarithmic' ? 'logarithmic' : 'uniform';
+            } catch (_) {
+                sel.value = 'uniform';
+            }
+        }
     })();
     </script>
 </div>

--- a/plugins/highway_3d/settings.html
+++ b/plugins/highway_3d/settings.html
@@ -49,7 +49,7 @@
             <option value="uniform">Uniform (equal width per fret — Rocksmith style)</option>
             <option value="logarithmic">Instrument (logarithmic — decreasing toward bridge)</option>
         </select>
-        <p class="text-xs text-gray-500 mt-1">A página será recarregada ao alterar.</p>
+        <p class="text-xs text-gray-500 mt-1">The page will reload when changed.</p>
     </div>
 
     <script>

--- a/tests/js/highway_3d_fret_spacing.test.js
+++ b/tests/js/highway_3d_fret_spacing.test.js
@@ -1,0 +1,44 @@
+// Pins the fret-spacing setting in plugins/highway_3d/screen.js (PR #329).
+// The board can render fret columns either Uniform (equal width, Rocksmith
+// Remastered style) or Logarithmic (real instrument geometry), switchable at
+// runtime via window.h3dSetFretSpacing and persisted in localStorage. A
+// refactor that renames the storage key, drops the uniform/log branch in
+// fretX, or stops validating the mode would silently regress the setting.
+//
+// Source-level only — same strategy as the other tests/js/ files.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+test('fret-spacing mode is read from the highway_3d.fretSpacing localStorage key', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /_h3dFretUniform\s*=\s*localStorage\.getItem\(\s*'highway_3d\.fretSpacing'\s*\)\s*!==\s*'logarithmic'/,
+        'startup must read highway_3d.fretSpacing and treat anything but "logarithmic" as uniform',
+    );
+});
+
+test('fretX switches between the uniform and logarithmic implementations', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /const\s+fretX\s*=\s*f\s*=>\s*_h3dFretUniform\s*\?\s*_fretXUni\(f\)\s*:\s*_fretXLog\(f\)/,
+        'fretX must pick _fretXUni when _h3dFretUniform else _fretXLog',
+    );
+});
+
+test('h3dSetFretSpacing validates the mode against the two supported values', () => {
+    // An unexpected input must not be persisted verbatim — it is coerced to
+    // one of 'logarithmic' | 'uniform' before writing to localStorage.
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /window\.h3dSetFretSpacing\s*=\s*mode\s*=>\s*\{[\s\S]*?mode\s*===\s*'logarithmic'\s*\?\s*'logarithmic'\s*:\s*'uniform'[\s\S]*?localStorage\.setItem\(\s*'highway_3d\.fretSpacing'/,
+        'h3dSetFretSpacing must coerce mode to a supported value before persisting',
+    );
+});

--- a/tests/js/highway_3d_slide_target.test.js
+++ b/tests/js/highway_3d_slide_target.test.js
@@ -1,0 +1,62 @@
+// Pins slide-target gem suppression in plugins/highway_3d/screen.js (PR #329).
+// A note that is the slide/link destination of a preceding sustained note has
+// its gem body suppressed (skipBody=true) so it does not render a duplicate
+// gem on top of the slide trail — but the sustain/slide trail itself still
+// renders so the slide motion stays visible. A refactor that drops the
+// _slideTargetSet pre-pass, stops threading _isSlideTgt into drawNote, or
+// moves the trail back inside the !skipBody gate would silently reintroduce
+// duplicate gems or erase slide trails.
+//
+// Source-level only — same strategy as the other tests/js/ files.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+test('a _slideTargetSet pre-pass builds the suppressed-gem set from bundle.notes', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /const\s+checkSrc\s*=\s*\([^)]*\)\s*=>\s*\{[\s\S]*?stSet\.add\(/,
+        'pre-pass checkSrc must populate the slide-target set',
+    );
+    assert.match(
+        src,
+        /if\s*\(\s*stSet\.size\s*>\s*0\s*\)\s*_slideTargetSet\s*=\s*stSet/,
+        '_slideTargetSet must be assigned from the pre-pass result',
+    );
+});
+
+test('_isSlideTgt is derived from _slideTargetSet membership', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /_isSlideTgt\s*=\s*!!\(\s*_slideTargetSet\s*&&\s*_slideTargetSet\.has\(/,
+        '_isSlideTgt must test _slideTargetSet membership',
+    );
+});
+
+test('_isSlideTgt is threaded into drawNote as the skipBody argument', () => {
+    // drawNote(n, now, openX, skipLabel, skipBody, ...) — _isSlideTgt sits in
+    // the 5th (skipBody) position so the gem body is suppressed.
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /drawNote\(\s*\n\s*n,\s*\n\s*now,\s*\n\s*singleOpenX,\s*\n\s*skipLabel,\s*\n\s*_isSlideTgt,/,
+        '_isSlideTgt must be passed as drawNote\'s skipBody argument',
+    );
+});
+
+test('the sustain trail renders for all notes, including skipBody slide targets', () => {
+    // The trail block must stay outside the !skipBody gem gate so suppressed
+    // slide-target gems still show their slide trail.
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /Rendered for ALL notes with sustain, including skipBody=true/,
+        'the sustain-trail comment contract must remain, marking the trail as unconditional',
+    );
+});

--- a/tests/js/highway_3d_slide_target.test.js
+++ b/tests/js/highway_3d_slide_target.test.js
@@ -45,7 +45,7 @@ test('_isSlideTgt is threaded into drawNote as the skipBody argument', () => {
     const src = fs.readFileSync(SCREEN_JS, 'utf8');
     assert.match(
         src,
-        /drawNote\(\s*\n\s*n,\s*\n\s*now,\s*\n\s*singleOpenX,\s*\n\s*skipLabel,\s*\n\s*_isSlideTgt,/,
+        /drawNote\(\s*n\s*,\s*now\s*,\s*singleOpenX\s*,\s*skipLabel\s*,\s*_isSlideTgt\s*,/,
         '_isSlideTgt must be passed as drawNote\'s skipBody argument',
     );
 });

--- a/tests/js/highway_3d_sustain_bloom.test.js
+++ b/tests/js/highway_3d_sustain_bloom.test.js
@@ -1,0 +1,49 @@
+// Pins the sustain bloom glow in plugins/highway_3d/screen.js (PR #329).
+// Sustained chord rails get a soft gaussian glow: a DataTexture gaussian
+// (_makeGaussTex) drives a wider, additive-blended plane mesh (pSusRailBloom)
+// rendered behind the core rail. A refactor that drops the gaussian texture,
+// stops using additive blending, or bumps the bloom renderOrder above the
+// core rail (16) would silently regress or invert the effect.
+//
+// Source-level only — same strategy as the other tests/js/ files.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+test('a gaussian DataTexture helper (_makeGaussTex) drives the bloom falloff', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /function\s+_makeGaussTex\s*\(/,
+        '_makeGaussTex must exist to build the bloom gaussian texture',
+    );
+    assert.match(
+        src,
+        /_bloomGaussTex\s*=\s*_makeGaussTex\(/,
+        'the bloom texture must be produced by _makeGaussTex',
+    );
+});
+
+test('the bloom rail material uses additive blending', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /mSusRailBloomBase\s*=\s*new\s+T\.MeshBasicMaterial\(\{[\s\S]*?blending:\s*T\.AdditiveBlending[\s\S]*?\}\)/,
+        'mSusRailBloomBase must blend additively so it brightens what is behind it',
+    );
+});
+
+test('the bloom pool seeds meshes at renderOrder 14, behind the core rail (16)', () => {
+    // renderOrder 14 keeps the bloom behind the core sustain rail (16) so the
+    // glow reads as a trail rather than occluding the rail.
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /pSusRailBloom\s*=\s*pool\([^)]*,\s*\(\)\s*=>\s*\{[\s\S]*?m\.renderOrder\s*=\s*14\s*;[\s\S]*?\}\s*\)/,
+        'pSusRailBloom pool must seed meshes with renderOrder = 14',
+    );
+});


### PR DESCRIPTION
## Summary

### 🆕 Frethand-Mute Chord Strum Indicator
Adds a dedicated FH X symbol to the 3D highway chord box, analogous to the
existing PM strum indicator. Appears on `isRepeat` chords where any note carries
`mt: true` (frethand mute).

- **`gFHXFill` geometry** — `BufferGeometry` with 12 vertices and 10 triangles
  covering 4 corner quadrants + centre diamond. Lateral wings stop at `fx = ±0.50`
  (no solid side blocks), distinguishing it visually from the PM symbol (full width).
- **8-line `FH_XLINES`** — L/R convergence nodes at `fx = ±0.28`, T/B at
  `fy = ±0.42`; outer terminals on top/bottom borders at `fx = ±0.50` (wings) and
  `fx = ±0.15` (arms).
- **`pFHXFill` pool** — same material setup (`MeshBasicMaterial`, `depthTest: false`,
  `renderOrder 10.5`) as `pPMXFill`, wired into reset and teardown alongside it.
- Design files (`chord_strum_pm_preview.html`, `chord_strum_pm_editor.html`) updated
  to match final geometry.

### 🌟 Sustain Bloom
Adds a soft gaussian bloom layer to sustain rails via a dedicated `pSusRailBloom`
pool. A `DataTexture` gaussian (`_makeGaussTex`) drives a wider, additive-blended
plane mesh behind the core rail, giving sustained notes a glowing trail effect.

### 🎸 Technique Marker Overhaul
- **Pinch-harmonic icon** redesigned: 5-form concentric ellipse (black border →
  string-colour body → black ring → string-colour inner → black dot), rasterised
  at 512 px for crispness.
- **Mute X** (`pm` / `mt`) redrawn with `lineCap: 'square'`, proper `pad ≥
  outerW / √2` to prevent clipped caps, each diagonal stroked independently for
  a clean border at every tip and edge.
- **`_spriteMat2MeshMat()`** — converts any `SpriteMaterial` to a
  `MeshBasicMaterial` sharing its canvas texture, so technique markers rotate
  with the gem (`approachRot`) on a `PlaneGeometry` mesh instead of billboarding.

### ⚙️ Fret Spacing Setting
- Adds **Uniform** (equal-width per fret, Rocksmith Remastered style) and
  **Logarithmic** (real instrument geometry) fret-spacing modes, switchable at
  runtime via `window.h3dSetFretSpacing(mode)` (persisted in `localStorage`).
- New **"3D Highway — Fretboard"** section in `settings.html` with a `<select>`
  that reloads the page on change.

### 🔧 Slide-Target Gem Suppression
Tracks `linkNext` destination notes via `_slideTargetSet` to suppress duplicate
gem bodies on slide targets — the sustain/slide trail still renders so the slide
motion stays visible.

## Files changed
| File | Changes |
|------|---------|
| `plugins/highway_3d/screen.js` | FH geometry + pool, sustain bloom, technique marker rework, slide-target suppression, fret-spacing toggle |
| `plugins/highway_3d/settings.html` | Fret spacing selector (Uniform / Logarithmic) |
| `plugins/highway_3d/plugin.json` | Version bump `3.16.0 → 3.17.0` |

## Test plan
- [ ] FH chord strum: repeat muted chords show the FH X symbol; first chord shows only the frame
- [ ] PM chord strum: unchanged — still shows on repeat PM chords
- [ ] Sustain trails glow visibly on long notes
- [ ] Pinch-harmonic icon renders as concentric ellipses (no square artefacts)
- [ ] Mute X tips are clean at all four corners
- [ ] Fret spacing toggle in Settings → reloads and applies Uniform / Logarithmic correctly
- [ ] Slide notes: target gem body suppressed, trail still visible

## Screenshots 
- Chord Strum Frethand Mute:
<img width="240" height="93" alt="image" src="https://github.com/user-attachments/assets/dfb8ed2e-53ee-4ac8-9b93-a393c2fa434e" />

- Chord Strum Palm Mute:
<img width="240" height="89" alt="image" src="https://github.com/user-attachments/assets/bf0f99fd-9e8a-43c9-917f-b59df9ca9095" />

- Sustain Bloom (accent chord):
<img width="309" height="178" alt="image" src="https://github.com/user-attachments/assets/034cc1bb-249e-4551-ac6b-89af06052cdf" />

- Pinch Harmonic symbol:
<img width="332" height="314" alt="image" src="https://github.com/user-attachments/assets/d31fd336-1989-4835-928b-8aa881e7a624" />

- Palm mute symbol: 
<img width="75" height="42" alt="image" src="https://github.com/user-attachments/assets/7d6e6024-f082-4db8-b532-21dc1bb85c24" />

- Frethand Mute:
<img width="87" height="104" alt="image" src="https://github.com/user-attachments/assets/00b069ac-aba6-4f19-9bdb-eef0e70d08fc" />

- New "3D Highway — Fretboard" section in settings.html:
<img width="605" height="134" alt="image" src="https://github.com/user-attachments/assets/cd70450c-786d-47cc-b7cc-d5ecef1a9a65" />

- New fret-spacing mode view:
<img width="972" height="633" alt="image" src="https://github.com/user-attachments/assets/7f0c6264-34a8-4ffe-956f-e9d81830183c" />
