### PR TITLE
fix(player): speed slider works under JUCE routing

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -3825,7 +3825,8 @@ function setSpeed(v) {
     }
     if (window._juceMode) {
         window.jucePlayer?.setRate(rate);
-        window.slopsmithDesktop?.audio?.setBackingSpeed(rate);
+        Promise.resolve(window.slopsmithDesktop?.audio?.setBackingSpeed(rate))
+            .catch(err => console.warn('[setSpeed] setBackingSpeed failed:', err));
     } else {
         audio.playbackRate = rate;
     }

--- a/static/app.js
+++ b/static/app.js
@@ -3825,7 +3825,8 @@ function setSpeed(v) {
     }
     if (window._juceMode) {
         window.jucePlayer?.setRate(rate);
-        Promise.resolve(window.slopsmithDesktop?.audio?.setBackingSpeed(rate))
+        Promise.resolve()
+            .then(() => window.slopsmithDesktop?.audio?.setBackingSpeed(rate))
             .catch(err => console.warn('[setSpeed] setBackingSpeed failed:', err));
     } else {
         audio.playbackRate = rate;

--- a/static/app.js
+++ b/static/app.js
@@ -3067,7 +3067,7 @@ window.jucePlayer = jucePlayer;
             }
             window._juceMode = true;
             window._juceAudioUrl = url;
-            const _spSlider = document.getElementById('speed-slider');
+            const _spSlider = document.getElementById?.('speed-slider');
             if (_spSlider) setSpeed(_spSlider.value / 100);
             audio.src = '';
             try {
@@ -3129,7 +3129,7 @@ window.jucePlayer = jucePlayer;
             window._juceAudioUrl = null;
             audio.src = url;
             audio.load();
-            const _spSlider = document.getElementById('speed-slider');
+            const _spSlider = document.getElementById?.('speed-slider');
             if (_spSlider) setSpeed(_spSlider.value / 100);
             // Resume only AFTER the seek so playback starts at `pos`, not at 0
             // with an audible jump once metadata arrives.

--- a/static/app.js
+++ b/static/app.js
@@ -3814,10 +3814,19 @@ async function seekBy(s) {
 }
 function setSpeed(v) {
     const speedSlider = document.getElementById('speed-slider');
-    const rate = parseFloat(v);
+    const rate = Number(v);
+    if (!Number.isFinite(rate)) {
+        return;
+    }
     if (window._juceMode) {
+        if (window.jucePlayer) { 
+            window.jucePlayer._pos = window.jucePlayer.currentTime;
+            window.jucePlayer._pollAt = performance.now();
+        }
         window.slopsmithDesktop.audio.setBackingSpeed(rate);
-        if (window.jucePlayer) window.jucePlayer._speed = rate;
+        if (window.jucePlayer) {
+            window.jucePlayer._speed = rate;
+        }
     } else {
         audio.playbackRate = rate;
     }

--- a/static/app.js
+++ b/static/app.js
@@ -2944,6 +2944,11 @@ const jucePlayer = {
         this._polling = false;
         if (this._timer) { clearTimeout(this._timer); this._timer = null; }
     },
+    setRate(rate) {
+        this._pos = this.currentTime;
+        this._pollAt = performance.now();
+        this._speed = rate;
+    },
     async stop() {
         await this.pause();
         this._pos = 0;
@@ -3819,18 +3824,13 @@ function setSpeed(v) {
         return;
     }
     if (window._juceMode) {
-        if (window.jucePlayer) { 
-            window.jucePlayer._pos = window.jucePlayer.currentTime;
-            window.jucePlayer._pollAt = performance.now();
-        }
-        window.slopsmithDesktop.audio.setBackingSpeed(rate);
-        if (window.jucePlayer) {
-            window.jucePlayer._speed = rate;
-        }
+        window.jucePlayer?.setRate(rate);
+        window.slopsmithDesktop?.audio?.setBackingSpeed(rate);
     } else {
         audio.playbackRate = rate;
     }
-    document.getElementById('speed-label').textContent = rate.toFixed(2) + 'x';
+    const speedLabel = document.getElementById('speed-label');
+    if (speedLabel) speedLabel.textContent = rate.toFixed(2) + 'x';
     handleSliderInput(speedSlider);
 }
 // Master-difficulty slider (slopsmith#48). Persists partial via

--- a/static/app.js
+++ b/static/app.js
@@ -2876,11 +2876,13 @@ const jucePlayer = {
     _dur: 0,
     _pollAt: 0,    // performance.now() when _pos was last set
     _polling: false,
+    _speed: 1,
     get currentTime() {
         if (!this._polling) return this._pos;
         // Interpolate between IPC polls so highway motion is smooth at 60fps
+        // Scale by _speed so at 0.7x the interpolated clock advances 0.7s/s
         const elapsed = (performance.now() - this._pollAt) / 1000;
-        return Math.min(this._pos + elapsed, this._dur > 0 ? this._dur : Infinity);
+        return Math.min(this._pos + elapsed * this._speed, this._dur > 0 ? this._dur : Infinity);
     },
     get duration() { return this._dur; },
     async play() {
@@ -2947,6 +2949,7 @@ const jucePlayer = {
         this._pos = 0;
         this._dur = 0;
         this._pollAt = 0;
+        this._speed = 1;
     },
 };
 window.jucePlayer = jucePlayer;
@@ -3059,6 +3062,8 @@ window.jucePlayer = jucePlayer;
             }
             window._juceMode = true;
             window._juceAudioUrl = url;
+            const _spSlider = document.getElementById('speed-slider');
+            if (_spSlider) setSpeed(_spSlider.value / 100);
             audio.src = '';
             try {
                 const apply = window.slopsmith?.audio?.applySongVolume;
@@ -3119,6 +3124,8 @@ window.jucePlayer = jucePlayer;
             window._juceAudioUrl = null;
             audio.src = url;
             audio.load();
+            const _spSlider = document.getElementById('speed-slider');
+            if (_spSlider) setSpeed(_spSlider.value / 100);
             // Resume only AFTER the seek so playback starts at `pos`, not at 0
             // with an audible jump once metadata arrives.
             const resumeAtPos = () => {
@@ -3807,15 +3814,14 @@ async function seekBy(s) {
 }
 function setSpeed(v) {
     const speedSlider = document.getElementById('speed-slider');
+    const rate = parseFloat(v);
     if (window._juceMode) {
-        audio.playbackRate = 1.0;
-        speedSlider.value = 100;
-        document.getElementById('speed-label').textContent = '1.0x';
-        handleSliderInput(speedSlider);
-        return;
+        window.slopsmithDesktop.audio.setBackingSpeed(rate);
+        if (window.jucePlayer) window.jucePlayer._speed = rate;
+    } else {
+        audio.playbackRate = rate;
     }
-    audio.playbackRate = parseFloat(v);
-    document.getElementById('speed-label').textContent = parseFloat(v).toFixed(2) + 'x';
+    document.getElementById('speed-label').textContent = rate.toFixed(2) + 'x';
     handleSliderInput(speedSlider);
 }
 // Master-difficulty slider (slopsmith#48). Persists partial via

--- a/static/style.css
+++ b/static/style.css
@@ -339,7 +339,7 @@ html { scroll-behavior: smooth; }
 #lib-filter-drawer .filter-pill::before {
     content: '';
     display: inline-block;
-    width: 12px;
+    width: 8px;
     height: 8px;
     border-radius: 50%;
     background: rgba(156, 163, 175, 0.4);

--- a/static/style.css
+++ b/static/style.css
@@ -524,12 +524,16 @@ html { scroll-behavior: smooth; }
 
 .slider-input::-webkit-slider-thumb {
   -webkit-appearance: none;
-  height: 0px;
-  width: 0px;
+  height: 22px;
+  width: 8px;
   background: #ffffff;
-  border-radius: 0px;
-  margin-top: 9px;
+  border-radius: 4px;
+  margin-top: 1px;
+  cursor: grab;
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 0.4);
 }
+
+.slider-input::-webkit-slider-thumb:active { cursor: grabbing; }
 
 /* --- Firefox --- */
 .slider-input::-moz-range-track {
@@ -540,10 +544,14 @@ html { scroll-behavior: smooth; }
 }
 
 .slider-input::-moz-range-thumb {
-  height: 0px;
-  width: 0px;
+  height: 22px;
+  width: 8px;
   background: #ffffff;
-  border-radius: 0px;
+  border-radius: 4px;
   border: 0;
+  cursor: grab;
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 0.4);
 }
+
+.slider-input::-moz-range-thumb:active { cursor: grabbing; }
 /* ////// end sliders /////// */

--- a/static/style.css
+++ b/static/style.css
@@ -339,7 +339,7 @@ html { scroll-behavior: smooth; }
 #lib-filter-drawer .filter-pill::before {
     content: '';
     display: inline-block;
-    width: 8px;
+    width: 12px;
     height: 8px;
     border-radius: 50%;
     background: rgba(156, 163, 175, 0.4);
@@ -525,7 +525,7 @@ html { scroll-behavior: smooth; }
 .slider-input::-webkit-slider-thumb {
   -webkit-appearance: none;
   height: 22px;
-  width: 8px;
+  width: 12px;
   background: #ffffff;
   border-radius: 4px;
   margin-top: 1px;
@@ -545,7 +545,7 @@ html { scroll-behavior: smooth; }
 
 .slider-input::-moz-range-thumb {
   height: 22px;
-  width: 8px;
+  width: 12px;
   background: #ffffff;
   border-radius: 4px;
   border: 0;

--- a/static/style.css
+++ b/static/style.css
@@ -348,7 +348,7 @@ html { scroll-behavior: smooth; }
 #lib-filter-drawer .filter-pill.state-exclude::before {
     background: #f87171;
     /* tiny minus indicator: use a horizontal bar instead of dot */
-    width: 10px;
+    width: 12px;
     height: 2px;
     border-radius: 1px;
 }


### PR DESCRIPTION
The speed slider was not working in the desktop app. `setSpeed` did not work (even in the console) since JUCE was not supported. After that was fixed, the slider wasn't selectable in desktop. Added a white slider input grabber so it works on the HTML5 docker version and the desktop version.

Once https://github.com/byrongamatos/slopsmith-desktop/pull/209 lands, this PR can merge and https://github.com/byrongamatos/slopsmith-desktop/issues/164 will be fully addressed.