### PR TITLE
fix(plugins): read plugin.json as UTF-8

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -619,7 +619,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             if not manifest_path.exists():
                 continue
             try:
-                manifest = json.loads(manifest_path.read_text())
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
             except Exception as e:
                 log.warning("Failed to read plugin manifest %s: %s", manifest_path, e)
                 continue


### PR DESCRIPTION
## Summary

- `Path.read_text()` with no `encoding=` argument defaults to `locale.getpreferredencoding(False)`. On Windows that's the system code page (cp1252 / cp1250 / GBK / etc.), not UTF-8.
- The bundled `audio_engine` plugin in slopsmith-desktop uses 🎸 (U+1F3B8) as its nav icon. Its UTF-8 bytes (`f0 9f 8e b8`) decode as garbage / `UnicodeDecodeError` under non-UTF-8 system locales.
- The loader's broad `except Exception` swallows the error and the plugin silently fails to register — Windows users see no "Audio" tab in the nav.
- RFC 8259 §8.1 requires JSON to be UTF-8. Pass `encoding="utf-8"` explicitly.

Reported by Windows users.

## Test plan

- [x] `python -c "json.loads(open(...).read())"` on the audio_engine manifest works on UTF-8 hosts
- [ ] Manual: Windows user confirms the Audio tab appears after this lands