### PR TITLE
fix(player): preserve pitch when changing playback speed

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -2867,11 +2867,9 @@ let isPlaying = false;
 
 function _applyPreservePitch(el) {
     if (!el) return;
-    try {
-        el.preservesPitch = true;
-        el.mozPreservesPitch = true;
-        el.webkitPreservesPitch = true;
-    } catch (_) {}
+    if ('preservesPitch' in el) el.preservesPitch = true;
+    if ('mozPreservesPitch' in el) el.mozPreservesPitch = true;
+    if ('webkitPreservesPitch' in el) el.webkitPreservesPitch = true;
 }
 _applyPreservePitch(audio);
 

--- a/static/app.js
+++ b/static/app.js
@@ -2865,6 +2865,16 @@ function retuneSong(filename, title, tuning, target) {
 const audio = document.getElementById('audio');
 let isPlaying = false;
 
+function _applyPreservePitch(el) {
+    if (!el) return;
+    try {
+        el.preservesPitch = true;
+        el.mozPreservesPitch = true;
+        el.webkitPreservesPitch = true;
+    } catch (_) {}
+}
+_applyPreservePitch(audio);
+
 // In Slopsmith Desktop, WASAPI Exclusive Mode locks the audio device so Chromium
 // cannot play through it. When window._juceMode is true, song audio is routed
 // through the JUCE backing track player instead of the HTML5 <audio> element.
@@ -3599,6 +3609,7 @@ function _adjustSongVolume(delta) {
 // (slopsmith#54). Delegates to audio-mixer's readSongVolume when loaded so
 // the in-memory fallback (for storage-blocked contexts) is authoritative.
 audio.addEventListener('loadedmetadata', () => {
+    _applyPreservePitch(audio);
     const applySongVolume = window.slopsmith?.audio?.applySongVolume;
     if (typeof applySongVolume === 'function') {
         void applySongVolume();

--- a/static/app.js
+++ b/static/app.js
@@ -3834,9 +3834,14 @@ function setSpeed(v) {
     }
     if (window._juceMode) {
         window.jucePlayer?.setRate(rate);
+        const juceAudio = window.slopsmithDesktop?.audio;
         Promise.resolve()
-            .then(() => window.slopsmithDesktop?.audio?.setBackingSpeed(rate))
-            .catch(err => console.warn('[setSpeed] setBackingSpeed failed:', err));
+            .then(() => juceAudio?.setBackingSpeed(rate))
+            // Match the HTML5 path: preserve pitch on the JUCE backing track too.
+            // Optional-chained call is a no-op on desktop builds that predate
+            // setBackingPreservePitch, so this is safe to ship unconditionally.
+            .then(() => juceAudio?.setBackingPreservePitch?.(true))
+            .catch(err => console.warn('[setSpeed] backing speed/preserve-pitch failed:', err));
     } else {
         audio.playbackRate = rate;
     }

--- a/static/index.html
+++ b/static/index.html
@@ -405,7 +405,7 @@
                 if (_waCtx.state === 'suspended') _waCtx.resume();
                 _waSource = _waCtx.createBufferSource();
                 _waSource.buffer = _waBuffer;
-                // AudioBufferSourceNode has no preservesPitch equivalent so this path always resamples pitch
+                // AudioBufferSourceNode has no preservesPitch equivalent so changing playbackRate here also changes pitch
                 _waSource.playbackRate.value = audioEl.playbackRate || 1;
                 _waSource.connect(_waCtx.destination);
                 _waStartTime = _waCtx.currentTime;

--- a/static/index.html
+++ b/static/index.html
@@ -405,6 +405,7 @@
                 if (_waCtx.state === 'suspended') _waCtx.resume();
                 _waSource = _waCtx.createBufferSource();
                 _waSource.buffer = _waBuffer;
+                // AudioBufferSourceNode has no preservesPitch equivalent so this path always resamples pitch
                 _waSource.playbackRate.value = audioEl.playbackRate || 1;
                 _waSource.connect(_waCtx.destination);
                 _waStartTime = _waCtx.currentTime;


### PR DESCRIPTION
When adjusting speed, pitch wasn't preserved. This should preserve pitch in most scenarios for the HTML5 build. There will need to be a separate JUCE fix for slopsmith-desktop.
