### PR TITLE
Add Folder Organizer to available plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Tuner](https://github.com/OmikronApex/slopsmith-plugin-tuner)                      | Floating tuner with customizable tunings   | `git clone ...slopsmith-plugin-tuner.git tuner`                         |
 | [Simplify Chords](https://github.com/bkranendonk/slopsmith-plugin-simplify-chords)  | Changes complex chords on the note highway to simpler ones. Inspired by Ultimate Guitar's Simplify button. | `git clone ...slopsmith-plugin-simplify-chords.git simplify-chords`     |
 | [Key Bindings](https://github.com/jackipicco/slopsmith-plugin-key-bindings)  | Highway key bindings for keyboard and TV remote| `git clone ...slopsmith-plugin-key-bindings.git key_bindings`     |
+| [Folder Organizer]https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name| `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
 
 
 Install any plugin by cloning it into your `plugins/` directory and restarting:

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Tuner](https://github.com/OmikronApex/slopsmith-plugin-tuner)                      | Floating tuner with customizable tunings   | `git clone ...slopsmith-plugin-tuner.git tuner`                         |
 | [Simplify Chords](https://github.com/bkranendonk/slopsmith-plugin-simplify-chords)  | Changes complex chords on the note highway to simpler ones. Inspired by Ultimate Guitar's Simplify button. | `git clone ...slopsmith-plugin-simplify-chords.git simplify-chords`     |
 | [Key Bindings](https://github.com/jackipicco/slopsmith-plugin-key-bindings)  | Highway key bindings for keyboard and TV remote| `git clone ...slopsmith-plugin-key-bindings.git key_bindings`     |
-| [Folder Organizer](https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name| `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
+| [Folder Organizer](https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name | `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
 
 
 Install any plugin by cloning it into your `plugins/` directory and restarting:

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Tuner](https://github.com/OmikronApex/slopsmith-plugin-tuner)                      | Floating tuner with customizable tunings   | `git clone ...slopsmith-plugin-tuner.git tuner`                         |
 | [Simplify Chords](https://github.com/bkranendonk/slopsmith-plugin-simplify-chords)  | Changes complex chords on the note highway to simpler ones. Inspired by Ultimate Guitar's Simplify button. | `git clone ...slopsmith-plugin-simplify-chords.git simplify-chords`     |
 | [Key Bindings](https://github.com/jackipicco/slopsmith-plugin-key-bindings)  | Highway key bindings for keyboard and TV remote| `git clone ...slopsmith-plugin-key-bindings.git key_bindings`     |
-| [Folder Organizer]https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name| `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
+| [Folder Organizer](https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name| `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
 
 
 Install any plugin by cloning it into your `plugins/` directory and restarting:


### PR DESCRIPTION
Adds the Folder Organizer plugin — organizes sloppak DLC songs into a collapsible folder tree with list and grid views, album art, live search, drag-and-drop, and folder management.