### PR TITLE
Add NAM Rig Builder to Available Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Simplify Chords](https://github.com/bkranendonk/slopsmith-plugin-simplify-chords)  | Changes complex chords on the note highway to simpler ones. Inspired by Ultimate Guitar's Simplify button. | `git clone ...slopsmith-plugin-simplify-chords.git simplify-chords`     |
 | [Key Bindings](https://github.com/jackipicco/slopsmith-plugin-key-bindings)  | Highway key bindings for keyboard and TV remote| `git clone ...slopsmith-plugin-key-bindings.git key_bindings`     |
 | [Folder Organizer](https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name | `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
+| [NAM Rig Builder](https://github.com/Jafz2001/slopsmith-plugin-nam-rig-builder) | Map Rocksmith tones to chained NAM neural-amp rigs (tone3000 captures + IRs) — full pedal→amp→cab playback, per-stage bypass, and a gear catalog | `git clone ...slopsmith-plugin-nam-rig-builder.git nam_rig_builder` |
 
 
 Install any plugin by cloning it into your `plugins/` directory and restarting:


### PR DESCRIPTION
Adds **NAM Rig Builder** to the Available Plugins registry table.

**Repo:** https://github.com/Jafz2001/slopsmith-plugin-nam-rig-builder
**Install dir:** `nam_rig_builder`

### What it does
Maps Rocksmith 2014 tones (amp + cab + pedals + racks) to tone3000 NAM
captures + IRs and plays each song through the full **pedal → amp → cab**
neural chain. Companion to the `nam_tone` engine plugin.

- Full multi-NAM chain in real playback (scoped `fetch` redirect — no app
  bundle edits, survives updates).
- Per-tone live preview, per-stage bypass (persisted), gear catalog with
  tone3000 capture photos + isolated audition.
- Gear map generated from the game's own `gears.psarc`; extracts Rocksmith's
  444 cab IRs. Works in deep-link mode (no key) or tone3000 API mode.

Follows the standard plugin format (`plugin.json`, `routes.py`,
`screen.html`/`screen.js`). Docs (`README.md`, `HANDOFF.md`, `CLAUDE.md`)
are in the repo.