### PR TITLE
feat: karaoke per-syllable pitch extraction during sloppak convert

### DIFF
--- a/docs/sloppak-spec.md
+++ b/docs/sloppak-spec.md
@@ -81,6 +81,8 @@ Full set of currently-recognized top-level keys:
 | `lyrics` | string | no | Path to lyrics JSON |
 | `lyrics_source` | string | no | Where the lyrics came from: `xml` (Rocksmith vocals.xml), `sng` (encrypted Rocksmith vocals.sng), `whisperx` (auto-transcribed), or `user` (hand-edited). Absent on legacy sloppaks — readers should treat missing as `xml` |
 | `lyric_transcription` | object | no | Structured metadata when lyrics came from an automated engine (currently `whisperx`). Same shape as the parent `stem_separation` block defined by [slopsmith#357](https://github.com/byrongamatos/slopsmith/issues/357) — see §2.3 for fields and semver semantics. Omitted for authored lyrics (`xml`/`sng`/`user`) |
+| `vocal_pitch` | string | no | Path to per-syllable pitch JSON (`{"version": 1, "notes": [{t, d, midi}, ...]}`). Consumed by [slopsmith-plugin-lyrics-karaoke](https://github.com/byrongamatos/slopsmith-plugin-lyrics-karaoke) to render karaoke note bars. See §2.4 |
+| `pitch_extraction` | object | no | Structured metadata when pitch was extracted by an automated engine (currently `crepe` via the demucs server's `/pitch` endpoint). Same shape as `stem_separation` / `lyric_transcription`. Omitted for hand-edited pitch tracks |
 | `cover` | string | no | Path to cover image |
 
 Unknown keys are **silently ignored** by the loader. This is deliberate — it's the extensibility hook (see §5).
@@ -156,6 +158,38 @@ Fields:
 - `version` — semver for Slopsmith's lyric-transcription artifact contract (independent of upstream Whisper / WhisperX versions). Bump per the same semantics #357 defines for stems: patch = metadata-only fixes, minor = backward-compatible additions, major = output shape changed and existing transcriptions should be regenerated.
 
 Omitted for authored lyrics (`xml` / `sng` / `user`). A remote WhisperX server can use this block as part of a cache key the same way #357 envisions for stems — caches should miss whenever any of the three fields change, ensuring stale transcriptions don't get returned after a model bump.
+
+### 2.4. `vocal_pitch`
+
+If present, points at a JSON file holding per-syllable pitch data — the karaoke companion to `lyrics`. Consumed by [slopsmith-plugin-lyrics-karaoke](https://github.com/byrongamatos/slopsmith-plugin-lyrics-karaoke) to render karaoke-style note bars over the lyric text. Shape:
+
+```json
+{
+  "version": 1,
+  "notes": [
+    {"t": 12.34, "d": 0.40, "midi": 64},
+    {"t": 12.78, "d": 0.55, "midi": 67}
+  ]
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `version` | Schema version (currently `1`). Bumped per the same rules as the manifest blocks |
+| `notes` | List of pitch entries, one per syllable that the extractor could lock onto. `t` + `d` mirror the matching `lyrics.json` entry; `midi` is the MIDI note number (60 = middle C). Syllables the extractor couldn't pitch (silent / sub-confidence) are omitted from this list — it may be shorter than `lyrics.json` |
+
+When pitch came from an automated engine (the demucs server's `/pitch` endpoint, which runs CREPE), the optional top-level `pitch_extraction` block records which engine + model produced the file. Same shape and semver semantics as `stem_separation` / `lyric_transcription`:
+
+```yaml
+pitch_extraction:
+  engine: crepe
+  model: v1
+  version: 1.0.0
+```
+
+Omitted for hand-edited pitch tracks. As with the other two automated-artifact blocks, a remote pitch server can use this for cache-key invalidation.
+
+The PSARC→sloppak converter runs pitch extraction automatically when `pitch_extraction.enabled` is set in converter config AND a server URL is configured (either `pitch_extraction.server_url` or the shared `demucs_server_url`) AND `_maybe_transcribe_lyrics` produced lyrics in the same pass. Sloppaks built before this field existed simply don't carry it — readers should treat missing `vocal_pitch` as "no pitch data, fall back to whatever the karaoke plugin's local-extraction path produces (if any)".
 
 ---
 

--- a/docs/sloppak-spec.md
+++ b/docs/sloppak-spec.md
@@ -582,12 +582,17 @@ keys: keys.json
 
 Each entry implicitly applies until the next event. Same model as `sections[]`.
 
-#### Vocal pitch contour
+#### Vocal pitch contour (a different shape, a different key)
 
-If you want a vocal-pitch overlay separate from the lyrics karaoke layer:
+The canonical `vocal_pitch` key + file (defined in §2.4) is the
+per-syllable note format consumed by the karaoke plugin —
+`{version: 1, notes: [{t, d, midi}]}`. If you want to ship a finer-
+grained pitch *contour* (one sample every 20 ms, Hz instead of MIDI),
+that's a different shape and should ride on its own manifest key so
+the two don't collide:
 
 ```yaml
-vocal_pitch: vocal_pitch.json
+vocal_pitch_contour: vocal_pitch_contour.json
 ```
 
 ```json
@@ -600,17 +605,8 @@ vocal_pitch: vocal_pitch.json
 }
 ```
 
-Or — if your data comes as windows of sustained notes — use the same shape as Rocksmith's `vocals.xml`:
-
-```json
-{
-  "version": 1,
-  "notes": [
-    {"t": 12.34, "d": 0.4, "midi": 64},
-    {"t": 12.74, "d": 0.6, "midi": 67}
-  ]
-}
-```
+Per §5.1, manifest keys are cheap — reach for a new one when the
+schema diverges, don't overload an existing key with a second shape.
 
 ### 5.4. `version` field — always include it
 

--- a/docs/sloppak-spec.md
+++ b/docs/sloppak-spec.md
@@ -175,10 +175,10 @@ If present, points at a JSON file holding per-syllable pitch data — the karaok
 
 | Field | Meaning |
 |---|---|
-| `version` | Schema version (currently `1`). Bumped per the same rules as the manifest blocks |
+| `version` | Schema version of this `vocal_pitch.json` file (currently the integer `1`). Bump on a breaking change to the `notes` entry shape. This is *not* the same as the top-level `pitch_extraction.version` block below, which is a semver string used as a cache-key for the extractor engine |
 | `notes` | List of pitch entries, one per syllable that the extractor could lock onto. `t` + `d` mirror the matching `lyrics.json` entry; `midi` is the MIDI note number (60 = middle C). Syllables the extractor couldn't pitch (silent / sub-confidence) are omitted from this list — it may be shorter than `lyrics.json` |
 
-When pitch came from an automated engine (the demucs server's `/pitch` endpoint, which runs CREPE), the optional top-level `pitch_extraction` block records which engine + model produced the file. Same shape and semver semantics as `stem_separation` / `lyric_transcription`:
+When pitch came from an automated engine (the demucs server's `/pitch` endpoint, which runs CREPE), the optional top-level `pitch_extraction` block records which engine + model produced the file. Same shape and semver-string semantics as `stem_separation` / `lyric_transcription` — distinct from the in-file integer `version` field above:
 
 ```yaml
 pitch_extraction:

--- a/docs/sloppak-spec.md
+++ b/docs/sloppak-spec.md
@@ -189,7 +189,7 @@ pitch_extraction:
 
 Omitted for hand-edited pitch tracks. As with the other two automated-artifact blocks, a remote pitch server can use this for cache-key invalidation.
 
-The PSARC→sloppak converter runs pitch extraction automatically when `pitch_extraction.enabled` is set in converter config AND a server URL is configured (either `pitch_extraction.server_url` or the shared `demucs_server_url`) AND the sloppak ends up with lyrics in the same pass — either because `_maybe_transcribe_lyrics` just produced them via WhisperX OR because they were already on disk (from PSARC xml/sng, hand-authoring, or an earlier convert). Sloppaks built before this field existed simply don't carry it — readers should treat missing `vocal_pitch` as "no pitch data, fall back to whatever the karaoke plugin's local-extraction path produces (if any)".
+The PSARC→sloppak converter runs pitch extraction automatically when `pitch_extraction.enabled` is set in converter config AND a server URL is configured (either `pitch_extraction.server_url` or the shared `demucs_server_url`) AND the sloppak has lyrics + a `stems/vocals.ogg` after the split pass — either because `_maybe_transcribe_lyrics` just produced them via WhisperX OR because they were already on disk (from PSARC xml/sng, hand-authoring, or an earlier convert). Pitch is *not* coupled to `whisperx.enabled` — setting `pitch_extraction.enabled=true` alone (with WhisperX off) is enough to retro-generate pitch over any existing on-disk lyrics. Sloppaks built before this field existed simply don't carry it — readers should treat missing `vocal_pitch` as "no pitch data, fall back to whatever the karaoke plugin's local-extraction path produces (if any)".
 
 ---
 

--- a/docs/sloppak-spec.md
+++ b/docs/sloppak-spec.md
@@ -189,7 +189,7 @@ pitch_extraction:
 
 Omitted for hand-edited pitch tracks. As with the other two automated-artifact blocks, a remote pitch server can use this for cache-key invalidation.
 
-The PSARC→sloppak converter runs pitch extraction automatically when `pitch_extraction.enabled` is set in converter config AND a server URL is configured (either `pitch_extraction.server_url` or the shared `demucs_server_url`) AND `_maybe_transcribe_lyrics` produced lyrics in the same pass. Sloppaks built before this field existed simply don't carry it — readers should treat missing `vocal_pitch` as "no pitch data, fall back to whatever the karaoke plugin's local-extraction path produces (if any)".
+The PSARC→sloppak converter runs pitch extraction automatically when `pitch_extraction.enabled` is set in converter config AND a server URL is configured (either `pitch_extraction.server_url` or the shared `demucs_server_url`) AND the sloppak ends up with lyrics in the same pass — either because `_maybe_transcribe_lyrics` just produced them via WhisperX OR because they were already on disk (from PSARC xml/sng, hand-authoring, or an earlier convert). Sloppaks built before this field existed simply don't carry it — readers should treat missing `vocal_pitch` as "no pitch data, fall back to whatever the karaoke plugin's local-extraction path produces (if any)".
 
 ---
 

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -662,6 +662,38 @@ def _get_whisperx_config() -> dict:
     }
 
 
+def _get_pitch_config() -> dict:
+    """Return the karaoke pitch-extraction sub-config from converter config.
+
+    Shape (all keys optional, defaults applied here):
+
+        {
+          "enabled": bool,         # default False — opt-in
+          "server_url": str | None,  # default None → fall back to demucs_server_url
+          "api_key": str | None,
+        }
+
+    When `server_url` is unset, callers fall through to
+    `_get_demucs_server_url()` — same pattern WhisperX uses, since the
+    same demucs server hosts the `/pitch` endpoint alongside `/separate`
+    and `/align`."""
+    cfg = _load_converter_config()
+    raw = cfg.get("pitch_extraction")
+    if not isinstance(raw, dict):
+        raw = {}
+    server_url = raw.get("server_url")
+    if isinstance(server_url, str):
+        server_url = server_url.rstrip("/") or None
+    else:
+        server_url = None
+    api_key = raw.get("api_key") if isinstance(raw.get("api_key"), str) else None
+    return {
+        "enabled": _coerce_bool(raw.get("enabled"), False),
+        "server_url": server_url,
+        "api_key": api_key or None,
+    }
+
+
 def _run_demucs_remote(full_ogg: Path, out_dir: Path, model: str) -> Path:
     """Run stem separation via remote demucs server."""
     import json
@@ -1119,6 +1151,139 @@ def _maybe_transcribe_lyrics(
     _progress(progress_cb, base_frac + span_frac, "transcribing",
               f"Wrote {len(lyrics)} lyric tokens")
     log.info("_maybe_transcribe_lyrics: wrote %d tokens to %s", len(lyrics), lyrics_path)
+
+    # Karaoke pitch extraction is the natural next step now that we
+    # have BOTH a vocal stem AND syllable-level lyric timings. Best-
+    # effort: failures must not undo the lyric write we just persisted.
+    _maybe_extract_pitch(source_dir, lyrics, vocals_path)
+    return True
+
+
+def _rewrite_pitch_manifest(
+    source_dir: Path,
+    pitch_rel: str,
+    *,
+    extraction: dict | None,
+) -> None:
+    """Set `vocal_pitch` + optional `pitch_extraction` block on the manifest.
+
+    Used by `_maybe_extract_pitch` after writing a fresh
+    `vocal_pitch.json`. Caller is responsible for having written the
+    file at `source_dir / pitch_rel` already.
+
+    `extraction` is the optional `pitch_extraction` provenance block
+    (engine / model / version) per the same shape `stem_separation`
+    and `lyric_transcription` use. Pass it when pitch came from an
+    automated engine (currently `crepe` via the demucs server); omit
+    for hand-edited pitch tracks. Passing `None` removes any existing
+    `pitch_extraction` key so a hand-edit doesn't inherit stale
+    auto-generated provenance."""
+    mf = source_dir / "manifest.yaml"
+    if not mf.exists():
+        mf = source_dir / "manifest.yml"
+    data = yaml.safe_load(mf.read_text(encoding="utf-8")) or {}
+    data["vocal_pitch"] = pitch_rel
+    if extraction is not None:
+        data["pitch_extraction"] = extraction
+    else:
+        data.pop("pitch_extraction", None)
+    mf.write_text(
+        yaml.safe_dump(data, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+
+
+def _maybe_extract_pitch(
+    source_dir: Path,
+    lyrics: list[dict],
+    vocals_path: Path,
+) -> bool:
+    """Per-syllable pitch extraction via the demucs server's /pitch endpoint.
+
+    Best-effort sibling to `_maybe_transcribe_lyrics`. Fires when:
+      1. `pitch_extraction.enabled` is True in converter config.
+      2. We have a vocal stem on disk (caller guarantees this — we're
+         called right after `_maybe_transcribe_lyrics` succeeded).
+      3. We have at least one lyric token (the endpoint needs timings).
+      4. A server URL is configured (either `pitch_extraction.server_url`
+         or the shared `demucs_server_url`). Local CREPE is deferred.
+
+    On success writes `vocal_pitch.json` (shape matches what
+    byrongamatos/slopsmith-plugin-lyrics-karaoke renders:
+    `{"version": 1, "notes": [{"t","d","midi"}, ...]}`) and adds
+    `vocal_pitch` + `pitch_extraction` keys to the manifest. On any
+    failure logs a warning and returns False — must NOT undo the
+    lyric write the surrounding transcription path already persisted."""
+    cfg = _get_pitch_config()
+    if not cfg["enabled"]:
+        log.debug("_maybe_extract_pitch: pitch_extraction.enabled=False — skipping")
+        return False
+    if not lyrics:
+        log.debug("_maybe_extract_pitch: no lyrics — nothing to time pitch against")
+        return False
+    if not vocals_path.exists():
+        log.debug("_maybe_extract_pitch: vocals stem missing — skipping")
+        return False
+
+    # Server URL precedence: explicit pitch_extraction.server_url first,
+    # else fall back to the shared demucs server (which hosts /pitch
+    # alongside /separate and /align).
+    server_url = cfg["server_url"] or _get_demucs_server_url()
+    if not server_url:
+        log.info("_maybe_extract_pitch: no server configured "
+                 "(pitch_extraction.server_url / demucs_server_url) — skipping. "
+                 "Local CREPE fallback not yet implemented.")
+        return False
+
+    try:
+        from vocal_pitch import (
+            extract_pitch_remote,
+            PITCH_EXTRACTION_ENGINE,
+            PITCH_EXTRACTION_MODEL,
+            PITCH_EXTRACTION_SCHEMA_VERSION,
+        )
+    except ImportError as e:
+        log.warning("_maybe_extract_pitch: vocal_pitch import failed: %s", e)
+        return False
+
+    try:
+        notes = extract_pitch_remote(
+            vocals_path, lyrics, server_url, api_key=cfg["api_key"],
+        )
+    except Exception as e:
+        log.warning("_maybe_extract_pitch: pitch extraction failed for %s: %s",
+                    source_dir.name, e, exc_info=True)
+        return False
+
+    if not notes:
+        log.info("_maybe_extract_pitch: %s produced no notes", source_dir.name)
+        return False
+
+    pitch_path = source_dir / "vocal_pitch.json"
+    pitch_payload = {"version": 1, "notes": notes}
+    extraction_meta = {
+        "engine": PITCH_EXTRACTION_ENGINE,
+        "model": PITCH_EXTRACTION_MODEL,
+        "version": PITCH_EXTRACTION_SCHEMA_VERSION,
+    }
+    try:
+        pitch_path.write_text(
+            json.dumps(pitch_payload, separators=(",", ":")), encoding="utf-8"
+        )
+        _rewrite_pitch_manifest(
+            source_dir, "vocal_pitch.json", extraction=extraction_meta,
+        )
+    except Exception as e:
+        log.warning("_maybe_extract_pitch: failed to persist pitch for %s: %s",
+                    source_dir.name, e, exc_info=True)
+        if pitch_path.exists():
+            try:
+                pitch_path.unlink()
+            except OSError:
+                pass
+        return False
+
+    log.info("_maybe_extract_pitch: wrote %d notes to %s", len(notes), pitch_path)
     return True
 
 

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import os
 import re
 import shutil
@@ -1019,6 +1020,13 @@ def _load_lyrics_for_pitch(lyrics_path: Path) -> list[dict] | None:
         if isinstance(t, bool) or isinstance(d, bool):
             continue
         if not isinstance(t, (int, float)) or not isinstance(d, (int, float)):
+            continue
+        # `json.loads` accepts the non-standard `NaN`/`Infinity`/`-Infinity`
+        # literals by default and turns them into Python floats — so the
+        # isinstance check above passes them through. Filter explicitly so
+        # they don't reach extract_pitch_remote() (which would re-serialize
+        # them and trigger a strict-server 4xx, or worse).
+        if not math.isfinite(float(t)) or not math.isfinite(float(d)):
             continue
         out.append(entry)
     return out or None

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -1087,8 +1087,12 @@ def _maybe_transcribe_lyrics(
         # Re-scale the transcriber's 0..1 progress into the LYRIC
         # sub-portion of our slice — so the lyric phase tops out at
         # base + _lyric_span and the pitch phase has room to advance
-        # the bar further without it visibly moving backwards.
-        _progress(progress_cb, base_frac + _lyric_span * (0.10 + 0.80 * frac), stage, msg)
+        # the bar further without it visibly moving backwards. Clamp
+        # the input so a transcriber that overshoots (e.g. emits >1.0
+        # on a "post-processing" stage) can't punch through the lyric
+        # boundary and force a backward step on the pitch hand-off.
+        clamped = max(0.0, min(1.0, frac))
+        _progress(progress_cb, base_frac + _lyric_span * (0.10 + 0.80 * clamped), stage, msg)
 
     try:
         if server_url:

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -1423,8 +1423,16 @@ def _maybe_extract_pitch(
         "version": PITCH_EXTRACTION_SCHEMA_VERSION,
     }
     try:
+        # `allow_nan=False` so non-finite floats raise ValueError here
+        # rather than silently writing non-standard `NaN`/`Infinity`
+        # tokens that strict JSON consumers (e.g. browsers,
+        # `json.loads` with `parse_constant`) would reject. Belt-and-
+        # braces — `extract_pitch_remote` already filters non-finite
+        # values on the way in, but this catches a future call site
+        # that bypasses that loader.
         pitch_path.write_text(
-            json.dumps(pitch_payload, separators=(",", ":")), encoding="utf-8"
+            json.dumps(pitch_payload, separators=(",", ":"), allow_nan=False),
+            encoding="utf-8",
         )
         _rewrite_pitch_manifest(
             source_dir, "vocal_pitch.json", extraction=extraction_meta,

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -986,6 +986,37 @@ def _rewrite_lyrics_manifest(
     )
 
 
+def _load_lyrics_for_pitch(lyrics_path: Path) -> list[dict] | None:
+    """Load an existing lyrics JSON for pitch extraction's purposes.
+
+    The pitch endpoint only needs each entry's `t` + `d`; the rest of
+    the lyrics shape (word text, formatting hints, etc.) is forwarded
+    unchanged but ignored server-side. So this loader's bar is low:
+    return a list of dicts that each have `t` + `d`. Any other shape
+    (missing fields, top-level non-list, malformed JSON, IO error)
+    returns None so the caller skips the pitch hand-off rather than
+    crashing the surrounding transcription pass.
+
+    NOT a manifest reader — caller has already resolved the path via
+    `_existing_lyrics_path`. NOT a general lyrics validator — the
+    sloppak loader owns shape validation for read-time use."""
+    try:
+        raw = json.loads(lyrics_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as e:
+        log.debug("_load_lyrics_for_pitch: %s read/parse failed: %s", lyrics_path, e)
+        return None
+    if not isinstance(raw, list):
+        return None
+    out: list[dict] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        if "t" not in entry or "d" not in entry:
+            continue
+        out.append(entry)
+    return out or None
+
+
 def _maybe_transcribe_lyrics(
     source_dir: Path,
     produced_stems: list[dict],
@@ -1052,9 +1083,27 @@ def _maybe_transcribe_lyrics(
     # Checking only `source_dir / "lyrics.json"` would silently
     # overwrite an existing entry at a different location and leave
     # the manifest pointing at a new file we just wrote.
-    if not force and _existing_lyrics_path(source_dir) is not None:
+    existing_lyrics_path = (None if force else _existing_lyrics_path(source_dir))
+    if existing_lyrics_path is not None:
         log.info("_maybe_transcribe_lyrics: %s already has lyrics, skipping (use force=True to override)",
                  source_dir.name)
+        # Existing lyrics + a vocals stem + a configured server still
+        # satisfy the karaoke pitch pre-condition, even though we're
+        # not transcribing here. Load the on-disk lyrics and run pitch
+        # so sloppaks whose lyrics came from PSARC xml/sng (or were
+        # hand-authored) also get pre-generated karaoke pitch — not
+        # just the WhisperX-transcribed ones.
+        existing_lyrics = _load_lyrics_for_pitch(existing_lyrics_path)
+        if existing_lyrics:
+            _maybe_extract_pitch(
+                source_dir, existing_lyrics, vocals_path,
+                progress_cb=progress_cb,
+                base_frac=base_frac,
+                span_frac=span_frac,
+            )
+            # _maybe_extract_pitch flushes to base_frac + span_frac on
+            # every exit path, so we don't need an additional _skip flush.
+            return False
         return _skip("Lyrics already present")
 
     cfg = _get_whisperx_config()

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -1148,14 +1148,36 @@ def _maybe_transcribe_lyrics(
                 pass
         return _skip(f"Failed to write lyrics: {e}")
 
-    _progress(progress_cb, base_frac + span_frac, "transcribing",
+    # Reserve a sub-slice of our span for pitch extraction so the
+    # UI / log progress bar doesn't pin at 100% while CREPE is still
+    # uploading + running server-side. Lyric transcription owns the
+    # first chunk, pitch the tail. The actual slice fraction is
+    # arbitrary; 30% for pitch reflects that upload + remote inference
+    # is typically faster than WhisperX alignment but still
+    # user-visible.
+    _LYRIC_PORTION = 0.7
+    lyric_done_frac = base_frac + span_frac * _LYRIC_PORTION
+    pitch_base = lyric_done_frac
+    pitch_span = base_frac + span_frac - lyric_done_frac
+
+    _progress(progress_cb, lyric_done_frac, "transcribing",
               f"Wrote {len(lyrics)} lyric tokens")
     log.info("_maybe_transcribe_lyrics: wrote %d tokens to %s", len(lyrics), lyrics_path)
 
     # Karaoke pitch extraction is the natural next step now that we
     # have BOTH a vocal stem AND syllable-level lyric timings. Best-
     # effort: failures must not undo the lyric write we just persisted.
-    _maybe_extract_pitch(source_dir, lyrics, vocals_path)
+    _maybe_extract_pitch(
+        source_dir, lyrics, vocals_path,
+        progress_cb=progress_cb,
+        base_frac=pitch_base,
+        span_frac=pitch_span,
+    )
+    # Flush to the top of our reserved slice regardless of whether
+    # pitch ran, so the caller's progress bar always reaches the
+    # boundary the wrapper promised.
+    _progress(progress_cb, base_frac + span_frac, "transcribing",
+              "Lyric + pitch pass complete")
     return True
 
 
@@ -1197,6 +1219,10 @@ def _maybe_extract_pitch(
     source_dir: Path,
     lyrics: list[dict],
     vocals_path: Path,
+    *,
+    progress_cb: ProgressCB = None,
+    base_frac: float = 0.0,
+    span_frac: float = 0.0,
 ) -> bool:
     """Per-syllable pitch extraction via the demucs server's /pitch endpoint.
 
@@ -1208,22 +1234,35 @@ def _maybe_extract_pitch(
       4. A server URL is configured (either `pitch_extraction.server_url`
          or the shared `demucs_server_url`). Local CREPE is deferred.
 
+    `progress_cb` / `base_frac` / `span_frac` mirror the same slice
+    contract as `_maybe_transcribe_lyrics`: emit progress inside the
+    range `[base_frac, base_frac + span_frac]`. Defaults to a
+    zero-width slice so direct callers (tests, retroactive CLI) can
+    invoke without progress bookkeeping.
+
     On success writes `vocal_pitch.json` (shape matches what
     byrongamatos/slopsmith-plugin-lyrics-karaoke renders:
     `{"version": 1, "notes": [{"t","d","midi"}, ...]}`) and adds
     `vocal_pitch` + `pitch_extraction` keys to the manifest. On any
     failure logs a warning and returns False — must NOT undo the
     lyric write the surrounding transcription path already persisted."""
+    def _flush_skip(reason: str) -> bool:
+        # Mirror _maybe_transcribe_lyrics._skip — push the progress bar
+        # to the top of our reserved slice on early-exit so callers
+        # don't pin short of the boundary.
+        _progress(progress_cb, base_frac + span_frac, "pitch", reason)
+        return False
+
     cfg = _get_pitch_config()
     if not cfg["enabled"]:
         log.debug("_maybe_extract_pitch: pitch_extraction.enabled=False — skipping")
-        return False
+        return _flush_skip("Pitch extraction disabled")
     if not lyrics:
         log.debug("_maybe_extract_pitch: no lyrics — nothing to time pitch against")
-        return False
+        return _flush_skip("No lyrics to time pitch against")
     if not vocals_path.exists():
         log.debug("_maybe_extract_pitch: vocals stem missing — skipping")
-        return False
+        return _flush_skip("Vocals stem missing")
 
     # Server URL precedence: explicit pitch_extraction.server_url first,
     # else fall back to the shared demucs server (which hosts /pitch
@@ -1233,7 +1272,7 @@ def _maybe_extract_pitch(
         log.info("_maybe_extract_pitch: no server configured "
                  "(pitch_extraction.server_url / demucs_server_url) — skipping. "
                  "Local CREPE fallback not yet implemented.")
-        return False
+        return _flush_skip("No pitch server configured")
 
     try:
         from vocal_pitch import (
@@ -1244,20 +1283,30 @@ def _maybe_extract_pitch(
         )
     except ImportError as e:
         log.warning("_maybe_extract_pitch: vocal_pitch import failed: %s", e)
-        return False
+        return _flush_skip(f"vocal_pitch import failed: {e}")
+
+    # Scale extract_pitch_remote's internal 0..1 progress into our
+    # reserved slice so the overall progress bar advances smoothly
+    # through upload + inference, rather than waiting until the call
+    # returns to jump.
+    def _scaled_progress(frac: float, stage: str, msg: str) -> None:
+        clamped = max(0.0, min(1.0, frac))
+        _progress(progress_cb, base_frac + span_frac * clamped, stage, msg)
 
     try:
         notes = extract_pitch_remote(
-            vocals_path, lyrics, server_url, api_key=cfg["api_key"],
+            vocals_path, lyrics, server_url,
+            api_key=cfg["api_key"],
+            progress_cb=_scaled_progress,
         )
     except Exception as e:
         log.warning("_maybe_extract_pitch: pitch extraction failed for %s: %s",
                     source_dir.name, e, exc_info=True)
-        return False
+        return _flush_skip(f"Pitch extraction failed: {e}")
 
     if not notes:
         log.info("_maybe_extract_pitch: %s produced no notes", source_dir.name)
-        return False
+        return _flush_skip("No pitch notes produced")
 
     pitch_path = source_dir / "vocal_pitch.json"
     pitch_payload = {"version": 1, "notes": notes}
@@ -1281,8 +1330,10 @@ def _maybe_extract_pitch(
                 pitch_path.unlink()
             except OSError:
                 pass
-        return False
+        return _flush_skip(f"Failed to write pitch: {e}")
 
+    _progress(progress_cb, base_frac + span_frac, "pitch",
+              f"Wrote {len(notes)} pitch notes")
     log.info("_maybe_extract_pitch: wrote %d notes to %s", len(notes), pitch_path)
     return True
 

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -989,13 +989,16 @@ def _rewrite_lyrics_manifest(
 def _load_lyrics_for_pitch(lyrics_path: Path) -> list[dict] | None:
     """Load an existing lyrics JSON for pitch extraction's purposes.
 
-    The pitch endpoint only needs each entry's `t` + `d`; the rest of
-    the lyrics shape (word text, formatting hints, etc.) is forwarded
-    unchanged but ignored server-side. So this loader's bar is low:
-    return a list of dicts that each have `t` + `d`. Any other shape
-    (missing fields, top-level non-list, malformed JSON, IO error)
-    returns None so the caller skips the pitch hand-off rather than
-    crashing the surrounding transcription pass.
+    The pitch endpoint only needs each entry's `t` + `d` (and rejects
+    non-numeric values server-side with a 4xx); the rest of the lyrics
+    shape (word text, formatting hints, etc.) is forwarded unchanged
+    but ignored. So this loader's bar is: return a list of dicts that
+    each have a numeric `t` + numeric `d`. Bools are excluded
+    explicitly because `isinstance(True, int)` is True in Python and
+    the endpoint would reject them. Any other shape (missing fields,
+    wrong types, top-level non-list, malformed JSON, IO error) returns
+    None so the caller skips the pitch hand-off rather than crashing
+    the surrounding transcription pass.
 
     NOT a manifest reader — caller has already resolved the path via
     `_existing_lyrics_path`. NOT a general lyrics validator — the
@@ -1011,7 +1014,11 @@ def _load_lyrics_for_pitch(lyrics_path: Path) -> list[dict] | None:
     for entry in raw:
         if not isinstance(entry, dict):
             continue
-        if "t" not in entry or "d" not in entry:
+        t = entry.get("t")
+        d = entry.get("d")
+        if isinstance(t, bool) or isinstance(d, bool):
+            continue
+        if not isinstance(t, (int, float)) or not isinstance(d, (int, float)):
             continue
         out.append(entry)
     return out or None
@@ -1286,11 +1293,18 @@ def _maybe_extract_pitch(
 ) -> bool:
     """Per-syllable pitch extraction via the demucs server's /pitch endpoint.
 
-    Best-effort sibling to `_maybe_transcribe_lyrics`. Fires when:
+    Best-effort sibling to `_maybe_transcribe_lyrics`. Called from
+    both the WhisperX success path and the existing-lyrics short-
+    circuit inside `_maybe_transcribe_lyrics`, so the vocals gate
+    below is enforced here rather than assumed from a single caller.
+    Fires when:
       1. `pitch_extraction.enabled` is True in converter config.
-      2. We have a vocal stem on disk (caller guarantees this — we're
-         called right after `_maybe_transcribe_lyrics` succeeded).
-      3. We have at least one lyric token (the endpoint needs timings).
+      2. There is at least one lyric token (the endpoint needs
+         timings — either freshly produced by WhisperX or loaded from
+         an existing on-disk lyrics file via `_load_lyrics_for_pitch`).
+      3. The vocal stem exists on disk (defensive — both production
+         call sites have already checked this, but tests + future
+         callers may not).
       4. A server URL is configured (either `pitch_extraction.server_url`
          or the shared `demucs_server_url`). Local CREPE is deferred.
 

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -1016,6 +1016,18 @@ def _maybe_transcribe_lyrics(
     Returns True when lyrics were written, False otherwise. All
     exceptions are caught and logged at WARNING — the caller treats
     transcription as best-effort."""
+    # Split this step's reserved slice between lyric transcription and
+    # the optional pitch extraction that runs on its output. Pitch
+    # takes the tail; transcription owns the head. Defined at the top
+    # of the function so the inner progress callbacks below (which
+    # scale WhisperX's 0..1 into our slice) can rescale into the lyric
+    # sub-portion rather than the whole slice — otherwise WhisperX
+    # progress could overshoot the lyric/pitch boundary and the bar
+    # would visibly move backwards once the lyric phase completes.
+    _LYRIC_PORTION = 0.7
+    _lyric_span = span_frac * _LYRIC_PORTION
+    _pitch_span = span_frac - _lyric_span
+
     # Helper: emit a "skip" progress update at the end of this step's
     # reserved slice so callers' progress printers / UIs don't stall
     # short of base_frac + span_frac when the transcription bails on
@@ -1068,13 +1080,15 @@ def _maybe_transcribe_lyrics(
     # server hosts WhisperX at /align too), else local in-process.
     server_url = cfg["server_url"] or _get_demucs_server_url()
 
-    _progress(progress_cb, base_frac + span_frac * 0.10, "transcribing",
+    _progress(progress_cb, base_frac + _lyric_span * 0.10, "transcribing",
               "Transcribing vocals" + (f" (remote: {server_url})" if server_url else " (local)"))
 
     def _inner_cb(frac: float, stage: str, msg: str) -> None:
-        # Re-scale the transcriber's 0..1 progress into the slice this
-        # step owns in the outer convert/split pipeline.
-        _progress(progress_cb, base_frac + span_frac * (0.10 + 0.80 * frac), stage, msg)
+        # Re-scale the transcriber's 0..1 progress into the LYRIC
+        # sub-portion of our slice — so the lyric phase tops out at
+        # base + _lyric_span and the pitch phase has room to advance
+        # the bar further without it visibly moving backwards.
+        _progress(progress_cb, base_frac + _lyric_span * (0.10 + 0.80 * frac), stage, msg)
 
     try:
         if server_url:
@@ -1148,19 +1162,12 @@ def _maybe_transcribe_lyrics(
                 pass
         return _skip(f"Failed to write lyrics: {e}")
 
-    # Reserve a sub-slice of our span for pitch extraction so the
-    # UI / log progress bar doesn't pin at 100% while CREPE is still
-    # uploading + running server-side. Lyric transcription owns the
-    # first chunk, pitch the tail. The actual slice fraction is
-    # arbitrary; 30% for pitch reflects that upload + remote inference
-    # is typically faster than WhisperX alignment but still
-    # user-visible.
-    _LYRIC_PORTION = 0.7
-    lyric_done_frac = base_frac + span_frac * _LYRIC_PORTION
-    pitch_base = lyric_done_frac
-    pitch_span = base_frac + span_frac - lyric_done_frac
-
-    _progress(progress_cb, lyric_done_frac, "transcribing",
+    # Lyric phase complete — flush to the top of its sub-portion
+    # (computed up-front as _lyric_span) so the bar settles cleanly
+    # at the lyric/pitch boundary before _maybe_extract_pitch takes
+    # over the tail. _inner_cb already scales WhisperX into this
+    # same sub-portion, so no backward motion is possible here.
+    _progress(progress_cb, base_frac + _lyric_span, "transcribing",
               f"Wrote {len(lyrics)} lyric tokens")
     log.info("_maybe_transcribe_lyrics: wrote %d tokens to %s", len(lyrics), lyrics_path)
 
@@ -1170,8 +1177,8 @@ def _maybe_transcribe_lyrics(
     _maybe_extract_pitch(
         source_dir, lyrics, vocals_path,
         progress_cb=progress_cb,
-        base_frac=pitch_base,
-        span_frac=pitch_span,
+        base_frac=base_frac + _lyric_span,
+        span_frac=_pitch_span,
     )
     # Flush to the top of our reserved slice regardless of whether
     # pitch ran, so the caller's progress bar always reaches the

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -1075,7 +1075,32 @@ def _maybe_transcribe_lyrics(
         return False
 
     if not enabled:
-        return False  # not reserving a progress slice when disabled
+        # WhisperX disabled, but pitch extraction may still be enabled
+        # AND find existing lyrics on disk to work with — don't bail
+        # before that flow gets a chance. Note: we only reach this
+        # branch when the outer caller actually decided to reserve a
+        # slice for us (either wx_enabled OR pitch_enabled in
+        # _split_in_dir), so flushing to the slice top on exit is
+        # correct either way.
+        existing = _existing_lyrics_path(source_dir)
+        if existing is not None:
+            vocals_path = source_dir / "stems" / "vocals.ogg"
+            if vocals_path.exists():
+                existing_lyrics = _load_lyrics_for_pitch(existing)
+                if existing_lyrics:
+                    _maybe_extract_pitch(
+                        source_dir, existing_lyrics, vocals_path,
+                        progress_cb=progress_cb,
+                        base_frac=base_frac,
+                        span_frac=span_frac,
+                    )
+                    return False
+        # No pitch hand-off happened — flush the slice the caller
+        # reserved for us so the progress bar still reaches the
+        # promised boundary.
+        _progress(progress_cb, base_frac + span_frac, "transcribing",
+                  "Lyric/pitch pass skipped (transcription disabled)")
+        return False
     if not any(s.get("id") == "vocals" for s in produced_stems):
         log.debug("_maybe_transcribe_lyrics: no vocals stem in produced output")
         return _skip("No vocals stem to transcribe")
@@ -1431,12 +1456,18 @@ def _split_in_dir(
     use_remote = remote_url is not None
 
     # Reserve the tail of the progress budget for the optional WhisperX
-    # transcription step. Demucs gets the bulk (0..split_span); transcription
-    # owns the rest (split_span..1.0). When transcription is disabled the
-    # entire span is consumed by splitting.
+    # transcription + pitch-extraction steps. Demucs gets the bulk
+    # (0..split_span); the lyric/pitch pass owns the rest
+    # (split_span..1.0). The slice is reserved when EITHER WhisperX OR
+    # pitch extraction is enabled — pitch alone is enough to need the
+    # tail because it runs on existing lyrics even when WhisperX is
+    # disabled (the "Lyrics already present" short-circuit inside
+    # _maybe_transcribe_lyrics handles the hand-off).
     wx_enabled = bool(transcribe_lyrics if transcribe_lyrics is not None
                       else _get_whisperx_config()["enabled"])
-    split_span = span_frac * (0.85 if wx_enabled else 1.0)
+    pitch_enabled = bool(_get_pitch_config()["enabled"])
+    needs_post_split = wx_enabled or pitch_enabled
+    split_span = span_frac * (0.85 if needs_post_split else 1.0)
 
     if use_remote:
         _progress(progress_cb, base_frac + split_span * 0.05, "splitting",
@@ -1478,17 +1509,20 @@ def _split_in_dir(
             return (len(_STEM_ORDER), s["id"])
     produced.sort(key=_order_key)
 
-    # Optional WhisperX transcription — runs after stems are encoded
-    # but before `full.ogg` is removed (the order doesn't strictly
-    # matter for the vocals stem, which is independent, but keeping
-    # `full.ogg` around through the transcription call gives a fallback
-    # input if a future variant ever needs the mixed track). Wrapped
-    # internally so failures don't break the split.
-    if wx_enabled:
+    # Optional WhisperX transcription + pitch extraction — runs after
+    # stems are encoded but before `full.ogg` is removed (the order
+    # doesn't strictly matter for the vocals stem, which is
+    # independent, but keeping `full.ogg` around through the
+    # transcription call gives a fallback input if a future variant
+    # ever needs the mixed track). Wrapped internally so failures
+    # don't break the split. The `enabled` argument controls only
+    # WhisperX; _maybe_transcribe_lyrics still attempts pitch
+    # extraction on existing lyrics when wx is off but pitch is on.
+    if needs_post_split:
         _maybe_transcribe_lyrics(
             source_dir,
             produced,
-            enabled=True,
+            enabled=wx_enabled,
             progress_cb=progress_cb,
             base_frac=base_frac + split_span,
             span_frac=span_frac - split_span,

--- a/lib/vocal_pitch.py
+++ b/lib/vocal_pitch.py
@@ -110,6 +110,8 @@ def extract_pitch_remote(
     # Wrap the upload so a connection / DNS / timeout failure becomes a
     # RuntimeError instead of leaking requests' own exception hierarchy
     # past the docstring contract.
+    log.debug("POST %s/pitch vocals=%s lyrics=%d timeout=%ds",
+              server_url, vocals_path.name, len(lyrics), timeout)
     try:
         with open(vocals_path, "rb") as f:
             resp = requests.post(
@@ -161,6 +163,8 @@ def extract_pitch_remote(
         except (TypeError, ValueError):
             continue
 
+    log.debug("CREPE /pitch returned %d raw notes, %d after normalization",
+              len(raw_notes), len(out))
     if progress_cb:
         try:
             progress_cb(1.0, "pitch", f"Got {len(out)} pitch notes")

--- a/lib/vocal_pitch.py
+++ b/lib/vocal_pitch.py
@@ -1,0 +1,158 @@
+"""Per-syllable vocal pitch extraction via the demucs server's /pitch endpoint.
+
+Sibling to `lyrics_transcribe.py` on the karaoke side: once we have
+isolated vocals + per-syllable lyric timing (both produced by the
+WhisperX fallback or shipped in the source PSARC), the /pitch endpoint
+runs CREPE over the vocals stem and returns one MIDI note per supplied
+timing token. The result lands in `<sloppak>/vocal_pitch.json` in the
+shape the byrongamatos/slopsmith-plugin-lyrics-karaoke renderer
+already consumes:
+
+    {"version": 1, "notes": [{"t": float, "d": float, "midi": int}, ...]}
+
+Pre-generating during sloppak conversion means the karaoke plugin no
+longer has to run pYIN locally on every first-play — the file is
+already there.
+
+Engine selection
+────────────────
+This module exposes only the remote path (`extract_pitch_remote`). The
+demucs server's /pitch endpoint runs CREPE on a GPU when available,
+which is materially better than the pYIN fallback the karaoke plugin
+runs locally. Adding a local CREPE path here would mean pulling
+`crepe` + `tensorflow` as plugin deps (~500 MB+ on top of the
+existing torch/demucs/whisperx). Deferred until users hit the gap.
+If you need a local fallback today, install
+`byrongamatos/slopsmith-plugin-lyrics-karaoke` and let its local
+pYIN run when the server isn't reachable.
+
+Cache key parity with stem_separation / lyric_transcription
+───────────────────────────────────────────────────────────
+A `pitch_extraction` manifest block mirrors the shape introduced by
+slopsmith#357: `{engine, model, version}`. Today engine is fixed at
+`"crepe"` (the server's choice) and model at `"v1"` (server doesn't
+yet expose the CREPE capacity dial it uses internally; this is the
+requested value, same caveat as `lyric_transcription.model`). The
+schema version is independent of the upstream CREPE version and bumps
+per slopsmith's contract:
+   * patch — metadata-only or implementation fixes
+   * minor — backward-compatible additions
+   * major — output shape / semantics changed; existing
+            vocal_pitch.json should be regenerated and remote caches
+            should miss
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Callable, Optional
+
+log = logging.getLogger("slopsmith.lib.vocal_pitch")
+
+ProgressCB = Optional[Callable[[float, str, str], None]]
+
+# `pitch_extraction` manifest-block constants. See module docstring for
+# semver semantics.
+PITCH_EXTRACTION_ENGINE = "crepe"
+PITCH_EXTRACTION_MODEL = "v1"
+PITCH_EXTRACTION_SCHEMA_VERSION = "1.0.0"
+
+
+def extract_pitch_remote(
+    vocals_path: Path,
+    lyrics: list[dict],
+    server_url: str,
+    *,
+    api_key: str | None = None,
+    timeout: int = 300,
+    progress_cb: ProgressCB = None,
+) -> list[dict]:
+    """POST the vocal stem + lyric timings to `{server_url}/pitch`.
+
+    `lyrics` is the same `[{t, d, w}, ...]` list slopsmith writes to
+    `lyrics.json`. The endpoint only consumes `t` + `d` (it doesn't
+    need the word text), but we pass the full payload through —
+    slimmer to forward what we already have than to project.
+
+    Returns the server's `notes` list verbatim:
+    `[{"t": float, "d": float, "midi": int}, ...]`. Tokens the server
+    couldn't extract a pitch for (silent, sub-threshold confidence,
+    no neighbour to borrow from) are omitted from the response — the
+    output may be shorter than the input lyrics.
+
+    Errors raise `RuntimeError` with a truncated server response so
+    the caller can log+continue without bringing down the surrounding
+    transcription / split job. Matches the failure idiom in
+    `transcribe_vocals_remote` and `_run_demucs_remote`."""
+    import requests
+
+    server_url = server_url.rstrip("/")
+    if progress_cb:
+        try:
+            progress_cb(0.10, "pitch", f"Uploading to CREPE server ({server_url})")
+        except Exception:
+            pass
+
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    # The /pitch endpoint validates each entry has numeric `t` + `d`;
+    # the `w` field is ignored server-side but harmless to forward.
+    with open(vocals_path, "rb") as f:
+        resp = requests.post(
+            f"{server_url}/pitch",
+            files={"file": (vocals_path.name, f, "audio/ogg")},
+            data={"lyrics": json.dumps(lyrics)},
+            headers=headers or None,
+            timeout=timeout,
+        )
+
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"CREPE server error ({resp.status_code}): {resp.text[:300]}"
+        )
+
+    try:
+        data = resp.json()
+    except ValueError as e:
+        raise RuntimeError(f"CREPE server returned non-JSON: {e}") from e
+
+    if not isinstance(data, dict) or "notes" not in data:
+        raise RuntimeError(
+            f"CREPE server returned unexpected shape: {str(data)[:300]}"
+        )
+
+    raw_notes = data.get("notes")
+    if not isinstance(raw_notes, list):
+        raise RuntimeError(
+            f"CREPE server `notes` is not a list: {type(raw_notes).__name__}"
+        )
+
+    # Defensive: skip malformed entries entirely rather than crashing
+    # the whole pass on one bad record. Same posture as the WhisperX
+    # remote path.
+    out: list[dict] = []
+    for n in raw_notes:
+        if not isinstance(n, dict):
+            continue
+        if "t" not in n or "d" not in n or "midi" not in n:
+            continue
+        try:
+            out.append({
+                "t": round(float(n["t"]), 3),
+                "d": round(float(n["d"]), 3),
+                "midi": int(n["midi"]),
+            })
+        except (TypeError, ValueError):
+            continue
+
+    if progress_cb:
+        try:
+            progress_cb(1.0, "pitch", f"Got {len(out)} pitch notes")
+        except Exception:
+            pass
+
+    return out

--- a/lib/vocal_pitch.py
+++ b/lib/vocal_pitch.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -158,7 +159,10 @@ def extract_pitch_remote(
 
     # Defensive: skip malformed entries entirely rather than crashing
     # the whole pass on one bad record. Same posture as the WhisperX
-    # remote path.
+    # remote path. Non-finite t/d (NaN, ±Inf — a misbehaving server or
+    # a numerical edge in CREPE could surface them) are also filtered
+    # so they can't reach the on-disk vocal_pitch.json and break
+    # strict-JSON consumers downstream.
     out: list[dict] = []
     for n in raw_notes:
         if not isinstance(n, dict):
@@ -166,9 +170,13 @@ def extract_pitch_remote(
         if "t" not in n or "d" not in n or "midi" not in n:
             continue
         try:
+            t = float(n["t"])
+            d = float(n["d"])
+            if not math.isfinite(t) or not math.isfinite(d):
+                continue
             out.append({
-                "t": round(float(n["t"]), 3),
-                "d": round(float(n["d"]), 3),
+                "t": round(t, 3),
+                "d": round(d, 3),
                 "midi": int(n["midi"]),
             })
         except (TypeError, ValueError):

--- a/lib/vocal_pitch.py
+++ b/lib/vocal_pitch.py
@@ -112,6 +112,15 @@ def extract_pitch_remote(
     # past the docstring contract.
     log.debug("POST %s/pitch vocals=%s lyrics=%d timeout=%ds",
               server_url, vocals_path.name, len(lyrics), timeout)
+    # Catch both `requests.RequestException` (network / DNS / timeout /
+    # upload aborted) AND `OSError` from the `open(vocals_path)` itself
+    # (file disappeared between gate-check and upload, permissions
+    # change, EIO). Both surface as `RuntimeError` to keep the
+    # docstring contract one-type and let the caller handle every
+    # failure mode with one `except`. RequestException MUST be caught
+    # first because it inherits from OSError — listing OSError first
+    # would steal the network-failure path and label it as a vocals
+    # read error.
     try:
         with open(vocals_path, "rb") as f:
             resp = requests.post(
@@ -123,6 +132,8 @@ def extract_pitch_remote(
             )
     except requests.RequestException as e:
         raise RuntimeError(f"CREPE server request failed: {e}") from e
+    except OSError as e:
+        raise RuntimeError(f"Reading vocals stem {vocals_path.name} failed: {e}") from e
 
     if resp.status_code != 200:
         raise RuntimeError(

--- a/lib/vocal_pitch.py
+++ b/lib/vocal_pitch.py
@@ -76,15 +76,21 @@ def extract_pitch_remote(
     need the word text), but we pass the full payload through —
     slimmer to forward what we already have than to project.
 
-    Returns the server's `notes` list verbatim:
-    `[{"t": float, "d": float, "midi": int}, ...]`. Tokens the server
-    couldn't extract a pitch for (silent, sub-threshold confidence,
-    no neighbour to borrow from) are omitted from the response — the
-    output may be shorter than the input lyrics.
+    Returns a normalized `notes` list: each entry is
+    `{"t": float, "d": float, "midi": int}` with `t`/`d` rounded to 3
+    decimals and `midi` coerced to int. Malformed server entries
+    (missing key, non-numeric, wrong type) are skipped rather than
+    propagated. Tokens the server couldn't extract a pitch for
+    (silent, sub-threshold confidence, no neighbour to borrow from)
+    are omitted from the response — the output may be shorter than
+    the input lyrics.
 
     Errors raise `RuntimeError` with a truncated server response so
     the caller can log+continue without bringing down the surrounding
-    transcription / split job. Matches the failure idiom in
+    transcription / split job. Transport-level failures
+    (`requests.RequestException`: connection, DNS, timeout, upload
+    aborted) are wrapped here so callers see one exception type, not
+    requests' hierarchy. Matches the failure idiom in
     `transcribe_vocals_remote` and `_run_demucs_remote`."""
     import requests
 
@@ -101,14 +107,20 @@ def extract_pitch_remote(
 
     # The /pitch endpoint validates each entry has numeric `t` + `d`;
     # the `w` field is ignored server-side but harmless to forward.
-    with open(vocals_path, "rb") as f:
-        resp = requests.post(
-            f"{server_url}/pitch",
-            files={"file": (vocals_path.name, f, "audio/ogg")},
-            data={"lyrics": json.dumps(lyrics)},
-            headers=headers or None,
-            timeout=timeout,
-        )
+    # Wrap the upload so a connection / DNS / timeout failure becomes a
+    # RuntimeError instead of leaking requests' own exception hierarchy
+    # past the docstring contract.
+    try:
+        with open(vocals_path, "rb") as f:
+            resp = requests.post(
+                f"{server_url}/pitch",
+                files={"file": (vocals_path.name, f, "audio/ogg")},
+                data={"lyrics": json.dumps(lyrics)},
+                headers=headers or None,
+                timeout=timeout,
+            )
+    except requests.RequestException as e:
+        raise RuntimeError(f"CREPE server request failed: {e}") from e
 
     if resp.status_code != 200:
         raise RuntimeError(

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -858,6 +858,29 @@ def test_load_lyrics_for_pitch_returns_none_when_all_entries_filtered(tmp_path):
     assert sloppak_convert._load_lyrics_for_pitch(p) is None
 
 
+def test_load_lyrics_for_pitch_filters_non_finite_t_or_d(tmp_path):
+    """`json.loads` accepts the non-standard `NaN`/`Infinity` literals
+    by default, so the isinstance(_, float) check alone would pass them
+    through to the /pitch endpoint and trigger a strict-server 4xx (or
+    worse — get fed to CREPE and silently corrupt the timing). Filter
+    explicitly client-side so non-finite values never leave this loader."""
+    # Use python literals directly to bypass json's NaN-permissiveness;
+    # mock the loader's file content by passing a dict shape with these
+    # values directly via the json round-trip.
+    p = tmp_path / "lyrics.json"
+    # Python's json.dumps with allow_nan=True (the default) emits these
+    # as bare `NaN` / `Infinity` tokens which json.loads round-trips.
+    p.write_text(
+        '[{"t": 0.0, "d": 0.5, "w": "ok"},'
+        ' {"t": NaN, "d": 0.5, "w": "nan-t"},'
+        ' {"t": 0.0, "d": Infinity, "w": "inf-d"},'
+        ' {"t": -Infinity, "d": 0.5, "w": "neg-inf-t"}]',
+        encoding="utf-8",
+    )
+    out = sloppak_convert._load_lyrics_for_pitch(p)
+    assert out == [{"t": 0.0, "d": 0.5, "w": "ok"}]
+
+
 def test_load_lyrics_for_pitch_filters_non_numeric_t_or_d(tmp_path):
     """The /pitch endpoint rejects non-numeric t/d server-side with a 4xx;
     filter those out client-side so we don't waste a round-trip and so the

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -787,6 +787,30 @@ def test_maybe_extract_pitch_swallows_remote_failure(tmp_path, monkeypatch):
     assert not (src / "vocal_pitch.json").exists()
 
 
+def test_maybe_extract_pitch_persists_with_allow_nan_false(tmp_path, monkeypatch):
+    """vocal_pitch.json must never contain `NaN`/`Infinity` tokens —
+    they're non-standard JSON and break strict consumers (browsers'
+    JSON.parse rejects them outright). The persistence path uses
+    allow_nan=False so a future caller that bypasses the
+    extract_pitch_remote filter would surface a ValueError at write
+    time rather than poison the on-disk file."""
+    src = _make_sloppak_with_vocals(tmp_path)
+    _patch_pitch_config(monkeypatch)
+
+    import vocal_pitch
+    monkeypatch.setattr(vocal_pitch, "extract_pitch_remote",
+                        lambda *a, **kw: [{"t": float("nan"), "d": 0.5, "midi": 64}])
+
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.5, "w": "hi"}], src / "stems" / "vocals.ogg",
+    )
+    # Best-effort: the ValueError from allow_nan=False is caught + logged
+    # as warning, returns False. Crucially, vocal_pitch.json was NOT
+    # written with a NaN/Infinity token poisoning future reads.
+    assert out is False
+    assert not (src / "vocal_pitch.json").exists()
+
+
 def test_maybe_extract_pitch_writes_file_and_manifest(tmp_path, monkeypatch):
     src = _make_sloppak_with_vocals(tmp_path)
     _patch_pitch_config(monkeypatch)

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -817,6 +817,85 @@ def test_maybe_extract_pitch_writes_file_and_manifest(tmp_path, monkeypatch):
     }
 
 
+def test_load_lyrics_for_pitch_accepts_minimal_shape(tmp_path):
+    p = tmp_path / "lyrics.json"
+    p.write_text(_json.dumps([
+        {"t": 0.0, "d": 0.5, "w": "hi"},
+        {"t": 1.0, "d": 0.3, "w": "world"},
+    ]), encoding="utf-8")
+    out = sloppak_convert._load_lyrics_for_pitch(p)
+    assert out == [
+        {"t": 0.0, "d": 0.5, "w": "hi"},
+        {"t": 1.0, "d": 0.3, "w": "world"},
+    ]
+
+
+def test_load_lyrics_for_pitch_returns_none_on_missing_file(tmp_path):
+    assert sloppak_convert._load_lyrics_for_pitch(tmp_path / "nope.json") is None
+
+
+def test_load_lyrics_for_pitch_returns_none_on_malformed_json(tmp_path):
+    p = tmp_path / "lyrics.json"
+    p.write_text("{not json", encoding="utf-8")
+    assert sloppak_convert._load_lyrics_for_pitch(p) is None
+
+
+def test_load_lyrics_for_pitch_filters_entries_missing_t_or_d(tmp_path):
+    p = tmp_path / "lyrics.json"
+    p.write_text(_json.dumps([
+        {"t": 0.0, "d": 0.5, "w": "ok"},
+        {"t": 1.0, "w": "missing-d"},      # filtered
+        {"d": 0.2, "w": "missing-t"},      # filtered
+        "not-a-dict",                      # filtered
+    ]), encoding="utf-8")
+    out = sloppak_convert._load_lyrics_for_pitch(p)
+    assert out == [{"t": 0.0, "d": 0.5, "w": "ok"}]
+
+
+def test_load_lyrics_for_pitch_returns_none_when_all_entries_filtered(tmp_path):
+    p = tmp_path / "lyrics.json"
+    p.write_text(_json.dumps([{"w": "no-times"}]), encoding="utf-8")
+    assert sloppak_convert._load_lyrics_for_pitch(p) is None
+
+
+def test_maybe_transcribe_lyrics_runs_pitch_when_lyrics_already_exist(tmp_path, monkeypatch):
+    """When a sloppak ships with lyrics (PSARC xml/sng or hand-authored),
+    WhisperX skips — but the pitch path should STILL run since the
+    karaoke pitch pre-condition (lyrics + vocals + server) is met."""
+    src = _make_sloppak_with_vocals(tmp_path)
+    # Add an existing lyrics file declared by the manifest.
+    existing = src / "lyrics.json"
+    existing.write_text(
+        _json.dumps([{"t": 0.0, "d": 0.5, "w": "ohai"}]), encoding="utf-8"
+    )
+    mf = _yaml.safe_load((src / "manifest.yaml").read_text(encoding="utf-8"))
+    mf["lyrics"] = "lyrics.json"
+    (src / "manifest.yaml").write_text(_yaml.safe_dump(mf), encoding="utf-8")
+
+    _patch_pitch_config(monkeypatch)
+    # Capture the lyrics arg that pitch receives so we can confirm it
+    # got the existing-on-disk lyrics, not an empty list or something.
+    received = {}
+    import vocal_pitch
+    def _stub(*args, **kwargs):
+        # args = (vocals_path, lyrics, server_url); we capture lyrics.
+        received["lyrics"] = args[1]
+        return [{"t": 0.0, "d": 0.5, "midi": 64}]
+    monkeypatch.setattr(vocal_pitch, "extract_pitch_remote", _stub)
+
+    out = sloppak_convert._maybe_transcribe_lyrics(
+        src,
+        [{"id": "vocals", "file": "stems/vocals.ogg"}],
+        enabled=True,
+    )
+    # Transcription itself did NOT run — the function returns False.
+    assert out is False
+    # But pitch DID run, with the on-disk lyrics.
+    assert received.get("lyrics") == [{"t": 0.0, "d": 0.5, "w": "ohai"}]
+    # And vocal_pitch.json got written.
+    assert (src / "vocal_pitch.json").exists()
+
+
 def test_maybe_extract_pitch_emits_progress_within_slice(tmp_path, monkeypatch):
     src = _make_sloppak_with_vocals(tmp_path)
     _patch_pitch_config(monkeypatch)

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -671,3 +671,177 @@ def test_cleanup_stale_temp_dirs_skips_symlinks(tmp_path, monkeypatch):
     assert removed == 0
     assert link.exists()
     assert target.exists() and (target / "do_not_delete.txt").exists()
+
+
+# ── _maybe_extract_pitch ────────────────────────────────────────────────────
+# The pitch path is best-effort and gated on multiple config + filesystem
+# conditions. These cover the skip gates + the happy-path write to make
+# sure the sloppak ends up with vocal_pitch.json + manifest provenance,
+# and that early-exit paths don't crash or partially update the manifest.
+
+import json as _json
+import yaml as _yaml
+
+
+def _make_sloppak_with_vocals(tmp_path):
+    """Minimal unpacked-sloppak skeleton: manifest + stems/vocals.ogg."""
+    src = tmp_path / "song.sloppak"
+    src.mkdir()
+    (src / "manifest.yaml").write_text(
+        _yaml.safe_dump({"id": "song", "stems": [{"id": "vocals", "file": "stems/vocals.ogg"}]}),
+        encoding="utf-8",
+    )
+    (src / "stems").mkdir()
+    (src / "stems" / "vocals.ogg").write_bytes(b"fake-ogg")
+    return src
+
+
+def _patch_pitch_config(monkeypatch, **overrides):
+    """Stub _get_pitch_config so tests don't have to spin up a real config.json."""
+    base = {"enabled": True, "server_url": "http://stub:7865", "api_key": None}
+    base.update(overrides)
+    monkeypatch.setattr(sloppak_convert, "_get_pitch_config", lambda: base)
+    # Also clear the demucs-server fallback so server_url precedence is deterministic.
+    monkeypatch.setattr(sloppak_convert, "_get_demucs_server_url", lambda: None)
+
+
+def test_maybe_extract_pitch_skips_when_disabled(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    _patch_pitch_config(monkeypatch, enabled=False)
+
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.5, "w": "hi"}], src / "stems" / "vocals.ogg",
+    )
+    assert out is False
+    assert not (src / "vocal_pitch.json").exists()
+    mf = _yaml.safe_load((src / "manifest.yaml").read_text(encoding="utf-8"))
+    assert "vocal_pitch" not in mf
+    assert "pitch_extraction" not in mf
+
+
+def test_maybe_extract_pitch_skips_when_no_lyrics(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    _patch_pitch_config(monkeypatch)
+
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [], src / "stems" / "vocals.ogg",
+    )
+    assert out is False
+    assert not (src / "vocal_pitch.json").exists()
+
+
+def test_maybe_extract_pitch_skips_when_vocals_missing(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    (src / "stems" / "vocals.ogg").unlink()
+    _patch_pitch_config(monkeypatch)
+
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.5, "w": "hi"}], src / "stems" / "vocals.ogg",
+    )
+    assert out is False
+    assert not (src / "vocal_pitch.json").exists()
+
+
+def test_maybe_extract_pitch_skips_when_no_server(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    # Empty server_url AND no demucs fallback (the _patch_pitch_config default).
+    _patch_pitch_config(monkeypatch, server_url=None)
+
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.5, "w": "hi"}], src / "stems" / "vocals.ogg",
+    )
+    assert out is False
+    assert not (src / "vocal_pitch.json").exists()
+
+
+def test_maybe_extract_pitch_skips_when_remote_returns_empty(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    _patch_pitch_config(monkeypatch)
+    # Stub vocal_pitch.extract_pitch_remote (load_sibling import inside
+    # _maybe_extract_pitch resolves to the top-level vocal_pitch module
+    # since pyproject pythonpath = ['.', 'lib']).
+    import vocal_pitch
+    monkeypatch.setattr(vocal_pitch, "extract_pitch_remote", lambda *a, **kw: [])
+
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.5, "w": "hi"}], src / "stems" / "vocals.ogg",
+    )
+    assert out is False
+    assert not (src / "vocal_pitch.json").exists()
+
+
+def test_maybe_extract_pitch_swallows_remote_failure(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    _patch_pitch_config(monkeypatch)
+
+    def _boom(*a, **kw):
+        raise RuntimeError("CREPE server request failed: connection refused")
+    import vocal_pitch
+    monkeypatch.setattr(vocal_pitch, "extract_pitch_remote", _boom)
+
+    # Must NOT raise — best-effort contract.
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.5, "w": "hi"}], src / "stems" / "vocals.ogg",
+    )
+    assert out is False
+    assert not (src / "vocal_pitch.json").exists()
+
+
+def test_maybe_extract_pitch_writes_file_and_manifest(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    _patch_pitch_config(monkeypatch)
+
+    fake_notes = [
+        {"t": 0.0, "d": 0.5, "midi": 64},
+        {"t": 0.6, "d": 0.4, "midi": 67},
+    ]
+    import vocal_pitch
+    monkeypatch.setattr(vocal_pitch, "extract_pitch_remote", lambda *a, **kw: fake_notes)
+
+    out = sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.5, "w": "hi"}], src / "stems" / "vocals.ogg",
+    )
+    assert out is True
+
+    pitch_path = src / "vocal_pitch.json"
+    assert pitch_path.exists()
+    payload = _json.loads(pitch_path.read_text(encoding="utf-8"))
+    assert payload == {"version": 1, "notes": fake_notes}
+
+    mf = _yaml.safe_load((src / "manifest.yaml").read_text(encoding="utf-8"))
+    assert mf["vocal_pitch"] == "vocal_pitch.json"
+    assert mf["pitch_extraction"] == {
+        "engine": vocal_pitch.PITCH_EXTRACTION_ENGINE,
+        "model": vocal_pitch.PITCH_EXTRACTION_MODEL,
+        "version": vocal_pitch.PITCH_EXTRACTION_SCHEMA_VERSION,
+    }
+
+
+def test_maybe_extract_pitch_emits_progress_within_slice(tmp_path, monkeypatch):
+    src = _make_sloppak_with_vocals(tmp_path)
+    _patch_pitch_config(monkeypatch)
+
+    # Have the stub call its own progress_cb at 0.5 to verify scaling
+    # into the caller's [base_frac, base_frac+span_frac] slice.
+    def _stub_extract(*args, **kwargs):
+        cb = kwargs["progress_cb"]
+        cb(0.0, "pitch", "start")
+        cb(0.5, "pitch", "mid")
+        return [{"t": 0.0, "d": 0.1, "midi": 60}]
+    import vocal_pitch
+    monkeypatch.setattr(vocal_pitch, "extract_pitch_remote", _stub_extract)
+
+    fracs: list[float] = []
+    def _capture(f, stage, msg):
+        fracs.append(round(f, 4))
+    sloppak_convert._maybe_extract_pitch(
+        src, [{"t": 0.0, "d": 0.1, "w": "x"}], src / "stems" / "vocals.ogg",
+    # Reserve [0.6, 0.8] of the overall progress space for this call.
+        progress_cb=_capture, base_frac=0.6, span_frac=0.2,
+    )
+
+    # Strictly monotonic; first scaled tick at 0.60 (0.0 → base), then
+    # 0.70 (0.5 mid → base + span/2), then the terminal 0.80 flush.
+    assert fracs[0] == 0.6
+    assert 0.7 in fracs
+    assert fracs[-1] == 0.8

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -858,6 +858,26 @@ def test_load_lyrics_for_pitch_returns_none_when_all_entries_filtered(tmp_path):
     assert sloppak_convert._load_lyrics_for_pitch(p) is None
 
 
+def test_load_lyrics_for_pitch_filters_non_numeric_t_or_d(tmp_path):
+    """The /pitch endpoint rejects non-numeric t/d server-side with a 4xx;
+    filter those out client-side so we don't waste a round-trip and so the
+    happy path's "got N notes" log line reflects what's actually plausible."""
+    p = tmp_path / "lyrics.json"
+    p.write_text(_json.dumps([
+        {"t": 0.0, "d": 0.5, "w": "ok"},
+        {"t": "0.0", "d": 0.5, "w": "string-t"},   # filtered (string)
+        {"t": 1.0, "d": None, "w": "none-d"},      # filtered (None)
+        {"t": True, "d": 0.5, "w": "bool-t"},      # filtered (bool — int subclass but server rejects)
+        {"t": 0.0, "d": False, "w": "bool-d"},     # filtered
+        {"t": 2, "d": 1, "w": "int-ok"},           # kept (int IS numeric)
+    ]), encoding="utf-8")
+    out = sloppak_convert._load_lyrics_for_pitch(p)
+    assert out == [
+        {"t": 0.0, "d": 0.5, "w": "ok"},
+        {"t": 2, "d": 1, "w": "int-ok"},
+    ]
+
+
 def test_maybe_transcribe_lyrics_runs_pitch_when_lyrics_already_exist(tmp_path, monkeypatch):
     """When a sloppak ships with lyrics (PSARC xml/sng or hand-authored),
     WhisperX skips — but the pitch path should STILL run since the

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -878,6 +878,43 @@ def test_load_lyrics_for_pitch_filters_non_numeric_t_or_d(tmp_path):
     ]
 
 
+def test_maybe_transcribe_lyrics_runs_pitch_when_whisperx_disabled_and_lyrics_exist(tmp_path, monkeypatch):
+    """The structural case from Copilot round 6: a user who has
+    pitch_extraction.enabled=True but whisperx.enabled=False (or a
+    convert that explicitly disables transcription) should still get
+    pitch over their existing on-disk lyrics. Previously the
+    `if not enabled: return False` short-circuit at the top of
+    _maybe_transcribe_lyrics killed the pitch path before it could
+    fire."""
+    src = _make_sloppak_with_vocals(tmp_path)
+    existing = src / "lyrics.json"
+    existing.write_text(
+        _json.dumps([{"t": 0.0, "d": 0.5, "w": "hi"}]), encoding="utf-8"
+    )
+    mf = _yaml.safe_load((src / "manifest.yaml").read_text(encoding="utf-8"))
+    mf["lyrics"] = "lyrics.json"
+    (src / "manifest.yaml").write_text(_yaml.safe_dump(mf), encoding="utf-8")
+
+    _patch_pitch_config(monkeypatch)
+    received = {}
+    import vocal_pitch
+    def _stub(*args, **kwargs):
+        received["lyrics"] = args[1]
+        return [{"t": 0.0, "d": 0.5, "midi": 64}]
+    monkeypatch.setattr(vocal_pitch, "extract_pitch_remote", _stub)
+
+    out = sloppak_convert._maybe_transcribe_lyrics(
+        src,
+        [{"id": "vocals", "file": "stems/vocals.ogg"}],
+        # WhisperX explicitly off — the wx_enabled=False path used to
+        # return immediately without touching pitch.
+        enabled=False,
+    )
+    assert out is False
+    assert received.get("lyrics") == [{"t": 0.0, "d": 0.5, "w": "hi"}]
+    assert (src / "vocal_pitch.json").exists()
+
+
 def test_maybe_transcribe_lyrics_runs_pitch_when_lyrics_already_exist(tmp_path, monkeypatch):
     """When a sloppak ships with lyrics (PSARC xml/sng or hand-authored),
     WhisperX skips — but the pitch path should STILL run since the

--- a/tests/test_vocal_pitch.py
+++ b/tests/test_vocal_pitch.py
@@ -1,0 +1,163 @@
+"""Tests for lib/vocal_pitch.py — karaoke per-syllable pitch via /pitch endpoint.
+
+Live CREPE inference is too heavy to test in CI (server-side feature),
+so these tests stub `requests.post` and verify the request shape +
+response parsing. End-to-end positive case is a manual verification
+step (see PR description).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import vocal_pitch
+from vocal_pitch import extract_pitch_remote
+
+
+class _FakeResponse:
+    def __init__(self, *, status_code=200, json_body=None, text=""):
+        self.status_code = status_code
+        self._json_body = json_body
+        self.text = text
+
+    def json(self):
+        if isinstance(self._json_body, Exception):
+            raise self._json_body
+        return self._json_body
+
+
+def _stub_post(monkeypatch, captured: dict, response: _FakeResponse):
+    """Patch requests.post and capture the call args so tests can assert
+    on request shape without standing up an actual HTTP server."""
+    def fake_post(url, files=None, data=None, headers=None, timeout=None):
+        captured["url"] = url
+        captured["files"] = files
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+        return response
+    import requests
+    monkeypatch.setattr(requests, "post", fake_post)
+
+
+def test_extract_pitch_remote_happy_path(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"fakeogg")
+    lyrics = [{"t": 1.0, "d": 0.5, "w": "hi"}, {"t": 2.0, "d": 0.3, "w": "world"}]
+    captured: dict = {}
+    _stub_post(monkeypatch, captured, _FakeResponse(json_body={
+        "notes": [
+            {"t": 1.0, "d": 0.5, "midi": 64},
+            {"t": 2.0, "d": 0.3, "midi": 67},
+        ],
+    }))
+    got = extract_pitch_remote(vocals, lyrics, "http://server:7865")
+    assert got == [
+        {"t": 1.0, "d": 0.5, "midi": 64},
+        {"t": 2.0, "d": 0.3, "midi": 67},
+    ]
+    # URL: server_url + /pitch, no double slash even when server_url has trailing /
+    assert captured["url"] == "http://server:7865/pitch"
+    # Lyrics serialized in the multipart Form body
+    assert json.loads(captured["data"]["lyrics"]) == lyrics
+
+
+def test_extract_pitch_remote_strips_trailing_slash_on_server_url(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    captured: dict = {}
+    _stub_post(monkeypatch, captured, _FakeResponse(json_body={"notes": []}))
+    extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865/")
+    assert captured["url"] == "http://server:7865/pitch"
+
+
+def test_extract_pitch_remote_includes_api_key_when_set(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    captured: dict = {}
+    _stub_post(monkeypatch, captured, _FakeResponse(json_body={"notes": []}))
+    extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}],
+                         "http://server:7865", api_key="secret")
+    assert captured["headers"] == {"Authorization": "Bearer secret"}
+
+
+def test_extract_pitch_remote_no_headers_when_no_api_key(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    captured: dict = {}
+    _stub_post(monkeypatch, captured, _FakeResponse(json_body={"notes": []}))
+    extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+    assert captured["headers"] is None
+
+
+def test_extract_pitch_remote_raises_on_non_200(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    _stub_post(monkeypatch, {}, _FakeResponse(status_code=500, text="server boom"))
+    with pytest.raises(RuntimeError, match="CREPE server error.*500.*server boom"):
+        extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+
+
+def test_extract_pitch_remote_raises_on_non_json(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    _stub_post(monkeypatch, {}, _FakeResponse(json_body=ValueError("not json")))
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+
+
+def test_extract_pitch_remote_raises_on_missing_notes_key(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    _stub_post(monkeypatch, {}, _FakeResponse(json_body={"something_else": []}))
+    with pytest.raises(RuntimeError, match="unexpected shape"):
+        extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+
+
+def test_extract_pitch_remote_raises_on_non_list_notes(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    _stub_post(monkeypatch, {}, _FakeResponse(json_body={"notes": "not a list"}))
+    with pytest.raises(RuntimeError, match="not a list"):
+        extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+
+
+def test_extract_pitch_remote_filters_malformed_entries(tmp_path, monkeypatch):
+    # Server returns a mix of valid + malformed entries. Defensive parser
+    # skips the bad ones instead of crashing the whole pass.
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    _stub_post(monkeypatch, {}, _FakeResponse(json_body={"notes": [
+        {"t": 1.0, "d": 0.5, "midi": 60},        # ok
+        "not a dict",                            # drop
+        {"t": 2.0, "d": 0.5},                    # missing midi → drop
+        {"t": "not numeric", "d": 0.5, "midi": 65},  # bad t → drop
+        {"t": 3.0, "d": 0.3, "midi": 67},        # ok
+    ]}))
+    got = extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+    assert got == [
+        {"t": 1.0, "d": 0.5, "midi": 60},
+        {"t": 3.0, "d": 0.3, "midi": 67},
+    ]
+
+
+def test_extract_pitch_remote_rounds_to_three_decimals(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    _stub_post(monkeypatch, {}, _FakeResponse(json_body={"notes": [
+        {"t": 1.234567, "d": 0.876543, "midi": 60},
+    ]}))
+    got = extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+    assert got[0]["t"] == 1.235
+    assert got[0]["d"] == 0.877
+
+
+def test_pitch_extraction_constants_are_stable():
+    """Pin the constants so a refactor that silently bumps engine name or
+    schema version trips this test instead of shipping a wire break to
+    cache consumers."""
+    assert vocal_pitch.PITCH_EXTRACTION_ENGINE == "crepe"
+    assert vocal_pitch.PITCH_EXTRACTION_MODEL == "v1"
+    assert vocal_pitch.PITCH_EXTRACTION_SCHEMA_VERSION == "1.0.0"

--- a/tests/test_vocal_pitch.py
+++ b/tests/test_vocal_pitch.py
@@ -164,6 +164,27 @@ def test_extract_pitch_remote_filters_malformed_entries(tmp_path, monkeypatch):
     ]
 
 
+def test_extract_pitch_remote_filters_non_finite_server_notes(tmp_path, monkeypatch):
+    """A misbehaving server (or numerical edge in CREPE) could surface
+    NaN/±Inf for t or d. They must not reach the on-disk vocal_pitch.json
+    — strict-JSON consumers (e.g. browser JSON.parse) would reject the
+    non-standard NaN/Infinity tokens that allow_nan=True would emit."""
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    _stub_post(monkeypatch, {}, _FakeResponse(json_body={"notes": [
+        {"t": 1.0, "d": 0.5, "midi": 64},                # kept
+        {"t": float("nan"), "d": 0.5, "midi": 60},       # filtered
+        {"t": 0.0, "d": float("inf"), "midi": 60},       # filtered
+        {"t": float("-inf"), "d": 0.5, "midi": 60},      # filtered
+        {"t": 2.0, "d": 0.3, "midi": 67},                # kept
+    ]}))
+    got = extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://s:7865")
+    assert got == [
+        {"t": 1.0, "d": 0.5, "midi": 64},
+        {"t": 2.0, "d": 0.3, "midi": 67},
+    ]
+
+
 def test_extract_pitch_remote_rounds_to_three_decimals(tmp_path, monkeypatch):
     vocals = tmp_path / "vocals.ogg"
     vocals.write_bytes(b"")

--- a/tests/test_vocal_pitch.py
+++ b/tests/test_vocal_pitch.py
@@ -103,6 +103,16 @@ def test_extract_pitch_remote_wraps_request_exception_as_runtimeerror(tmp_path, 
         extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
 
 
+def test_extract_pitch_remote_wraps_oserror_as_runtimeerror(tmp_path):
+    # Vocals file deliberately missing — open() raises FileNotFoundError
+    # (an OSError subclass) which must surface as RuntimeError per the
+    # docstring contract, not leak the raw OSError. Mirrors the
+    # network-error wrapping above.
+    vocals = tmp_path / "does_not_exist.ogg"
+    with pytest.raises(RuntimeError, match="Reading vocals stem.*does_not_exist.ogg failed"):
+        extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+
+
 def test_extract_pitch_remote_raises_on_non_200(tmp_path, monkeypatch):
     vocals = tmp_path / "vocals.ogg"
     vocals.write_bytes(b"")

--- a/tests/test_vocal_pitch.py
+++ b/tests/test_vocal_pitch.py
@@ -92,6 +92,17 @@ def test_extract_pitch_remote_no_headers_when_no_api_key(tmp_path, monkeypatch):
     assert captured["headers"] is None
 
 
+def test_extract_pitch_remote_wraps_request_exception_as_runtimeerror(tmp_path, monkeypatch):
+    vocals = tmp_path / "vocals.ogg"
+    vocals.write_bytes(b"")
+    import requests
+    def _raise(*a, **kw):
+        raise requests.ConnectionError("dns blew up")
+    monkeypatch.setattr(requests, "post", _raise)
+    with pytest.raises(RuntimeError, match="CREPE server request failed.*dns blew up"):
+        extract_pitch_remote(vocals, [{"t": 0, "d": 0.1, "w": "x"}], "http://server:7865")
+
+
 def test_extract_pitch_remote_raises_on_non_200(tmp_path, monkeypatch):
     vocals = tmp_path / "vocals.ogg"
     vocals.write_bytes(b"")


### PR DESCRIPTION
## Summary

Pre-generates the karaoke pitch data inside sloppaks during convert, instead of leaving it as a runtime cost for [slopsmith-plugin-lyrics-karaoke](https://github.com/byrongamatos/slopsmith-plugin-lyrics-karaoke) to handle locally on first play. Now that #381 ensures lyrics + vocals stem are present at convert time, the demucs server's existing `/pitch` endpoint can run CREPE server-side and we ship the result inside the sloppak as a `vocal_pitch.json` the karaoke plugin already knows how to render.

Per Byron's suggestion: *"i was thinking maybe we should add the karaoke conversion during sloppak conversion, now that we always will have lyrics — the demucs server has an endpoint for that"*.

## Pipeline

```
Demucs split → stems/vocals.ogg
WhisperX     → lyrics.json   (+ lyric_transcription block)
CREPE /pitch → vocal_pitch.json (+ pitch_extraction block)
```

Each step gates on the previous one's output. Failure at any step is best-effort — the surrounding split / conversion never aborts. The karaoke plugin's existing reader (`_persist_pitch` at [routes.py:495](https://github.com/byrongamatos/slopsmith-plugin-lyrics-karaoke/blob/main/routes.py#L495)) consumes the file shape unchanged.

## What lands

- **New `lib/vocal_pitch.py`** — `extract_pitch_remote(vocals_path, lyrics, server_url, ...)` posts to `/pitch`, returns `[{t, d, midi}]`. Constants `PITCH_EXTRACTION_{ENGINE,MODEL,SCHEMA_VERSION}` centralize the provenance block values.
- **`_maybe_extract_pitch()` in `lib/sloppak_convert.py`** — best-effort step that runs after `_maybe_transcribe_lyrics` writes a fresh `lyrics.json`. Gates on `pitch_extraction.enabled` config + vocals stem + lyrics + server URL.
- **`_get_pitch_config()`** reads `pitch_extraction.{enabled, server_url, api_key}` from the same `config.json` whisperx + demucs settings live in. `server_url` falls through to `demucs_server_url` so a single-server deployment (the common case) just works.
- **`_rewrite_pitch_manifest()`** writes `vocal_pitch: vocal_pitch.json` + `pitch_extraction: {engine, model, version}` block. Mirrors the `lyric_transcription` / `stem_separation` pattern per #357.
- **Spec doc §2.4** — full `vocal_pitch` documentation with schema, semver semantics, and pointer to the karaoke plugin.
- **10 unit tests** in `tests/test_vocal_pitch.py` — happy path, error modes (non-200, non-JSON, missing/non-list `notes`), defensive entry filtering, rounding, api-key header routing, constants pin.

## Config

`${CONFIG_DIR}/config.json` gains an optional block:

```json
{
  "pitch_extraction": {
    "enabled": false,
    "server_url": null,
    "api_key": null
  }
}
```

Default disabled. Setting `enabled: true` (and either `server_url` or relying on `demucs_server_url`) is the opt-in.

## Test plan

- [x] 10 unit tests pass.
- [x] Existing `test_lyrics_transcribe.py` + `test_sloppak_convert.py` unchanged behavior (67 pass, 1 skipped, 1 pre-existing unrelated PATH-casing failure on Windows).
- [ ] **Manual**: convert a PSARC with vocals on a host with the demucs server reachable + `pitch_extraction.enabled: true`. Verify `vocal_pitch.json` lands inside the sloppak with the `pitch_extraction` manifest block. Open the sloppak with the karaoke plugin installed → confirm pitch bars render without the plugin re-running pYIN.
- [ ] **Manual (server unreachable)**: convert with `enabled: true` but server unreachable. Verify lyrics still land, pitch step logs a warning and skips, the sloppak is otherwise complete.

## Out of scope

* **Local CREPE / pYIN fallback** — today the gate logs + skips when no server is configured. The karaoke plugin's existing local-pYIN path still works as a runtime fallback for users who don't run a demucs server.
* **WS payload exposure of vocal_pitch** through the highway endpoint. The karaoke plugin reads the file directly via a custom backend route, so the WS surface isn't required for it to work. Adding it would let other plugins consume the data the same way they consume `lyrics`.
* **Server-side actual-vs-requested model introspection** — same parallel gap as `lyric_transcription.model` / `stem_separation.model`. Worth tackling on all three blocks together when the server gains a config-reporting endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)