### PR TITLE
feat: add SlopScale to community plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Simplify Chords](https://github.com/bkranendonk/slopsmith-plugin-simplify-chords)  | Changes complex chords on the note highway to simpler ones. Inspired by Ultimate Guitar's Simplify button. | `git clone ...slopsmith-plugin-simplify-chords.git simplify-chords`     |
 | [Key Bindings](https://github.com/jackipicco/slopsmith-plugin-key-bindings)  | Highway key bindings for keyboard and TV remote| `git clone ...slopsmith-plugin-key-bindings.git key_bindings`     |
 | [Folder Organizer](https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name | `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
+| [SlopScale](https://github.com/ChrisBeWithYou/slopsmith-plugin-slopscale)              | Scale, arpeggio, and sweep-arpeggio practice routines with 3D highway, 2D highway, and tab renderers. Pathway selector, CAGED shape-run arpeggios, and generated audio backing. | `git clone ...slopsmith-plugin-slopscale.git slopscale`               |
 | [NAM Rig Builder](https://github.com/Jafz2001/slopsmith-plugin-nam-rig-builder) | Map Rocksmith tones to chained NAM neural-amp rigs (tone3000 captures + IRs) — full pedal→amp→cab playback, per-stage bypass, and a gear catalog | `git clone ...slopsmith-plugin-nam-rig-builder.git nam_rig_builder` |
 
 


### PR DESCRIPTION
## Summary

Adds [SlopScale](https://github.com/ChrisBeWithYou/slopsmith-plugin-slopscale) to the community plugin table in the README.

**SlopScale** is a scale, arpeggio, and sweep-arpeggio practice plugin with:
- Pathway selector (Pentatonic Foundation, Chord-Tone Targeting, Modal Awareness, Diatonic Triad Drill, Seventh Vocabulary, ii–V–I Workout, Harmonic Minor Exotic, Sweep Arpeggio Primer) + Custom mode
- Three renderers: 3D Note Highway (delegated to host), built-in 2D Highway, built-in 2D Tablature
- CAGED shape-run arpeggios — exact fingering geometry transposed per chord, strict-ascend and closest-position modes
- Sweep arpeggio primer with proper one-note-per-string sweeps and HOPO turnaround
- Generated audio: synthesised notes, metronome with grouped accents, harmony backing

## Install

```bash
cd /path/to/slopsmith/plugins
git clone https://github.com/ChrisBeWithYou/slopsmith-plugin-slopscale.git slopscale
docker compose restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)