### PR TITLE
Add audio_preview plugin to curated list

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Key Bindings](https://github.com/jackipicco/slopsmith-plugin-key-bindings)  | Highway key bindings for keyboard and TV remote| `git clone ...slopsmith-plugin-key-bindings.git key_bindings`     |
 | [Folder Organizer](https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name | `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
 | [NAM Rig Builder](https://github.com/Jafz2001/slopsmith-plugin-nam-rig-builder) | Map Rocksmith tones to chained NAM neural-amp rigs (tone3000 captures + IRs) — full pedal→amp→cab playback, per-stage bypass, and a gear catalog | `git clone ...slopsmith-plugin-nam-rig-builder.git nam_rig_builder` |
-| [Audio Preview](https://github.com/saleemk/slopsmith-plugin-audio-preview) | Quick audio previews from library cards with configurable start time, volume, and duration | `git clone https://github.com/saleemk/slopsmith-plugin-audio-preview.git audio_preview` |
+| [Audio Preview](https://github.com/saleemk/slopsmith-plugin-audio-preview) | Quick audio previews from library cards with configurable start time, volume, and duration | `git clone ...slopsmith-plugin-audio-preview.git audio_preview` |
 
 Install any plugin by cloning it into your `plugins/` directory and restarting:
 

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Routes are registered under `/api/plugins/{plugin_id}/` to avoid conflicts.
 | [Key Bindings](https://github.com/jackipicco/slopsmith-plugin-key-bindings)  | Highway key bindings for keyboard and TV remote| `git clone ...slopsmith-plugin-key-bindings.git key_bindings`     |
 | [Folder Organizer](https://github.com/Elit3d/slopsmith-plugin-folder-organizer) | Organize your sloppak DLC songs into a folder tree view, grouped by subfolder name | `git clone ...slopsmith-plugin-folder-organizer.git folder-organizer`     |
 | [NAM Rig Builder](https://github.com/Jafz2001/slopsmith-plugin-nam-rig-builder) | Map Rocksmith tones to chained NAM neural-amp rigs (tone3000 captures + IRs) — full pedal→amp→cab playback, per-stage bypass, and a gear catalog | `git clone ...slopsmith-plugin-nam-rig-builder.git nam_rig_builder` |
-
+| [Audio Preview](https://github.com/saleemk/slopsmith-plugin-audio-preview) | Quick audio previews from library cards with configurable start time, volume, and duration | `git clone https://github.com/saleemk/slopsmith-plugin-audio-preview.git audio_preview` |
 
 Install any plugin by cloning it into your `plugins/` directory and restarting:
 


### PR DESCRIPTION
Adds Audio Preview plugin to the curated plugin list.

## Plugin Features
- Play button on each library card for quick previews
- Configurable start time, volume, and duration
- Supports PSARC and multi-stem sloppaks
- MIT licensed (AGPL-compatible)

Repository: https://github.com/saleemk/slopsmith-plugin-audio-preview
Release: v1.0.0