### PR TITLE
fix(highway): preserve naming_mode param on arrangement switch

### DIFF
--- a/static/highway.js
+++ b/static/highway.js
@@ -3034,9 +3034,10 @@ function createHighway() {
             _resetChordRenderState();
             const wsParams = new URLSearchParams();
             if (arrangement !== undefined) wsParams.set('arrangement', arrangement);
-            if (typeof window._getArrangementNamingMode === 'function') {
-                wsParams.set('naming_mode', window._getArrangementNamingMode());
-            }
+            const namingMode = typeof window._getArrangementNamingMode === 'function'
+                ? window._getArrangementNamingMode()
+                : (localStorage.getItem('arrangementNamingMode') || 'smart');
+            wsParams.set('naming_mode', namingMode);
             const qs = wsParams.toString();
             // filename might already be encoded from data-play attribute
             const decoded = decodeURIComponent(filename);

--- a/static/highway.js
+++ b/static/highway.js
@@ -3034,9 +3034,16 @@ function createHighway() {
             _resetChordRenderState();
             const wsParams = new URLSearchParams();
             if (arrangement !== undefined) wsParams.set('arrangement', arrangement);
-            const namingMode = typeof window._getArrangementNamingMode === 'function'
-                ? window._getArrangementNamingMode()
-                : (localStorage.getItem('arrangementNamingMode') || 'smart');
+            let namingMode = 'smart';
+            if (typeof window._getArrangementNamingMode === 'function') {
+                const v = window._getArrangementNamingMode();
+                if (v === 'smart' || v === 'legacy') namingMode = v;
+            } else {
+                try {
+                    const v = localStorage.getItem('arrangementNamingMode');
+                    if (v === 'smart' || v === 'legacy') namingMode = v;
+                } catch (_) {}
+            }
             wsParams.set('naming_mode', namingMode);
             const qs = wsParams.toString();
             // filename might already be encoded from data-play attribute

--- a/static/highway.js
+++ b/static/highway.js
@@ -3032,10 +3032,15 @@ function createHighway() {
             _filteredHandShapes = null;
             _phrasesHaveHandShapes = false;
             _resetChordRenderState();
-            const arrParam = arrangement !== undefined ? `?arrangement=${arrangement}` : '';
+            const wsParams = new URLSearchParams();
+            if (arrangement !== undefined) wsParams.set('arrangement', arrangement);
+            if (typeof window._getArrangementNamingMode === 'function') {
+                wsParams.set('naming_mode', window._getArrangementNamingMode());
+            }
+            const qs = wsParams.toString();
             // filename might already be encoded from data-play attribute
             const decoded = decodeURIComponent(filename);
-            const wsUrl = `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws/highway/${decoded}${arrParam}`;
+            const wsUrl = `${location.protocol === 'https:' ? 'wss:' : 'ws:'}//${location.host}/ws/highway/${decoded}${qs ? '?' + qs : ''}`;
             console.log('reconnect:', wsUrl);
             this.connect(wsUrl, _connectOpts);
         },


### PR DESCRIPTION
## Summary

- When switching arrangements (e.g. Lead → Rhythm), the WebSocket
  reconnect path was only sending `?arrangement=N`, dropping the
  `naming_mode` parameter. The server would then default to legacy/combo
  mode, reverting smart arrangement names.
- Fixed `highway.js` `reconnect()` to build the query string with
  `URLSearchParams`, forwarding `naming_mode` from
  `window._getArrangementNamingMode()` — consistent with how the initial
  `playSong` connect in `app.js` works.

## Test plan
- [ ] Open a song with Arrangement Names set to Smart
- [ ] Confirm arrangements show smart names (Lead, Alt. Lead, etc.)
- [ ] Switch arrangement (e.g. Lead → Rhythm)
- [ ] Confirm smart names are preserved — no revert to Combo
- [ ] Confirm WS request includes `?arrangement=1&naming_mode=smart`