### PR TITLE
fix(highway_3d): fret-hand mute X appearing on non-muted chord gems

### DIFF
--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -8207,6 +8207,14 @@
                             Object.assign(_scrChordNote, cn);
                             _scrChordNote.t   = ch.t;
                             _scrChordNote.sus = cn.sus || 0;
+                            // `fhm` is omit-when-false in the wire format (unlike `mt`/`pm`
+                            // which are always emitted). Before 5913129, chord-level
+                            // fretHandMute was folded into `mt` (always-emitted), so
+                            // Object.assign would overwrite any stale value. After that
+                            // commit fhm is its own field — absent on non-muted notes —
+                            // so Object.assign leaves a stale `true` from a previous
+                            // muted chord note untouched. Reset it explicitly here.
+                            _scrChordNote.fhm = cn.fhm || false;
                             drawNote(
                                 _scrChordNote,
                                 now,


### PR DESCRIPTION
## Problem

After a chord with fret-hand muted notes scrolls past, subsequent
non-muted chord gems incorrectly display the fret-hand mute X symbol.

The bug surfaces only after the first muted chord is rendered — hence
"after a while" — and persists for all chord gems that follow.

## Root cause

`_scrChordNote` is a persistent scratch object reused across chord notes
each frame to avoid per-note allocations (`Object.assign(_scrChordNote, cn)`).
`Object.assign` only copies properties that **exist** on the source — it
does not clear properties absent from `cn`.

`fhm` (fret-hand mute) is **omit-when-false** in the wire format
(`note_to_wire` only emits it when `True`). Before commit 5913129,
chord-level `fretHandMute` was folded into `mt` (string mute), which is
always emitted — so `Object.assign` would correctly overwrite `mt` with
`false` on non-muted notes. After 5913129 moved `fretHandMute` to its own
`fhm` field, a non-muted `cn` has no `fhm` property at all, leaving
the stale `true` from the previous muted chord note in `_scrChordNote`.

## Fix

Explicitly reset `_scrChordNote.fhm` from `cn` after the `Object.assign`,
so the absence of the property on a non-muted note is treated as `false`.

## Testing

Load any song that contains fret-hand muted chords followed by normal
chords (e.g. a song with X-marked power chords mid-song). Verify that
the X symbol disappears from chord gems after the muted passage.