### PR TITLE
feat: async plugin loading — never gate core startup on plugin installs (#421)

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -19,10 +19,24 @@ log = logging.getLogger("slopsmith.plugins")
 
 
 PLUGINS_DIR = Path(__file__).parent
+# Holds only *ready* (loaded) plugins — those whose dependencies installed
+# and whose routes registered. A plugin GRADUATES from PENDING_PLUGINS into
+# this list when it becomes ready. Kept ready-only because every consumer
+# that imports LOADED_PLUGINS (settings export/import, diagnostics, the
+# orphan-detection in lib/diagnostics_bundle.py) wants only usable plugins.
 LOADED_PLUGINS = []
-# Guards all mutations of and snapshots from LOADED_PLUGINS so the
-# background plugin-loader thread and the event-loop request handlers
-# never race on the list.
+# Every discovered plugin that is NOT yet ready, keyed by plugin_id and held
+# in discovery order. Each value is a lightweight, manifest-derived nav entry
+# (no routes, no callables) carrying a `status` of "installing" or "failed"
+# (plus `error` text when failed) so /api/plugins can render the nav slot
+# immediately — disabled "installing…" / "failed" — while the background
+# loader works through installs sequentially. A plugin leaves PENDING_PLUGINS
+# only by GRADUATING into LOADED_PLUGINS (ready); a failed plugin stays here
+# so it remains a visible, disabled nav entry until the next restart retries it.
+PENDING_PLUGINS: dict = {}
+# Guards all mutations of and snapshots from LOADED_PLUGINS and
+# PENDING_PLUGINS so the background plugin-loader thread and the event-loop
+# request handlers never race on either structure.
 PLUGINS_LOCK = threading.RLock()
 
 # Persistent pip install location (survives container restarts)
@@ -546,6 +560,46 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             # Progress reporting must never break plugin startup.
             pass
 
+    # Re-entrancy: a fresh load_plugins() pass owns the published state from
+    # scratch. Clearing BOTH structures at the START (rather than an atomic
+    # clear()+extend() at the END) lets us publish each plugin incrementally
+    # as it graduates, so /api/plugins reflects ready plugins the moment they
+    # are usable instead of all-at-once when the slowest install finishes.
+    # Tests and dev "reload plugins" re-invoke this; the clear keeps repeated
+    # passes from accumulating duplicates while preserving list identity.
+    with PLUGINS_LOCK:
+        LOADED_PLUGINS.clear()
+        PENDING_PLUGINS.clear()
+
+    def _loaded_count() -> int:
+        with PLUGINS_LOCK:
+            return len(LOADED_PLUGINS)
+
+    def _mark_failed(plugin_id: str, error: str) -> None:
+        """Flip a pending plugin's status to "failed" with error text so it
+        stays a visible, disabled nav entry. No-op if the plugin already
+        graduated (it can't fail after becoming ready)."""
+        with PLUGINS_LOCK:
+            entry = PENDING_PLUGINS.get(plugin_id)
+            if entry is not None:
+                entry["status"] = "failed"
+                entry["error"] = error
+
+    def _graduate(entry: dict) -> int:
+        """Move a plugin from pending to loaded (ready). Inserts into
+        LOADED_PLUGINS at the slot dictated by its discovery order (`_order`)
+        so the published list stays in discovery order even when earlier
+        plugins failed (leaving gaps) or a user-copy fallback graduates out of
+        sequence after the main loop. Pops the pending entry under the same
+        lock so a reader never sees the plugin in both structures. Returns the
+        new ready count."""
+        order = entry.get("_order", 0)
+        with PLUGINS_LOCK:
+            pos = sum(1 for e in LOADED_PLUGINS if e.get("_order", 0) < order)
+            LOADED_PLUGINS.insert(pos, entry)
+            PENDING_PLUGINS.pop(entry["id"], None)
+            return len(LOADED_PLUGINS)
+
     # Collect plugin directories — user plugins first so they override built-in
     plugin_dirs = []
     user_plugins_dir = os.environ.get("SLOPSMITH_PLUGINS_DIR")
@@ -735,10 +789,41 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         total=len(plugin_load_specs),
     )
 
-    # Accumulate into a local list and publish atomically once all
-    # plugins are loaded, so concurrent readers never see a partially
-    # populated LOADED_PLUGINS.
-    _loaded_batch: list = []
+    def _nav_entry(plugin_id: str, plugin_dir: Path, manifest: dict, order: int) -> dict:
+        """Build the manifest-derived nav fields shared by a pending entry and
+        a graduated (ready) entry. Carries everything /api/plugins needs to
+        render the nav slot — name, nav, type, bundled flag, version, and the
+        has_* capability booleans — without importing the plugin's code."""
+        return {
+            "id": plugin_id,
+            "name": manifest.get("name", plugin_id),
+            "nav": manifest.get("nav"),
+            "type": manifest.get("type"),
+            "bundled": _is_bundled(plugin_dir, manifest),
+            "version": manifest.get("version"),
+            "has_screen": bool(manifest.get("screen")),
+            "has_script": bool(manifest.get("script")),
+            "has_settings": bool(manifest.get("settings")),
+            "has_tour": _is_valid_tour_manifest(manifest.get("tour")),
+            "_order": order,
+        }
+
+    # Record EVERY discovered plugin as a pending "installing" nav entry up
+    # front, in discovery order, so /api/plugins can render the full nav
+    # immediately — before any (potentially 20-30 min) dependency install
+    # runs. A plugin graduates out of here into LOADED_PLUGINS when ready;
+    # on failure it stays here flipped to "failed". `_spec_order` maps each
+    # kept plugin_id to its discovery index so a user-copy fallback graduating
+    # after the main loop can reclaim the bundled plugin's original nav slot.
+    _spec_order: dict[str, int] = {}
+    with PLUGINS_LOCK:
+        for idx, (plugin_id, plugin_dir, manifest) in enumerate(plugin_load_specs):
+            _spec_order[plugin_id] = idx
+            entry = _nav_entry(plugin_id, plugin_dir, manifest, idx)
+            entry["status"] = "installing"
+            entry["error"] = None
+            PENDING_PLUGINS[plugin_id] = entry
+
     # Track plugin_ids whose routes.setup() raised an exception, so we
     # can fall back to evicted user copies for those plugin_ids below.
     _route_failed_ids: set[str] = set()
@@ -768,11 +853,18 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         )
         req_ok = _install_requirements(plugin_dir, plugin_id)
         if not req_ok:
+            # Non-fatal: a pip failure may just mean an OPTIONAL dependency
+            # couldn't be installed (read-only filesystem, an extra a plugin
+            # degrades gracefully without). We surface the error but still try
+            # to load routes. If the plugin genuinely needs the missing dep its
+            # routes will fail to import below and it becomes "failed" there —
+            # so a real install failure still surfaces as a visible, disabled
+            # nav entry (ADR 0001) without disabling plugins that work anyway.
             _emit_progress(
                 "plugin-error",
                 f"Failed to install requirements for '{plugin_id}'",
                 plugin_id=plugin_id,
-                loaded=idx,
+                loaded=_loaded_count(),
                 total=len(plugin_load_specs),
                 error="Requirements installation failed; check server logs for details",
             )
@@ -805,7 +897,12 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         )
         plugin_context["log"] = logging.getLogger(f"slopsmith.plugin.{plugin_id}")
 
-        # Load routes using importlib to avoid module name collisions
+        # Load routes using importlib to avoid module name collisions.
+        # `route_ok` gates graduation: only a plugin that installs AND
+        # registers its routes cleanly becomes ready. A route failure leaves
+        # it "failed" in PENDING_PLUGINS (the fallback block below may still
+        # graduate a user-copy for an evicted bundled plugin).
+        route_ok = True
         routes_file = manifest.get("routes")
         if routes_file:
             _emit_progress(
@@ -848,6 +945,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     log.info("Loaded routes for plugin %r", plugin_id)
             except Exception as e:
                 log.exception("Failed to load routes for plugin %r", plugin_id)
+                route_ok = False
                 _route_failed_ids.add(plugin_id)
                 # If this was a mid-flight timeout, mark the plugin so the
                 # fallback block skips it — the original setup() may still be
@@ -897,36 +995,29 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     # Purge immediately to prevent module leakage into later plugins.
                     for _k in _stale:
                         sys.modules.pop(_k, None)
+                _mark_failed(plugin_id, str(e))
                 _emit_progress(
                     "plugin-error",
                     f"Failed loading routes for '{plugin_id}'",
                     plugin_id=plugin_id,
-                    loaded=idx,
+                    loaded=_loaded_count(),
                     total=len(plugin_load_specs),
                     error=str(e),
                 )
 
-        _loaded_batch.append({
-            "id": plugin_id,
-            "name": manifest.get("name", plugin_id),
-            "nav": manifest.get("nav"),
-            # `type` is an optional manifest hint for the frontend —
-            # e.g. "visualization" lets the highway viz picker know
-            # this plugin offers a renderer. Absent → no declared
-            # role; plugin is still loaded and scripts run, it just
-            # doesn't show up in role-specific UIs. See slopsmith#36.
-            "type": manifest.get("type"),
-            # Uses the same _is_bundled() helper as the duplicate-skip path.
-            # See the helper's docstring for the three-part check that prevents
-            # user-installed plugins (cloned into plugins/ or carrying a forged
-            # "bundled": true manifest field) from being misidentified as core.
-            # Surfaced in /api/plugins so the plugin-list UI can render a
-            # 'Bundled' badge next to the plugin name in the settings collapsible.
-            "bundled": _is_bundled(plugin_dir, manifest),
-            "has_screen": bool(manifest.get("screen")),
-            "has_script": bool(manifest.get("script")),
-            "has_settings": bool(manifest.get("settings")),
-            "has_tour": _is_valid_tour_manifest(manifest.get("tour")),
+        if not route_ok:
+            # Not ready: leave it "failed" in PENDING_PLUGINS so it shows as a
+            # disabled nav entry. If it's a bundled plugin that evicted a user
+            # copy, the fallback block below may still graduate that copy.
+            continue
+
+        # Graduate: dependencies are installed and routes registered, so the
+        # plugin is ready. Publish it incrementally — readers (and the SSE
+        # `plugin-registered` event that drives the frontend re-fetch) see it
+        # the moment it's usable, not when the slowest sibling finishes.
+        loaded_entry = dict(_nav_entry(plugin_id, plugin_dir, manifest, idx))
+        loaded_entry.update({
+            "status": "ready",
             # Normalized list of relpaths under CONFIG_DIR that this
             # plugin opts in to settings export/import. Empty for
             # plugins that don't declare `settings.server_files`. See
@@ -940,12 +1031,13 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             "_dir": plugin_dir,
             "_manifest": manifest,
         })
+        _new_count = _graduate(loaded_entry)
         log.info("Registered plugin %r (%s)", plugin_id, manifest.get("name", ""))
         _emit_progress(
             "plugin-registered",
             f"Registered plugin '{plugin_id}'",
             plugin_id=plugin_id,
-            loaded=idx + 1,
+            loaded=_new_count,
             total=len(plugin_load_specs),
         )
 
@@ -982,9 +1074,9 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "Restart the server to recover.",
                 evicted_id,
             )
-            # Remove the broken bundled entry too — its routes are in an
-            # unknown state and it should not appear in /api/plugins.
-            _loaded_batch[:] = [e for e in _loaded_batch if e["id"] != evicted_id]
+            # The broken bundled plugin never graduated (route_ok was False),
+            # so there is nothing to remove from LOADED_PLUGINS; it stays a
+            # "failed" pending entry until a restart recovers it.
             continue
         _ev_id, ev_dir, ev_manifest = evicted_spec
         log.warning(
@@ -992,15 +1084,11 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
             "falling back to user-installed copy at %s.",
             evicted_id, ev_dir,
         )
-        # Remove the broken bundled entry from the batch, recording its
-        # original position so the fallback is inserted there instead of
-        # being appended at the end (appending would change the order of
-        # plugins in /api/plugins and the frontend playSong wrapper chain).
-        _bundled_orig_idx = next(
-            (i for i, e in enumerate(_loaded_batch) if e["id"] == evicted_id),
-            len(_loaded_batch),
-        )
-        _loaded_batch[:] = [e for e in _loaded_batch if e["id"] != evicted_id]
+        # The fallback reclaims the bundled plugin's original discovery slot so
+        # /api/plugins order (and the frontend playSong wrapper chain) is
+        # preserved. The broken bundled copy never graduated, so we just
+        # graduate the user copy at the bundled plugin's `_order`.
+        _bundled_orig_order = _spec_order.get(evicted_id, len(plugin_load_specs))
         # Ensure the fallback directory is at the FRONT of sys.path so
         # its modules take priority over any bundled copy still present.
         # Simply inserting when absent is not enough: on repeated
@@ -1034,7 +1122,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "plugin-error",
                 f"Failed to install requirements for fallback copy of '{evicted_id}'",
                 plugin_id=evicted_id,
-                loaded=len(_loaded_batch),
+                loaded=_loaded_count(),
                 total=len(plugin_load_specs),
                 error="Requirements installation failed for fallback copy; check server logs",
             )
@@ -1100,21 +1188,23 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     "Fallback user-installed copy of %r also failed to load routes; "
                     "plugin unavailable (not registered).", evicted_id,
                 )
-                # Emit a plugin-error so startup-status reflects the
-                # fallback's failure as the root cause, not the earlier
-                # bundled-copy error. Without this the status stays on the
-                # stale bundled error even though that's no longer the
-                # active failure.
+                # Update the failed pending entry + emit a plugin-error so both
+                # /api/plugins and startup-status reflect the fallback's failure
+                # as the root cause, not the earlier bundled-copy error. Without
+                # this the status stays on the stale bundled error even though
+                # that's no longer the active failure.
+                _both_failed_err = (
+                    f"Both bundled and user-installed copies of '{evicted_id}' "
+                    "failed to load routes; plugin unavailable — check server logs"
+                )
+                _mark_failed(evicted_id, _both_failed_err)
                 _emit_progress(
                     "plugin-error",
                     f"Fallback copy of plugin '{evicted_id}' also failed to load routes",
                     plugin_id=evicted_id,
-                    loaded=len(_loaded_batch),
+                    loaded=_loaded_count(),
                     total=len(plugin_load_specs),
-                    error=(
-                        f"Both bundled and user-installed copies of '{evicted_id}' "
-                        "failed to load routes; plugin unavailable — check server logs"
-                    ),
+                    error=_both_failed_err,
                 )
                 # Warn on partial registration in the fallback path too.
                 _fallback_routes_after = len(getattr(app, "routes", []))
@@ -1126,21 +1216,14 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                     )
                 fallback_routes_ok = False
         if fallback_routes_ok:
-            _loaded_batch.insert(_bundled_orig_idx, {
-                "id": evicted_id,
-                "name": ev_manifest.get("name", evicted_id),
-                "nav": ev_manifest.get("nav"),
-                "type": ev_manifest.get("type"),
-                "bundled": False,  # user copy, not bundled
-                # Marks this entry as an emergency user-copy fallback: the
-                # bundled routes failed, so the evicted user-installed copy
-                # was loaded instead.  Surfaced in /api/plugins and the
-                # settings UI so users know the bundled build is broken.
+            ev_entry = dict(_nav_entry(evicted_id, ev_dir, ev_manifest, _bundled_orig_order))
+            ev_entry.update({
+                "status": "ready",
+                # _nav_entry already sets bundled=False for a user copy
+                # (not in PLUGINS_DIR); mark it as the emergency fallback so
+                # /api/plugins and the settings UI can warn that the bundled
+                # build is broken and an older user copy is running.
                 "fallback": True,
-                "has_screen": bool(ev_manifest.get("screen")),
-                "has_script": bool(ev_manifest.get("script")),
-                "has_settings": bool(ev_manifest.get("settings")),
-                "has_tour": _is_valid_tour_manifest(ev_manifest.get("tour")),
                 "_export_paths": _normalize_export_paths(ev_manifest.get("settings"), evicted_id),
                 "_diagnostics_paths": _normalize_diagnostics_paths(ev_manifest.get("diagnostics"), evicted_id),
                 "_diagnostics_callable_spec": _parse_diagnostics_callable(ev_manifest.get("diagnostics"), evicted_id),
@@ -1148,6 +1231,7 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "_dir": ev_dir,
                 "_manifest": ev_manifest,
             })
+            _graduate(ev_entry)
             log.info("Registered fallback user copy of plugin %r (%s)", evicted_id, ev_manifest.get("name", ""))
             # Emit a compensating progress event to clear the bundled-failure
             # error from startup-status. Without this, the final
@@ -1162,24 +1246,18 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
                 "plugin-registered",
                 f"Registered fallback copy of plugin '{evicted_id}'",
                 plugin_id=evicted_id,
-                loaded=len(_loaded_batch),
+                loaded=_loaded_count(),
                 total=len(plugin_load_specs),
                 clear_error=ev_req_ok,
             )
 
-    # Publish all plugins atomically so concurrent readers never observe
-    # a partially-populated list during the loading window.  We clear
-    # first so that repeated load_plugins() calls (tests, dev reloads,
-    # future "reload plugins" feature) never accumulate duplicate entries
-    # while keeping the list object identity stable.
-    with PLUGINS_LOCK:
-        LOADED_PLUGINS.clear()
-        LOADED_PLUGINS.extend(_loaded_batch)
-
+    # No final atomic publish: plugins were published incrementally as they
+    # graduated (see _graduate). LOADED_PLUGINS now holds exactly the ready
+    # plugins; any that failed remain visible as "failed" pending entries.
     _emit_progress(
         "plugins-complete",
-        f"Loaded {len(_loaded_batch)} plugin(s)",
-        loaded=len(_loaded_batch),
+        f"Loaded {_loaded_count()} plugin(s)",
+        loaded=_loaded_count(),
         total=len(plugin_load_specs),
     )
 
@@ -1222,10 +1300,19 @@ def register_plugin_api(app: FastAPI):
 
     @app.get("/api/plugins")
     def list_plugins():
+        # Return the UNION of ready (LOADED_PLUGINS) and not-yet-ready
+        # (PENDING_PLUGINS) plugins, each carrying a `status` so the nav can
+        # render every discovered plugin immediately — ready ones active,
+        # installing/failed ones disabled — instead of waiting for the
+        # slowest dependency install (issue #421). Rows are re-sorted by their
+        # discovery order so the nav slot of a still-installing plugin sits
+        # where it will land once ready, regardless of which structure it's in.
         with PLUGINS_LOCK:
-            snapshot = list(LOADED_PLUGINS)
-        return [
-            {
+            loaded = list(LOADED_PLUGINS)
+            pending = list(PENDING_PLUGINS.values())
+        rows: list[tuple] = []
+        for p in loaded:
+            rows.append((p.get("_order", 0), {
                 "id": p["id"],
                 "name": p["name"],
                 # Surface the manifest's `version` field (free-form
@@ -1255,9 +1342,35 @@ def register_plugin_api(app: FastAPI):
                 "has_script": p["has_script"],
                 "has_settings": p["has_settings"],
                 "has_tour": p.get("has_tour", False),
-            }
-            for p in snapshot
-        ]
+                # Anything in LOADED_PLUGINS is ready by construction.
+                "status": "ready",
+                "error": None,
+            }))
+        for e in pending:
+            rows.append((e.get("_order", 0), {
+                "id": e["id"],
+                "name": e["name"],
+                "version": e.get("version"),
+                "nav": e.get("nav"),
+                "type": e.get("type"),
+                "bundled": e.get("bundled", False),
+                # A pending plugin is never an active fallback (the fallback
+                # only exists once a user copy has graduated to ready).
+                "fallback": False,
+                "has_screen": e.get("has_screen", False),
+                "has_script": e.get("has_script", False),
+                "has_settings": e.get("has_settings", False),
+                "has_tour": e.get("has_tour", False),
+                # "installing" while its deps install; "failed" if the install
+                # or route load failed (the nav entry stays, disabled, with
+                # the error text in `error`).
+                "status": e.get("status", "installing"),
+                "error": e.get("error"),
+            }))
+        # Stable sort by discovery order. Stubbed test entries default to 0 and
+        # keep their insertion order (loaded before pending) under a stable sort.
+        rows.sort(key=lambda r: r[0])
+        return [row for _, row in rows]
 
     @app.get("/api/plugins/updates")
     def check_updates():
@@ -1283,6 +1396,8 @@ def register_plugin_api(app: FastAPI):
             snapshot = list(LOADED_PLUGINS)
         for p in snapshot:
             if p["id"] == plugin_id:
+                if p.get("status", "ready") != "ready":
+                    break
                 git_dir = p["_dir"] / ".git"
                 if not git_dir.exists():
                     return {"error": "Not a git repository"}
@@ -1315,6 +1430,8 @@ def register_plugin_api(app: FastAPI):
             snapshot = list(LOADED_PLUGINS)
         for p in snapshot:
             if p["id"] == plugin_id:
+                if p.get("status", "ready") != "ready":
+                    break
                 screen_file = p["_dir"] / p["_manifest"].get("screen", "screen.html")
                 if screen_file.exists():
                     return HTMLResponse(screen_file.read_text(encoding="utf-8"))
@@ -1326,6 +1443,8 @@ def register_plugin_api(app: FastAPI):
             snapshot = list(LOADED_PLUGINS)
         for p in snapshot:
             if p["id"] == plugin_id:
+                if p.get("status", "ready") != "ready":
+                    break
                 script_file = p["_dir"] / p["_manifest"].get("script", "screen.js")
                 if script_file.exists():
                     return Response(script_file.read_text(encoding="utf-8"), media_type="application/javascript")
@@ -1337,6 +1456,8 @@ def register_plugin_api(app: FastAPI):
             snapshot = list(LOADED_PLUGINS)
         for p in snapshot:
             if p["id"] == plugin_id:
+                if p.get("status", "ready") != "ready":
+                    break
                 settings = p["_manifest"].get("settings", {})
                 settings_file = p["_dir"] / (settings.get("html", "settings.html") if isinstance(settings, dict) else "settings.html")
                 if settings_file.exists():
@@ -1349,6 +1470,8 @@ def register_plugin_api(app: FastAPI):
             snapshot = list(LOADED_PLUGINS)
         for p in snapshot:
             if p["id"] == plugin_id:
+                if p.get("status", "ready") != "ready":
+                    break
                 tour_val = p["_manifest"].get("tour")
                 if not _is_valid_tour_manifest(tour_val):
                     break
@@ -1400,6 +1523,8 @@ def register_plugin_api(app: FastAPI):
             snapshot = list(LOADED_PLUGINS)
         for p in snapshot:
             if p["id"] == plugin_id:
+                if p.get("status", "ready") != "ready":
+                    break
                 target = safe_join(p["_dir"] / "assets", asset_path)
                 if target is None:
                     log.warning("Plugin %r: asset path rejected: %r", plugin_id, asset_path)

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -38,6 +38,16 @@ PENDING_PLUGINS: dict = {}
 # PENDING_PLUGINS so the background plugin-loader thread and the event-loop
 # request handlers never race on either structure.
 PLUGINS_LOCK = threading.RLock()
+# Monotonic load-generation counter, bumped under PLUGINS_LOCK at the start of
+# every load_plugins() pass. Each pass captures its generation and every
+# registry mutation (the pending seed, _graduate, _mark_failed) re-checks it
+# under the lock before touching LOADED_PLUGINS / PENDING_PLUGINS. This keeps a
+# still-running loader from an EARLIER pass — e.g. a "reload plugins" action,
+# SLOPSMITH_SYNC_STARTUP hot-reload, or test teardown re-invoking load_plugins()
+# while the first pass's background install thread is mid-flight — from
+# repopulating or duplicating entries after a NEWER pass has already cleared the
+# registries. Only the latest pass is allowed to publish.
+_LOAD_GENERATION = 0
 
 # Persistent pip install location (survives container restarts)
 _PIP_TARGET = Path(os.environ.get("CONFIG_DIR", "/config")) / "pip_packages"
@@ -567,9 +577,24 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # are usable instead of all-at-once when the slowest install finishes.
     # Tests and dev "reload plugins" re-invoke this; the clear keeps repeated
     # passes from accumulating duplicates while preserving list identity.
+    #
+    # Bump the load generation and capture it locally so every registry
+    # mutation below can verify it's still the latest pass before publishing.
+    # Without this, a background loader from an earlier pass could call
+    # _graduate()/_mark_failed() *after* this pass cleared the registries,
+    # re-inserting a plugin it already graduated (a duplicate) or resurrecting
+    # a stale "installing" entry. See _LOAD_GENERATION.
+    global _LOAD_GENERATION
     with PLUGINS_LOCK:
+        _LOAD_GENERATION += 1
+        my_generation = _LOAD_GENERATION
         LOADED_PLUGINS.clear()
         PENDING_PLUGINS.clear()
+
+    def _is_current_generation() -> bool:
+        """Return True iff this load pass is still the latest one. Callers MUST
+        already hold PLUGINS_LOCK (generation reads/writes are lock-guarded)."""
+        return _LOAD_GENERATION == my_generation
 
     def _loaded_count() -> int:
         with PLUGINS_LOCK:
@@ -578,8 +603,11 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     def _mark_failed(plugin_id: str, error: str) -> None:
         """Flip a pending plugin's status to "failed" with error text so it
         stays a visible, disabled nav entry. No-op if the plugin already
-        graduated (it can't fail after becoming ready)."""
+        graduated (it can't fail after becoming ready) or if a newer load pass
+        has superseded this one."""
         with PLUGINS_LOCK:
+            if not _is_current_generation():
+                return
             entry = PENDING_PLUGINS.get(plugin_id)
             if entry is not None:
                 entry["status"] = "failed"
@@ -591,10 +619,14 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         so the published list stays in discovery order even when earlier
         plugins failed (leaving gaps) or a user-copy fallback graduates out of
         sequence after the main loop. Pops the pending entry under the same
-        lock so a reader never sees the plugin in both structures. Returns the
-        new ready count."""
+        lock so a reader never sees the plugin in both structures. No-op (other
+        than returning the current count) if a newer load pass has superseded
+        this one, so a stale background loader can't re-insert into a registry
+        a newer pass already cleared. Returns the new ready count."""
         order = entry.get("_order", 0)
         with PLUGINS_LOCK:
+            if not _is_current_generation():
+                return len(LOADED_PLUGINS)
             pos = sum(1 for e in LOADED_PLUGINS if e.get("_order", 0) < order)
             LOADED_PLUGINS.insert(pos, entry)
             PENDING_PLUGINS.pop(entry["id"], None)
@@ -816,10 +848,25 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
     # kept plugin_id to its discovery index so a user-copy fallback graduating
     # after the main loop can reclaim the bundled plugin's original nav slot.
     _spec_order: dict[str, int] = {}
+    # Cache each kept plugin's base nav entry so graduation can dict()-copy it
+    # instead of re-deriving via _nav_entry() (which re-runs the three-part
+    # _is_bundled() filesystem check and _is_valid_tour_manifest()). Besides
+    # the wasted work, a second computation could disagree with the first if
+    # the filesystem changed mid-load (container overlay, plugin deleted), so
+    # the pending entry and the ready entry are guaranteed to describe the same
+    # plugin. _order is the only mutable field and it's identical here.
+    _spec_entries: dict[str, dict] = {}
     with PLUGINS_LOCK:
+        stale = not _is_current_generation()
         for idx, (plugin_id, plugin_dir, manifest) in enumerate(plugin_load_specs):
             _spec_order[plugin_id] = idx
-            entry = _nav_entry(plugin_id, plugin_dir, manifest, idx)
+            base = _nav_entry(plugin_id, plugin_dir, manifest, idx)
+            _spec_entries[plugin_id] = base
+            # A newer load pass already owns the registries — build the local
+            # caches (used by this pass's bookkeeping) but don't publish.
+            if stale:
+                continue
+            entry = dict(base)
             entry["status"] = "installing"
             entry["error"] = None
             PENDING_PLUGINS[plugin_id] = entry
@@ -1015,7 +1062,10 @@ def load_plugins(app: FastAPI, context: dict, progress_cb=None, route_setup_fn=N
         # plugin is ready. Publish it incrementally — readers (and the SSE
         # `plugin-registered` event that drives the frontend re-fetch) see it
         # the moment it's usable, not when the slowest sibling finishes.
-        loaded_entry = dict(_nav_entry(plugin_id, plugin_dir, manifest, idx))
+        # Reuse the base nav entry computed during discovery rather than
+        # re-deriving it, so the ready entry can't disagree with the pending
+        # one (see _spec_entries).
+        loaded_entry = dict(_spec_entries[plugin_id])
         loaded_entry.update({
             "status": "ready",
             # Normalized list of relpaths under CONFIG_DIR that this

--- a/server.py
+++ b/server.py
@@ -1987,9 +1987,10 @@ async def startup_events():
         # expose despite this branch reporting zero loaded plugins. Normal
         # startup clears it inside load_plugins; do the same here under the
         # same lock so this skip path matches that invariant.
-        from plugins import LOADED_PLUGINS, PLUGINS_LOCK
+        from plugins import LOADED_PLUGINS, PENDING_PLUGINS, PLUGINS_LOCK
         with PLUGINS_LOCK:
             LOADED_PLUGINS.clear()
+            PENDING_PLUGINS.clear()
         _set_startup_status(
             running=False,
             phase="complete",

--- a/static/app.js
+++ b/static/app.js
@@ -6840,10 +6840,22 @@ async function loadPlugins() {
             navContainer.appendChild(dropdown);
             const ddMenu = dropdown.querySelector('#plugin-dropdown');
 
-            // Close dropdown when clicking outside
-            document.addEventListener('click', (e) => {
-                if (!dropdown.contains(e.target)) ddMenu.classList.add('hidden');
-            });
+            // Close the plugin dropdown when clicking outside it. Bind ONCE:
+            // loadPlugins() re-runs on every plugin status change during
+            // startup (SSE-driven refetches), and each run rebuilds `dropdown`
+            // / `ddMenu`. A per-run addEventListener would leak a new global
+            // click listener on every refetch, each closing over a now-detached
+            // dropdown. The one-time handler instead resolves the LIVE dropdown
+            // from the DOM at click time, so it always targets the current one.
+            if (!window.slopsmith._pluginDropdownOutsideClickBound) {
+                window.slopsmith._pluginDropdownOutsideClickBound = true;
+                document.addEventListener('click', (e) => {
+                    const menu = document.getElementById('plugin-dropdown');
+                    if (!menu) return;
+                    const container = menu.parentElement;
+                    if (container && !container.contains(e.target)) menu.classList.add('hidden');
+                });
+            }
 
             for (const plugin of navPlugins) {
                 const screenId = `plugin-${plugin.id}`;
@@ -6855,6 +6867,11 @@ async function loadPlugins() {
                 // (#421). Entries without a status (legacy / stub) are ready.
                 const status = plugin.status || 'ready';
                 const isReady = status === 'ready';
+                // nav is truthy here (navPlugins is filtered on p.nav), but a
+                // nav object can still omit `label` (e.g. a script-only plugin
+                // that declares an empty nav). Fall back to name/id so a
+                // missing label never renders "undefined" or throws.
+                const label = plugin.nav?.label ?? plugin.name ?? plugin.id;
 
                 const item = document.createElement('a');
                 item.href = '#';
@@ -6866,10 +6883,10 @@ async function loadPlugins() {
 
                 if (isReady) {
                     item.className = 'block px-4 py-2 text-sm text-gray-400 hover:text-white hover:bg-dark-700 transition';
-                    item.textContent = plugin.nav.label;
+                    item.textContent = label;
                     item.onclick = (e) => { e.preventDefault(); ddMenu.classList.add('hidden'); showScreen(screenId); window.slopsmithDemoTrack?.('event/plugin-open/' + plugin.id); };
                     ma.className = 'text-gray-400 hover:text-white pl-4 text-sm';
-                    ma.textContent = plugin.nav.label;
+                    ma.textContent = label;
                     ma.onclick = (e) => { e.preventDefault(); showScreen(screenId); ma.closest('#mobile-menu').classList.add('hidden'); window.slopsmithDemoTrack?.('event/plugin-open/' + plugin.id); };
                 } else {
                     const installing = status === 'installing';
@@ -6883,13 +6900,13 @@ async function loadPlugins() {
                     item.className = cls;
                     item.setAttribute('aria-disabled', 'true');
                     item.title = tip;
-                    item.textContent = plugin.nav.label + suffix;
+                    item.textContent = label + suffix;
                     // Swallow clicks so a disabled entry never navigates.
                     item.onclick = (e) => { e.preventDefault(); };
                     ma.className = 'pl-4 text-sm text-gray-600 cursor-default select-none' + (installing ? ' animate-pulse' : '');
                     ma.setAttribute('aria-disabled', 'true');
                     ma.title = tip;
-                    ma.textContent = plugin.nav.label + suffix;
+                    ma.textContent = label + suffix;
                     ma.onclick = (e) => { e.preventDefault(); };
                 }
             }
@@ -7096,7 +7113,16 @@ function _refreshPluginsSoon() {
     clearTimeout(_pluginRefreshTimer);
     _pluginRefreshTimer = setTimeout(async () => {
         const plugins = await loadPlugins();
-        if (plugins) _populateVizPicker(plugins);
+        if (plugins) {
+            _populateVizPicker(plugins);
+        } else {
+            // loadPlugins() returned null because a refetch was already in
+            // flight, so this status change would otherwise be dropped. Re-arm
+            // the debounce so the newer state is still applied once the
+            // in-flight load finishes. Reuses the 250ms delay (and the
+            // in-flight guard clears quickly), so this can't tight-loop.
+            _refreshPluginsSoon();
+        }
     }, 250);
 }
 
@@ -7144,7 +7170,11 @@ async function _pollPluginStartup() {
     // poll forever.
     if (_pollStartupStarted) return;
     _pollStartupStarted = true;
-    const DEADLINE_MS = 30 * 60 * 1000; // generous: heavy ML installs can be long
+    // Generous headroom over the documented worst case (whisperx → torch et al.
+    // can take 20-30 min): a 30-min ceiling would stop polling right as a
+    // slipping install — slow mirror, pip retry — actually finishes. 60 min
+    // leaves margin so the late graduation still surfaces. (#421)
+    const DEADLINE_MS = 60 * 60 * 1000;
     const start = Date.now();
     let lastLoaded = -1;
     while (Date.now() - start < DEADLINE_MS) {

--- a/static/app.js
+++ b/static/app.js
@@ -6719,124 +6719,6 @@ async function checkScanAndLoad() {
 }
 
 // ── Plugin loader ───────────────────────────────────────────────────────
-function setPluginLoadingState(loading, message) {
-    console.log('[slopsmith] setPluginLoadingState', loading, message, new Error().stack.split('\n')[2]);
-    const navContainer = document.getElementById('nav-plugins');
-    const mobileNavContainer = document.getElementById('mobile-nav-plugins');
-    const settingsArea = document.getElementById('plugin-settings-area');
-    if (!navContainer || !mobileNavContainer) return;
-
-    if (loading) {
-        navContainer.innerHTML = `<span class="text-xs text-gray-500 animate-pulse">${esc(message || 'Loading plugins...')}</span>`;
-        mobileNavContainer.innerHTML = `
-            <span class="text-xs text-gray-600 uppercase tracking-wider">Plugins</span>
-            <span class="text-xs text-gray-500 animate-pulse">${esc(message || 'Loading plugins...')}</span>`;
-        if (settingsArea) settingsArea.classList.add('hidden');
-        return;
-    }
-
-    navContainer.innerHTML = '';
-    mobileNavContainer.innerHTML = '<span class="text-xs text-gray-600 uppercase tracking-wider">Plugins</span>';
-}
-
-function _makeTimeoutStatus() {
-    return { running: false, phase: 'timeout', message: 'Plugin startup timed out', error: null, current_plugin: '', loaded: 0, total: 0 };
-}
-
-async function _waitViaSSE(timeoutMs) {
-    if (typeof EventSource === 'undefined') return null;
-    // Must exceed the server's _SSE_KA_INTERVAL (15 s) — keepalives are data
-    // events so onmessage re-arms this timer.  A gap > MSG_DEADLINE_MS means
-    // the proxy is buffering or dropping; fall back to polling.  Update this
-    // if _SSE_KA_INTERVAL in server.py changes.
-    const MSG_DEADLINE_MS = 20000;
-    return new Promise((resolve) => {
-        let resolved = false;
-        let msgDeadlineTimer = null;
-        const armDeadline = () => {
-            clearTimeout(msgDeadlineTimer);
-            msgDeadlineTimer = setTimeout(() => done(null), MSG_DEADLINE_MS);
-        };
-        const done = (result) => {
-            if (resolved) return;
-            resolved = true;
-            clearTimeout(timer);
-            clearTimeout(msgDeadlineTimer);
-            es.close();
-            resolve(result);
-        };
-        const timer = setTimeout(() => {
-            done(_makeTimeoutStatus());
-        }, timeoutMs);
-        armDeadline(); // deadline for the first message
-        const es = new EventSource('/api/startup-status/stream');
-        // Startup is a one-shot connection; treat any error (including transient
-        // reconnects that EventSource would normally retry) as a signal to fall
-        // back to polling rather than waiting for the browser to retry.
-        es.onerror = () => done(null);
-        es.onmessage = (event) => {
-            armDeadline(); // re-arm on every message — server sends data-level keepalives
-            let status;
-            try { status = JSON.parse(event.data); } catch { return; }
-            if (!status || status.type === 'keepalive') return; // keepalive — deadline re-armed, nothing else to do
-            if (!status.phase) return;
-            const phase = (status.phase || '').trim();
-            const msg = (status.message || '').trim() || 'Loading plugins...';
-            const countMsg = status.total > 0 ? ` (${status.loaded || 0}/${status.total})` : '';
-            setPluginLoadingState(Boolean(status.running), `${msg}${countMsg}`);
-            if (!status.running && (phase === 'complete' || phase === 'error')) done(status);
-        };
-    });
-}
-
-async function _waitViaPolling(timeoutMs) {
-    const start = Date.now();
-    let last = null;
-    let failCount = 0;
-    const MAX_CONSECUTIVE_FAILURES = 5;
-    while (Date.now() - start < timeoutMs) {
-        try {
-            const resp = await fetch('/api/startup-status');
-            if (resp.ok) {
-                failCount = 0;
-                const status = await resp.json();
-                last = status;
-                const phase = (status.phase || '').trim();
-                const msg = (status.message || '').trim() || 'Loading plugins...';
-                const countMsg = status.total > 0 ? ` (${status.loaded || 0}/${status.total})` : '';
-                setPluginLoadingState(Boolean(status.running), `${msg}${countMsg}`);
-                if (!status.running && (phase === 'complete' || phase === 'error')) return status;
-            } else {
-                failCount++;
-                if (failCount >= MAX_CONSECUTIVE_FAILURES) {
-                    setPluginLoadingState(false);
-                    return last || { running: false, phase: 'error', message: 'Startup status unavailable', error: null, current_plugin: '', loaded: 0, total: 0 };
-                }
-            }
-        } catch (e) {
-            failCount++;
-            if (failCount >= MAX_CONSECUTIVE_FAILURES) {
-                setPluginLoadingState(false);
-                return last || { running: false, phase: 'error', message: 'Startup status unavailable', error: null, current_plugin: '', loaded: 0, total: 0 };
-            }
-        }
-        await new Promise((r) => setTimeout(r, 800));
-    }
-    setPluginLoadingState(false);
-    return _makeTimeoutStatus();
-}
-
-async function waitForPluginStartupComplete(timeoutMs = 180000) {
-    const start = Date.now();
-    const sseResult = await _waitViaSSE(timeoutMs);
-    if (sseResult !== null) return sseResult;
-    const remaining = Math.max(0, timeoutMs - (Date.now() - start));
-    if (remaining <= 0) {
-        return _makeTimeoutStatus();
-    }
-    return _waitViaPolling(remaining);
-}
-
 let _loadPluginsInFlight = false;
 
 async function loadPlugins() {
@@ -6862,7 +6744,7 @@ async function loadPlugins() {
         // so we must preserve that DOM — the script load guard below skips
         // re-evaluating screen.js, and a fresh empty DOM with no listeners
         // would leave the plugin half-hydrated on subsequent loadPlugins()
-        // calls (e.g. _scheduleStartupRehydration).
+        // calls (e.g. the streamed refetches in _streamPluginStartup).
         //
         // The DOM-existence check is the safety net for plugins that
         // disappeared and reappeared between calls (uninstall + reinstall,
@@ -6965,25 +6847,61 @@ async function loadPlugins() {
 
             for (const plugin of navPlugins) {
                 const screenId = `plugin-${plugin.id}`;
+                // A plugin is navigable only once it's ready. While its deps
+                // install (status "installing") or after a failed load
+                // (status "failed") we still render the nav slot — disabled,
+                // with an "installing…" suffix or the error as a tooltip — so
+                // the nav is stable and the user sees the plugin is coming
+                // (#421). Entries without a status (legacy / stub) are ready.
+                const status = plugin.status || 'ready';
+                const isReady = status === 'ready';
+
                 const item = document.createElement('a');
                 item.href = '#';
-                item.className = 'block px-4 py-2 text-sm text-gray-400 hover:text-white hover:bg-dark-700 transition';
-                item.textContent = plugin.nav.label;
-                item.onclick = (e) => { e.preventDefault(); ddMenu.classList.add('hidden'); showScreen(screenId); window.slopsmithDemoTrack?.('event/plugin-open/' + plugin.id); };
                 ddMenu.appendChild(item);
-
                 // Mobile nav — flat list
                 const ma = document.createElement('a');
                 ma.href = '#';
-                ma.className = 'text-gray-400 hover:text-white pl-4 text-sm';
-                ma.textContent = plugin.nav.label;
-                ma.onclick = (e) => { e.preventDefault(); showScreen(screenId); ma.closest('#mobile-menu').classList.add('hidden'); window.slopsmithDemoTrack?.('event/plugin-open/' + plugin.id); };
                 mobileNavContainer.appendChild(ma);
+
+                if (isReady) {
+                    item.className = 'block px-4 py-2 text-sm text-gray-400 hover:text-white hover:bg-dark-700 transition';
+                    item.textContent = plugin.nav.label;
+                    item.onclick = (e) => { e.preventDefault(); ddMenu.classList.add('hidden'); showScreen(screenId); window.slopsmithDemoTrack?.('event/plugin-open/' + plugin.id); };
+                    ma.className = 'text-gray-400 hover:text-white pl-4 text-sm';
+                    ma.textContent = plugin.nav.label;
+                    ma.onclick = (e) => { e.preventDefault(); showScreen(screenId); ma.closest('#mobile-menu').classList.add('hidden'); window.slopsmithDemoTrack?.('event/plugin-open/' + plugin.id); };
+                } else {
+                    const installing = status === 'installing';
+                    const suffix = installing ? ' (installing…)' : ' (failed)';
+                    const tip = installing
+                        ? 'This plugin is installing its dependencies and will become available shortly.'
+                        : (plugin.error || 'This plugin failed to load. Check the server startup log for details.');
+                    // Disabled appearance: dimmed, default cursor, no nav handler.
+                    const cls = 'block px-4 py-2 text-sm text-gray-600 cursor-default select-none'
+                        + (installing ? ' animate-pulse' : '');
+                    item.className = cls;
+                    item.setAttribute('aria-disabled', 'true');
+                    item.title = tip;
+                    item.textContent = plugin.nav.label + suffix;
+                    // Swallow clicks so a disabled entry never navigates.
+                    item.onclick = (e) => { e.preventDefault(); };
+                    ma.className = 'pl-4 text-sm text-gray-600 cursor-default select-none' + (installing ? ' animate-pulse' : '');
+                    ma.setAttribute('aria-disabled', 'true');
+                    ma.title = tip;
+                    ma.textContent = plugin.nav.label + suffix;
+                    ma.onclick = (e) => { e.preventDefault(); };
+                }
             }
         }
 
         for (const plugin of plugins) {
             try {
+            // Only ready plugins have their assets available (the backend
+            // guards screen.html/screen.js/settings.html on status=="ready").
+            // Installing/failed plugins contribute only the disabled nav slot
+            // built above — skip screen/settings/script injection for them.
+            if (plugin.status && plugin.status !== 'ready') continue;
             const screenId = `plugin-${plugin.id}`;
 
             // Inject screen container. Skip for already-hydrated plugins —
@@ -7169,48 +7087,86 @@ async function loadPlugins() {
     return plugins;
 }
 
-async function _scheduleStartupRehydration() {
-    // Continue polling until the backend startup completes (or a long deadline).
-    // Used when the initial waitForPluginStartupComplete() window expired before
-    // LOADED_PLUGINS was populated — re-hydrates plugins + viz picker once done.
-    const REHYDRATE_TIMEOUT_MS = 10 * 60 * 1000; // 10 min additional window
+// Re-run loadPlugins (and the viz picker, since a newly-ready plugin may
+// register a window.slopsmithViz_<id> factory) when plugin status changes.
+// Debounced so a burst of plugin-registered/plugin-error events during
+// startup collapses into a single refetch.
+let _pluginRefreshTimer = null;
+function _refreshPluginsSoon() {
+    clearTimeout(_pluginRefreshTimer);
+    _pluginRefreshTimer = setTimeout(async () => {
+        const plugins = await loadPlugins();
+        if (plugins) _populateVizPicker(plugins);
+    }, 250);
+}
+
+let _pluginStreamStarted = false;
+function _streamPluginStartup() {
+    // Watch the SAME /api/startup-status/stream the splash used to gate on.
+    // Instead of blocking, we let the nav render immediately (loadPlugins ran
+    // already) and refetch whenever a plugin graduates to ready or fails — so
+    // its nav slot flips from "installing…" to active/failed without a reload
+    // (#421). loadPlugins is idempotent (in-flight guard + version map), so
+    // extra refetches are cheap and safe.
+    if (_pluginStreamStarted) return;
+    _pluginStreamStarted = true;
+
+    if (typeof EventSource === 'undefined') { _pollPluginStartup(); return; }
+
+    const es = new EventSource('/api/startup-status/stream');
+    es.onmessage = (event) => {
+        let status;
+        try { status = JSON.parse(event.data); } catch { return; }
+        if (!status || status.type === 'keepalive') return;
+        const phase = (status.phase || '').trim();
+        if (phase === 'plugin-registered' || phase === 'plugin-error') {
+            _refreshPluginsSoon();
+        }
+        // Terminal: one last refetch to catch anything missed, then stop.
+        if (!status.running && (phase === 'complete' || phase === 'error')) {
+            _refreshPluginsSoon();
+            es.close();
+        }
+    };
+    es.onerror = () => {
+        // Stream dropped (proxy buffering, backend hiccup). Stop retrying the
+        // stream and fall back to a bounded poll so late installs still surface.
+        es.close();
+        _pollPluginStartup();
+    };
+}
+
+let _pollStartupStarted = false;
+async function _pollPluginStartup() {
+    // SSE-unavailable fallback: poll /api/startup-status until the backend
+    // finishes its plugin loader, refetching whenever the ready count changes
+    // or it goes terminal. Bounded so a backend that never finishes doesn't
+    // poll forever.
+    if (_pollStartupStarted) return;
+    _pollStartupStarted = true;
+    const DEADLINE_MS = 30 * 60 * 1000; // generous: heavy ML installs can be long
     const start = Date.now();
-    console.log('[slopsmith] _scheduleStartupRehydration: started');
-    while (Date.now() - start < REHYDRATE_TIMEOUT_MS) {
-        await new Promise((r) => setTimeout(r, 5000));
+    let lastLoaded = -1;
+    while (Date.now() - start < DEADLINE_MS) {
+        await new Promise((r) => setTimeout(r, 3000));
         try {
             const resp = await fetch('/api/startup-status');
             if (!resp.ok) continue;
             const status = await resp.json();
-            console.log('[slopsmith] _scheduleStartupRehydration: poll —', status.phase, 'running:', status.running);
-            if (!status.running) {
-                if (status.phase === 'complete') {
-                    console.log('[slopsmith] Background startup complete — re-hydrating plugins');
-                    const plugins = await loadPlugins();
-                    _populateVizPicker(plugins);
-                } else {
-                    console.warn('[slopsmith] Backend startup ended without completing — skipping re-hydration');
-                }
-                return;
-            }
+            const loaded = Number(status.loaded || 0);
+            if (loaded !== lastLoaded) { lastLoaded = loaded; _refreshPluginsSoon(); }
+            if (!status.running) { _refreshPluginsSoon(); return; }
         } catch (_e) { /* network error — keep trying */ }
     }
 }
 
 async function bootstrapPluginsAndUi() {
-    setPluginLoadingState(true, 'Loading plugins...');
-    const startup = await waitForPluginStartupComplete();
-    if (startup && (startup.phase === 'error' || startup.phase === 'timeout')) {
-        const msg = startup.error || startup.message || 'Plugin startup failed';
-        setPluginLoadingState(false, '');
-        console.warn('Plugin startup reported error:', msg);
-        // On timeout the backend may still be loading. Continue polling in the
-        // background so plugins are hydrated once startup eventually completes.
-        if (startup.phase === 'timeout') {
-            _scheduleStartupRehydration();
-        }
-    }
+    // #421: never gate the nav on full plugin startup. Render it immediately
+    // from /api/plugins (ready plugins active; installing/failed disabled),
+    // then stream plugin status so each entry resolves in place as its
+    // dependencies finish installing or its load fails.
     const plugins = await loadPlugins();
+    _streamPluginStartup();
     return plugins;
 }
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -72,10 +72,12 @@ def reset_plugin_state(monkeypatch):
     monkeypatch.delenv("SLOPSMITH_PLUGINS_DIR", raising=False)
     plugins = importlib.import_module("plugins")
     saved_loaded = list(plugins.LOADED_PLUGINS)
+    saved_pending = dict(plugins.PENDING_PLUGINS)
     saved_modules = {k: v for k, v in sys.modules.items() if k.startswith("plugin_")}
     saved_bare = {k: sys.modules[k] for k in _BARE_NAMES_USED if k in sys.modules}
     saved_path = list(sys.path)
     plugins.LOADED_PLUGINS.clear()
+    plugins.PENDING_PLUGINS.clear()
     for k in list(sys.modules):
         if k.startswith("plugin_") or k in _BARE_NAMES_USED:
             del sys.modules[k]
@@ -84,6 +86,8 @@ def reset_plugin_state(monkeypatch):
     finally:
         plugins.LOADED_PLUGINS.clear()
         plugins.LOADED_PLUGINS.extend(saved_loaded)
+        plugins.PENDING_PLUGINS.clear()
+        plugins.PENDING_PLUGINS.update(saved_pending)
         for k in list(sys.modules):
             if k.startswith("plugin_") or k in _BARE_NAMES_USED:
                 del sys.modules[k]
@@ -2440,6 +2444,167 @@ def test_progress_cb_emits_plugin_error_on_requirements_failure(tmp_path, reset_
     assert all(e["error"] for e in error_events), "plugin-error events must carry a non-empty error field"
     # Loading continued: req_fail is still registered.
     assert any(p["id"] == "req_fail" for p in plugins.LOADED_PLUGINS)
+
+
+# ── Async loading: pending registry, incremental publish, failed status ─────────
+
+def test_pending_then_incremental_publish_observed_during_setup(tmp_path, reset_plugin_state):
+    """Every discovered plugin is recorded in PENDING_PLUGINS as "installing"
+    up front, then GRADUATES into LOADED_PLUGINS as it becomes ready — one at a
+    time, not all-at-once at the end (issue #421 incremental publish).
+
+    Each plugin's setup() records the live LOADED/PENDING state under its own
+    plugin id (read from ctx['log'].name):
+      * During "aaa".setup(): both plugins are still pending+installing and
+        nothing has graduated yet (LOADED is empty).
+      * During "zzz".setup(): "aaa" has ALREADY graduated into LOADED while
+        "zzz" is still pending — proving plugins publish incrementally.
+    """
+    plugins = reset_plugin_state
+    body = (
+        "import plugins\n"
+        "def setup(app, ctx):\n"
+        "    pid = ctx['log'].name.rsplit('.', 1)[-1]\n"
+        "    app.state.snaps = getattr(app.state, 'snaps', {})\n"
+        "    app.state.snaps[pid] = {\n"
+        "        'pending': {k: v['status'] for k, v in plugins.PENDING_PLUGINS.items()},\n"
+        "        'loaded': [p['id'] for p in plugins.LOADED_PLUGINS],\n"
+        "    }\n"
+    )
+    _make_plugin(tmp_path, "aaa", routes_body=body)
+    _make_plugin(tmp_path, "zzz", routes_body=body)
+
+    fake_app = type("FakeApp", (), {})()
+    fake_app.state = type("State", (), {})()
+    _run_load_plugins(plugins, fake_app, tmp_path)
+
+    snaps = fake_app.state.snaps
+    # During aaa.setup(): both pending+installing, nothing graduated yet.
+    assert snaps["aaa"]["pending"] == {"aaa": "installing", "zzz": "installing"}
+    assert snaps["aaa"]["loaded"] == []
+    # During zzz.setup(): aaa already graduated (incremental publish); zzz pending.
+    assert snaps["zzz"]["loaded"] == ["aaa"]
+    assert "zzz" in snaps["zzz"]["pending"]
+    assert "aaa" not in snaps["zzz"]["pending"]
+    # Final: both ready, none pending.
+    assert sorted(p["id"] for p in plugins.LOADED_PLUGINS) == ["aaa", "zzz"]
+    assert plugins.PENDING_PLUGINS == {}
+
+
+def test_failed_plugin_shows_failed_status_and_stays_visible(tmp_path, reset_plugin_state):
+    """A plugin whose routes fail to load is NOT added to LOADED_PLUGINS
+    (ready-only) but STAYS visible as a disabled "failed" entry in
+    PENDING_PLUGINS and on /api/plugins, with its error text — so the nav can
+    render it disabled with a tooltip rather than dropping it (ADR 0001)."""
+    plugins = reset_plugin_state
+    _make_plugin(tmp_path, "okp")  # healthy, no-op setup
+    _make_plugin(
+        tmp_path, "broken",
+        routes_body="def setup(app, ctx):\n    raise RuntimeError('boom')\n",
+    )
+    _run_load_plugins(plugins, type("FakeApp", (), {})(), tmp_path)
+
+    # LOADED_PLUGINS stays ready-only: broken absent, okp present.
+    loaded_ids = {p["id"] for p in plugins.LOADED_PLUGINS}
+    assert "broken" not in loaded_ids
+    assert "okp" in loaded_ids
+    # broken remains a visible "failed" pending entry with error text.
+    assert plugins.PENDING_PLUGINS["broken"]["status"] == "failed"
+    assert plugins.PENDING_PLUGINS["broken"]["error"]
+    assert "okp" not in plugins.PENDING_PLUGINS  # graduated, no longer pending
+
+    # /api/plugins exposes the union with per-plugin status + error.
+    client = _make_api_client(plugins)
+    try:
+        rows = {p["id"]: p for p in client.get("/api/plugins").json()}
+        assert rows["broken"]["status"] == "failed"
+        assert rows["broken"]["error"]
+        assert rows["okp"]["status"] == "ready"
+        assert rows["okp"]["error"] is None
+    finally:
+        client.close()
+
+
+def test_api_plugins_surfaces_installing_pending_entry(tmp_path, reset_plugin_state):
+    """An "installing" pending entry surfaces on /api/plugins immediately with
+    its manifest-derived nav fields and status="installing" (no error), so the
+    frontend can render a disabled "installing…" nav slot before the (possibly
+    very slow) dependency install finishes."""
+    plugins = reset_plugin_state
+    pdir = tmp_path / "heavy"
+    pdir.mkdir()
+    plugins.PENDING_PLUGINS["heavy"] = {
+        "id": "heavy", "name": "Heavy ML Plugin", "nav": "/heavy",
+        "type": "visualization", "bundled": True, "version": "2.0.0",
+        "has_screen": True, "has_script": False, "has_settings": False,
+        "has_tour": False, "_order": 0, "status": "installing", "error": None,
+    }
+    client = _make_api_client(plugins)
+    try:
+        rows = {p["id"]: p for p in client.get("/api/plugins").json()}
+        h = rows["heavy"]
+        assert h["status"] == "installing"
+        assert h["error"] is None
+        assert h["nav"] == "/heavy"
+        assert h["type"] == "visualization"
+        assert h["bundled"] is True
+        assert h["version"] == "2.0.0"
+        assert h["has_screen"] is True
+        assert h["fallback"] is False
+    finally:
+        client.close()
+
+
+def test_api_plugins_union_sorted_by_discovery_order(tmp_path, reset_plugin_state):
+    """The /api/plugins union is re-sorted by discovery order so an installing
+    plugin occupies its eventual nav slot regardless of whether it currently
+    lives in LOADED_PLUGINS (ready) or PENDING_PLUGINS (installing/failed)."""
+    plugins = reset_plugin_state
+    pdir = tmp_path / "d"
+    pdir.mkdir()
+    # Ready plugin discovered SECOND (order 1) lives in LOADED_PLUGINS.
+    plugins.LOADED_PLUGINS.append({
+        "id": "ready_second", "name": "Ready", "nav": None, "type": None,
+        "bundled": False, "has_screen": False, "has_script": False,
+        "has_settings": False, "has_tour": False, "status": "ready",
+        "_order": 1, "_dir": pdir, "_manifest": {},
+    })
+    # Installing plugin discovered FIRST (order 0) lives in PENDING_PLUGINS.
+    plugins.PENDING_PLUGINS["installing_first"] = {
+        "id": "installing_first", "name": "Installing", "nav": None, "type": None,
+        "bundled": False, "version": None, "has_screen": False, "has_script": False,
+        "has_settings": False, "has_tour": False, "_order": 0,
+        "status": "installing", "error": None,
+    }
+    client = _make_api_client(plugins)
+    try:
+        order = [p["id"] for p in client.get("/api/plugins").json()]
+        assert order == ["installing_first", "ready_second"]
+    finally:
+        client.close()
+
+
+def test_pending_plugin_assets_not_served(tmp_path, reset_plugin_state):
+    """Asset endpoints serve only ready plugins. A plugin still installing
+    (present in PENDING_PLUGINS, absent from LOADED_PLUGINS) returns 404 for
+    its screen.js / screen.html even though its manifest advertises them."""
+    plugins = reset_plugin_state
+    pdir = tmp_path / "heavy"
+    pdir.mkdir()
+    (pdir / "screen.js").write_text("console.log('x');\n")
+    (pdir / "screen.html").write_text("<p>hi</p>\n")
+    plugins.PENDING_PLUGINS["heavy"] = {
+        "id": "heavy", "name": "Heavy", "nav": None, "type": None,
+        "bundled": False, "version": None, "has_screen": True, "has_script": True,
+        "has_settings": False, "has_tour": False, "_order": 0,
+        "status": "installing", "error": None, "_dir": pdir, "_manifest": {},
+    }
+    client = _make_api_client(plugins)
+    try:
+        assert client.get("/api/plugins/heavy/screen.js").status_code == 404
+        assert client.get("/api/plugins/heavy/screen.html").status_code == 404
+    finally:
+        client.close()
 
 
 # ── Tour API tests ─────────────────────────────────────────────────────────────

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2491,6 +2491,87 @@ def test_pending_then_incremental_publish_observed_during_setup(tmp_path, reset_
     assert plugins.PENDING_PLUGINS == {}
 
 
+def test_stale_load_pass_cannot_republish_after_newer_pass(tmp_path, reset_plugin_state):
+    """A still-running load pass must NOT republish into the registries after a
+    NEWER load_plugins() pass has cleared them (re-entrancy race: a "reload
+    plugins" action, SLOPSMITH_SYNC_STARTUP hot-reload, or test teardown firing
+    while the first pass's background install thread is mid-flight).
+
+    The loader bumps a generation token at the start of every pass; _graduate()
+    and _mark_failed() bail when the generation has advanced. Without the guard,
+    the older pass's _graduate() would re-insert a plugin the newer pass already
+    cleared, leaving a cross-generation / duplicate entry in LOADED_PLUGINS.
+    """
+    import threading
+
+    plugins = reset_plugin_state
+    setup_entered = threading.Event()
+    release_setup = threading.Event()
+    # Stash the events on the module so the file-exec'd plugin setup() can reach
+    # them without globals plumbing. Cleaned up at the end of the test.
+    plugins._TEST_setup_entered = setup_entered
+    plugins._TEST_release_setup = release_setup
+    try:
+        root1 = tmp_path / "gen1"
+        root2 = tmp_path / "gen2"
+        root1.mkdir()
+        root2.mkdir()
+        # Pass 1's plugin blocks inside setup() — past discovery and the PENDING
+        # seed, just before it would graduate — until the test releases it.
+        _make_plugin(
+            root1, "slow",
+            routes_body=(
+                "import plugins\n"
+                "def setup(app, ctx):\n"
+                "    plugins._TEST_setup_entered.set()\n"
+                "    plugins._TEST_release_setup.wait(5)\n"
+            ),
+        )
+        _make_plugin(root2, "fast")  # no-op setup, graduates immediately
+
+        errors = []
+
+        def _pass1():
+            saved = plugins.PLUGINS_DIR
+            plugins.PLUGINS_DIR = root1
+            try:
+                plugins.load_plugins(type("FakeApp", (), {})(), {})
+            except Exception as e:  # pragma: no cover - failure path
+                errors.append(e)
+            finally:
+                plugins.PLUGINS_DIR = saved
+
+        t1 = threading.Thread(target=_pass1)
+        t1.start()
+        # Wait until pass 1 is parked inside slow.setup() (discovery done,
+        # PENDING seeded, about to eventually graduate "slow").
+        assert setup_entered.wait(5), "pass 1 never entered slow.setup()"
+
+        # Pass 2 runs to completion on the main thread: bumps the generation,
+        # clears both registries, graduates "fast".
+        saved = plugins.PLUGINS_DIR
+        plugins.PLUGINS_DIR = root2
+        try:
+            plugins.load_plugins(type("FakeApp", (), {})(), {})
+        finally:
+            plugins.PLUGINS_DIR = saved
+
+        # Release pass 1; it resumes and attempts to graduate "slow" — now stale.
+        release_setup.set()
+        t1.join(5)
+        assert not t1.is_alive(), "pass 1 thread did not finish"
+        assert not errors, f"pass 1 raised: {errors}"
+
+        # Only pass 2's output survives. The stale pass's "slow" must NOT appear
+        # in either registry — its _graduate() was a no-op.
+        assert [p["id"] for p in plugins.LOADED_PLUGINS] == ["fast"]
+        assert "slow" not in plugins.PENDING_PLUGINS
+        assert "slow" not in {p["id"] for p in plugins.LOADED_PLUGINS}
+    finally:
+        delattr(plugins, "_TEST_setup_entered")
+        delattr(plugins, "_TEST_release_setup")
+
+
 def test_failed_plugin_shows_failed_status_and_stays_visible(tmp_path, reset_plugin_state):
     """A plugin whose routes fail to load is NOT added to LOADED_PLUGINS
     (ready-only) but STAYS visible as a disabled "failed" entry in


### PR DESCRIPTION
Fixes #421.

## Problem
A plugin that adds heavy ML wheels (whisperx → torch/ctranslate2/pyannote) froze startup for 20-30 minutes behind an "Installing requirements…" splash, even though the core app was otherwise ready.

## Approach
The core app is **never gated on plugin dependency installation**. The plugin loader discovers every plugin up front, records it as a pending **installing** nav entry, installs each plugin's requirements **sequentially** in the existing background loader thread, and **graduates** it to **ready** the moment its routes register. The nav renders immediately; a still-installing plugin shows as a disabled "installing…" entry that activates in place, and a load failure shows as a disabled "failed" entry with its error rather than vanishing.

This supersedes the earlier bundling/manifest approach (PR #605), which was rejected for ballooning installer size and doubling CI build cost.

## Backend (`plugins/__init__.py`, `server.py`)
- New `PENDING_PLUGINS` alongside `LOADED_PLUGINS` (both under `PLUGINS_LOCK`). `LOADED_PLUGINS` keeps meaning **ready-only**, so existing consumers (settings export/import, diagnostics, orphan logic) are untouched.
- Both cleared at the **start** of `load_plugins()` for re-entrancy; plugins publish **incrementally** as they graduate instead of one atomic swap at the end.
- Graduate pending→loaded on ready; a route-load failure leaves the plugin **failed** in `PENDING_PLUGINS` with error text. A requirements-install failure stays non-fatal (optional/read-only deps) — a genuinely missing dep then surfaces as the route import failure that follows.
- `/api/plugins` returns the **union** of pending + loaded, each with `status` (`installing`/`ready`/`failed`) and `error`, re-sorted by discovery order.
- Asset endpoints (screen/settings/tour/assets/update) guard on `status == "ready"`.
- Installs stay sequential; the `SLOPSMITH_SYNC_STARTUP` hatch and whole-file requirements marker are unchanged.

## Frontend (`static/app.js`)
- Stop blocking nav on `phase == "complete"`; render the nav from `/api/plugins` immediately (ready active; installing/failed disabled with badge/tooltip).
- Reuse the `/api/startup-status/stream` EventSource: on `plugin-registered`/`plugin-error`, debounced-refetch `/api/plugins` and re-run the idempotent `loadPlugins()`, with a bounded poll fallback when SSE is unavailable. The old wait-for-complete gate and 10-minute rehydration poll are removed.

## Tests
New tests cover: pending entry appears installing → graduates to ready, incremental publish observed mid-load, failed plugin stays visible with `status=failed`, `LOADED_PLUGINS` stays ready-only, `/api/plugins` union ordering, and that installing plugins don't serve assets.

## Merge order
Merge this **before** the desktop PR (slopsmith/slopsmith-desktop#267) — the desktop change relies on this backend streaming plugin status to the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugin navigation renders immediately and updates live; only ready plugins are active/clickable.
  * Plugin list API returns a stable discovery-order union of ready and pending plugins; non-ready plugins’ content endpoints are blocked.
  * Startup progress streaming, debounced refresh, and bounded polling keep UI in sync.

* **Bug Fixes**
  * Failed/installing plugins remain visible as disabled with status/error; skipped startups clear stale entries.
  * Bundled-plugin failures fall back to user copies when available.

* **Tests**
  * Added tests for pending/installing state, incremental publishing, re-entrancy, ordering, failure visibility, and asset access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->