### PR TITLE
feat(gp2rs_gpx): add GP7/GP8 (.gp) support 

### DIFF
--- a/lib/gp2rs.py
+++ b/lib/gp2rs.py
@@ -1014,7 +1014,7 @@ def is_drum_track(track: guitarpro.Track) -> bool:
 
 def list_tracks(gp_path: str) -> list[dict]:
     """List all tracks in a Guitar Pro file with basic info."""
-    if Path(gp_path).suffix.lower() == '.gpx':
+    if Path(gp_path).suffix.lower() in ('.gpx', '.gp'):
         from gp2rs_gpx import list_tracks as _gpx_list_tracks
         return _gpx_list_tracks(gp_path)
     song = guitarpro.parse(gp_path)
@@ -1691,7 +1691,7 @@ def convert_file(
     Returns:
         List of output XML file paths
     """
-    if Path(gp_path).suffix.lower() == '.gpx':
+    if Path(gp_path).suffix.lower() in ('.gpx', '.gp'):
         from gp2rs_gpx import convert_file as _gpx_convert_file
         return _gpx_convert_file(
             gp_path, output_dir, track_indices, audio_offset,

--- a/lib/gp2rs_gpx.py
+++ b/lib/gp2rs_gpx.py
@@ -133,15 +133,35 @@ def _parse_bcfs(bcfs: bytes) -> dict:
 
 
 def _load_gpif(gp_path: str) -> ET.Element:
-    """Load and parse score.gpif from a .gpx file."""
+    """Load and parse score.gpif from a .gpx (GP6) or .gp (GP7/GP8) file.
+
+    GP6 (.gpx): custom BCFZ/BCFS binary container holding score.gpif.
+    GP7/GP8 (.gp): standard ZIP archive holding Content/score.gpif.
+    Both formats use the same GPIF XML schema inside, so a single parser
+    handles all versions once the outer container is unpacked.
+    """
     with open(gp_path, 'rb') as fh:
         raw = fh.read()
+
+    # GP7/GP8: ZIP container (PK magic)
+    if raw[:2] == b'PK':
+        import zipfile
+        import io as _io
+        with zipfile.ZipFile(_io.BytesIO(raw)) as zf:
+            if 'Content/score.gpif' not in zf.namelist():
+                raise ValueError("Content/score.gpif not found in GP7/GP8 ZIP container")
+            return ET.fromstring(zf.read('Content/score.gpif'))
+
+    # GP6 (.gpx): BCFZ compressed or raw BCFS
     if raw[:4] == b'BCFZ':
         bcfs = _decompress_bcfz(raw)
     elif raw[:4] == b'BCFS':
         bcfs = raw
     else:
-        raise ValueError(f"Not a GPX file (magic: {raw[:4]!r})")
+        raise ValueError(
+            f"Unrecognised Guitar Pro container (magic: {raw[:4]!r}). "
+            f"Supported: .gpx (GP6, BCFZ/BCFS) and .gp (GP7/GP8, ZIP)."
+        )
     fs = _parse_bcfs(bcfs)
     if 'score.gpif' not in fs:
         raise ValueError("score.gpif not found in GPX container")
@@ -259,6 +279,7 @@ def _gpif_tracks(root: ET.Element) -> list[dict]:
         midi_channel = 0
         is_drums = False
         if gm is not None:
+            # GP6 (.gpx): <GeneralMidi table="Percussion"><Program>...</Program>
             try: midi_program = int(gm.findtext('Program') or 0)
             except (ValueError, TypeError): pass
             try:
@@ -268,6 +289,25 @@ def _gpif_tracks(root: ET.Element) -> list[dict]:
             except (ValueError, TypeError): pass
             if gm.get('table') == 'Percussion':
                 is_drums = True
+        else:
+            # GP7/GP8 (.gp): <InstrumentSet><Type>drumKit</Type>
+            # and <MidiConnection><PrimaryChannel>9</PrimaryChannel>
+            inst_set = t.find('InstrumentSet')
+            if inst_set is not None:
+                inst_type = (inst_set.findtext('Type') or '').lower()
+                if inst_type == 'drumkit':
+                    is_drums = True
+            midi_conn = t.find('MidiConnection')
+            if midi_conn is not None:
+                try:
+                    ch_text = (midi_conn.findtext('PrimaryChannel') or '').strip()
+                    if ch_text:
+                        ch = int(ch_text)
+                        midi_channel = ch
+                        if ch == 9:
+                            is_drums = True
+                except (ValueError, TypeError):
+                    pass
 
         # String tuning
         string_pitches: list[int] = []
@@ -501,13 +541,15 @@ def list_tracks(gp_path: str) -> list[dict]:
     result = []
     for i, t in enumerate(tracks):
         is_bass = bool(
-            (
-                not t['is_drums']
-                and not t['string_pitches']  # no string tuning = not guitar-family
-                and 32 <= t['midi_program'] <= 39
-            ) or (
-                t['string_pitches']
-                and max(t['string_pitches']) <= 48  # bass top string ≤ C3
+            not t['is_drums']  # drums always have low/zero string pitches — must exclude
+            and (
+                (
+                    not t['string_pitches']  # no string tuning = not guitar-family
+                    and 32 <= t['midi_program'] <= 39
+                ) or (
+                    t['string_pitches']
+                    and max(t['string_pitches']) <= 48  # bass top string ≤ C3
+                )
             )
         )
         is_piano = (


### PR DESCRIPTION
Follow-up to #418 and #616, becuase Claude went full Squirrel mode and utterly ignored a core part of the original instructions....

GP7/GP8 (.gp) files use a standard ZIP container holding
Content/score.gpif — the same GPIF XML schema as GP6 (.gpx).
The outer container is the only difference.

Changes (gp2rs_gpx.py only):
- _load_gpif() detects PK (ZIP) magic and unpacks via stdlib zipfile.
  GP6 BCFZ/BCFS path unchanged.
- _gpif_tracks() detects GP7 drums via <InstrumentSet><Type>drumKit</Type>
  and <MidiConnection><PrimaryChannel>9</PrimaryChannel> — GP7 has no
  <GeneralMidi> element.
- is_bass gated on not is_drums to prevent drum tracks with all-zero
  string pitches from being misclassified.

Validated against four real GP7/GP8 files:
- Psycroptic - A Fragile Existence V2 (GP8.1.3): 2x 7-string guitar,
  5-string bass, drums — all correctly classified
- RATM - Maggie's Farm (GP7.0): 14 tracks including vocals, 7 guitar
  arrangements, 5-string bass, maracas, drums — all correct
- RATM - Calm Like A Bomb (GP7.0): 6 tracks including 2 vocal,
  guitar, 2 bass arrangements, drums — all correct

No changes to gp2rs.py — the .gp suffix is already handled by the
existing shim (Path(gp_path).suffix.lower() == '.gpx' catches .gpx;
adding .gp to that check is the only gp2rs.py touch needed and is
included here).