### PR TITLE
fix(stems): split decoded WEM audio before lossy OGG encoding

### DIFF
--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -445,7 +445,7 @@ def convert_psarc_to_sloppak(
         if split_stems:
             full_wav = work_dir / "full.wav"
             _wem_to_wav(wems[0], full_wav)
-            _encode_ogg(full_wav, full_ogg)
+            full_ogg.parent.mkdir(parents=True, exist_ok=True)
         else:
             _wem_to_ogg(wems[0], full_ogg)
 
@@ -928,7 +928,9 @@ def _run_demucs(audio_path: Path, out_dir: Path, model: str) -> Path:
 
 
 def _encode_ogg(wav_path: Path, ogg_path: Path) -> None:
-    ffmpeg = _ffmpeg_cmd() or "ffmpeg"
+    ffmpeg = _ffmpeg_cmd()
+    if ffmpeg is None:
+        raise RuntimeError("ffmpeg not found on PATH")
     ogg_path.parent.mkdir(parents=True, exist_ok=True)
     r = _ffmpeg_wav_to_ogg(ffmpeg, wav_path, ogg_path)
     if r.returncode != 0 or not ogg_path.exists():
@@ -1546,11 +1548,14 @@ def _split_in_dir(
     separation_audio: Path | None = None,
 ) -> None:
     full_ogg = source_dir / "stems" / "full.ogg"
-    if not full_ogg.exists():
-        raise FileNotFoundError(
-            f"{full_ogg} not found — run PSARC conversion first or add stems/full.ogg."
-        )
-    separation_audio = separation_audio or full_ogg
+    if separation_audio is None:
+        if not full_ogg.exists():
+            raise FileNotFoundError(
+                f"{full_ogg} not found - run PSARC conversion first or add stems/full.ogg."
+            )
+        separation_audio = full_ogg
+    elif not separation_audio.exists():
+        raise FileNotFoundError(f"{separation_audio} not found.")
 
     # Try remote demucs server first, fall back to local
     remote_url = _get_demucs_server_url()
@@ -1611,12 +1616,10 @@ def _split_in_dir(
     produced.sort(key=_order_key)
 
     # Optional WhisperX transcription + pitch extraction — runs after
-    # stems are encoded but before `full.ogg` is removed (the order
-    # doesn't strictly matter for the vocals stem, which is
-    # independent, but keeping `full.ogg` around through the
-    # transcription call gives a fallback input if a future variant
-    # ever needs the mixed track). Wrapped internally so failures
-    # don't break the split. The `enabled` argument controls only
+    # stems are encoded but before an existing `full.ogg` is removed.
+    # Conversion-time splitting may provide a lossless WAV directly,
+    # so `full.ogg` is optional in that path. Wrapped internally so
+    # failures don't break the split. The `enabled` argument controls only
     # WhisperX; _maybe_transcribe_lyrics still attempts pitch
     # extraction on existing lyrics when wx is off but pitch is on.
     if needs_post_split:

--- a/lib/sloppak_convert.py
+++ b/lib/sloppak_convert.py
@@ -74,21 +74,27 @@ def _arrangement_id(name: str, used: set[str]) -> str:
     return candidate
 
 
-def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
+def _wem_to_wav(wem_path: str, out_wav: Path) -> None:
     vgmstream = _vgmstream_cmd()
-    ffmpeg = _ffmpeg_cmd()
     if not vgmstream:
         raise RuntimeError("vgmstream-cli not found on PATH")
+
+    out_wav.parent.mkdir(parents=True, exist_ok=True)
+    r = subprocess.run([vgmstream, "-o", str(out_wav), wem_path], capture_output=True)
+    if r.returncode != 0 or not out_wav.exists() or out_wav.stat().st_size < 100:
+        raise RuntimeError(
+            f"vgmstream-cli failed: {r.stderr.decode(errors='replace')}"
+        )
+
+
+def _wem_to_ogg(wem_path: str, out_ogg: Path) -> None:
+    ffmpeg = _ffmpeg_cmd()
     if not ffmpeg:
         raise RuntimeError("ffmpeg not found on PATH")
 
     with tempfile.TemporaryDirectory(prefix="s2p_wem_") as td:
         wav = Path(td) / "full.wav"
-        r = subprocess.run([vgmstream, "-o", str(wav), wem_path], capture_output=True)
-        if r.returncode != 0 or not wav.exists() or wav.stat().st_size < 100:
-            raise RuntimeError(
-                f"vgmstream-cli failed: {r.stderr.decode(errors='replace')}"
-            )
+        _wem_to_wav(wem_path, wav)
         out_ogg.parent.mkdir(parents=True, exist_ok=True)
         r2 = _ffmpeg_wav_to_ogg(ffmpeg, wav, out_ogg)
         if r2.returncode != 0 or not out_ogg.exists() or out_ogg.stat().st_size < 100:
@@ -368,8 +374,15 @@ def convert_psarc_to_sloppak(
     out_path: Path,
     as_dir: bool = False,
     progress_cb: ProgressCB = None,
+    split_stems: bool = False,
+    stem_model: str = "htdemucs_6s",
+    transcribe_lyrics: bool | None = None,
 ) -> Path:
-    """Convert a PSARC to a .sloppak (single-stem). Returns the output path."""
+    """Convert a PSARC to a .sloppak. Returns the output path.
+
+    When `split_stems` is true, separate the decoded WEM WAV before packing
+    so the separator never receives the lossy `stems/full.ogg` derivative.
+    """
     _progress(progress_cb, 0.02, "extracting", f"Unpacking {psarc_path.name}")
     tmp_extract = Path(tempfile.mkdtemp(prefix="s2p_extract_"))
     work_dir = Path(tempfile.mkdtemp(prefix="s2p_work_"))
@@ -423,11 +436,18 @@ def convert_psarc_to_sloppak(
                 "capo": arr.capo,
             })
 
-        _progress(progress_cb, 0.35, "extracting", "Converting audio (WEM → OGG)")
+        _progress(progress_cb, 0.35, "extracting", "Converting audio")
         wems = find_wem_files(str(tmp_extract))
         if not wems:
             raise RuntimeError("no WEM audio found in PSARC")
-        _wem_to_ogg(wems[0], work_dir / "stems" / "full.ogg")
+        full_ogg = work_dir / "stems" / "full.ogg"
+        full_wav = None
+        if split_stems:
+            full_wav = work_dir / "full.wav"
+            _wem_to_wav(wems[0], full_wav)
+            _encode_ogg(full_wav, full_ogg)
+        else:
+            _wem_to_ogg(wems[0], full_ogg)
 
         stems_manifest = [{"id": "full", "file": "stems/full.ogg", "default": "on"}]
 
@@ -479,7 +499,15 @@ def convert_psarc_to_sloppak(
             encoding="utf-8",
         )
 
-        _progress(progress_cb, 0.85, "packing", "Writing output")
+        if full_wav is not None:
+            _split_in_dir(
+                work_dir, stem_model, progress_cb, 0.45, 0.45,
+                transcribe_lyrics=transcribe_lyrics,
+                separation_audio=full_wav,
+            )
+            full_wav.unlink(missing_ok=True)
+
+        _progress(progress_cb, 0.95 if split_stems else 0.85, "packing", "Writing output")
         # Atomic write: build the output at a sibling `.tmp` path first,
         # then move/rename onto `out_path`. Without this, a kill mid-write
         # leaves a partial / truncated `.sloppak` (or worse, a half-deleted
@@ -723,7 +751,7 @@ def _get_pitch_config() -> dict:
     }
 
 
-def _run_demucs_remote(full_ogg: Path, out_dir: Path, model: str) -> Path:
+def _run_demucs_remote(audio_path: Path, out_dir: Path, model: str) -> Path:
     """Run stem separation via remote demucs server."""
     import json
     import requests
@@ -734,10 +762,11 @@ def _run_demucs_remote(full_ogg: Path, out_dir: Path, model: str) -> Path:
 
     # Upload the audio file — request all stems the model can produce
     stem_list = "drums,bass,vocals,other,guitar,piano"
-    with open(full_ogg, "rb") as f:
+    content_type = "audio/wav" if audio_path.suffix.lower() == ".wav" else "audio/ogg"
+    with open(audio_path, "rb") as f:
         resp = requests.post(
             f"{server_url}/separate",
-            files={"file": (full_ogg.name, f, "audio/ogg")},
+            files={"file": (audio_path.name, f, content_type)},
             params={"model": model, "stems": stem_list},
             timeout=600,
         )
@@ -779,7 +808,7 @@ def _run_demucs_remote(full_ogg: Path, out_dir: Path, model: str) -> Path:
     return result_dir
 
 
-def _run_demucs(full_ogg: Path, out_dir: Path, model: str) -> Path:
+def _run_demucs(audio_path: Path, out_dir: Path, model: str) -> Path:
     out_dir.mkdir(parents=True, exist_ok=True)
     env = os.environ.copy()
     config_dir = env.get("CONFIG_DIR", "/config")
@@ -876,7 +905,7 @@ def _run_demucs(full_ogg: Path, out_dir: Path, model: str) -> Path:
         "runpy.run_module('demucs.__main__', run_name='__main__', alter_sys=True)\n"
     )
     cmd = [sys.executable, "-c", bootstrap, json.dumps(extra_paths),
-           "-n", model, "-o", str(out_dir), str(full_ogg)]
+           "-n", model, "-o", str(out_dir), str(audio_path)]
     r = subprocess.run(cmd, env=env, capture_output=True, text=True)
     if r.returncode != 0:
         # demucs writes loader errors to stdout, not stderr -- include both
@@ -887,7 +916,7 @@ def _run_demucs(full_ogg: Path, out_dir: Path, model: str) -> Path:
         raise RuntimeError(
             f"demucs exited with code {r.returncode}: " + tail
         )
-    track_stem = full_ogg.stem
+    track_stem = audio_path.stem
     result_dir = out_dir / model / track_stem
     if not result_dir.exists():
         candidates = list((out_dir / model).iterdir()) if (out_dir / model).exists() else []
@@ -1514,12 +1543,14 @@ def _split_in_dir(
     base_frac: float,
     span_frac: float,
     transcribe_lyrics: bool | None = None,
+    separation_audio: Path | None = None,
 ) -> None:
     full_ogg = source_dir / "stems" / "full.ogg"
     if not full_ogg.exists():
         raise FileNotFoundError(
             f"{full_ogg} not found — run PSARC conversion first or add stems/full.ogg."
         )
+    separation_audio = separation_audio or full_ogg
 
     # Try remote demucs server first, fall back to local
     remote_url = _get_demucs_server_url()
@@ -1549,15 +1580,15 @@ def _split_in_dir(
     with tempfile.TemporaryDirectory(prefix="s2p_split_") as td:
         if use_remote:
             try:
-                result_dir = _run_demucs_remote(full_ogg, Path(td), model)
+                result_dir = _run_demucs_remote(separation_audio, Path(td), model)
             except Exception as e:
                 log.warning("Demucs remote failed (%s), falling back to local", e)
                 if demucs_available():
-                    result_dir = _run_demucs(full_ogg, Path(td), model)
+                    result_dir = _run_demucs(separation_audio, Path(td), model)
                 else:
                     raise RuntimeError(f"Remote demucs failed and local demucs not available: {e}")
         else:
-            result_dir = _run_demucs(full_ogg, Path(td), model)
+            result_dir = _run_demucs(separation_audio, Path(td), model)
 
         _progress(progress_cb, base_frac + split_span * 0.85, "splitting",
                   "Encoding split stems")

--- a/tests/test_psarc_to_sloppak.py
+++ b/tests/test_psarc_to_sloppak.py
@@ -275,9 +275,8 @@ def test_split_during_conversion_uses_decoded_wav_without_packing_it(
         out_wav.parent.mkdir(parents=True, exist_ok=True)
         out_wav.write_bytes(b"RIFF" + b"\x00" * 256)
 
-    def _stub_encode_ogg(_wav_path: Path, out_ogg: Path) -> None:
-        out_ogg.parent.mkdir(parents=True, exist_ok=True)
-        out_ogg.write_bytes(b"OggS" + b"\x00" * 256)
+    def _stub_encode_ogg(_wav_path: Path, _out_ogg: Path) -> None:
+        raise AssertionError("split_stems should not pre-encode stems/full.ogg")
 
     def _stub_split(source_dir: Path, _model: str, _progress_cb, _base_frac,
                     _span_frac, *, transcribe_lyrics=None,
@@ -285,7 +284,7 @@ def test_split_during_conversion_uses_decoded_wav_without_packing_it(
         assert separation_audio is not None
         observed["suffix"] = separation_audio.suffix
         observed["bytes"] = separation_audio.read_bytes()
-        (source_dir / "stems" / "full.ogg").unlink()
+        observed["full_ogg_exists"] = (source_dir / "stems" / "full.ogg").exists()
         vocals = source_dir / "stems" / "vocals.ogg"
         vocals.write_bytes(b"OggS" + b"\x00" * 256)
         sloppak_convert._rewrite_stems_manifest(
@@ -301,7 +300,11 @@ def test_split_during_conversion_uses_decoded_wav_without_packing_it(
     out = tmp_path / "split.sloppak"
     convert_psarc_to_sloppak(FIXTURE, out, split_stems=True)
 
-    assert observed == {"suffix": ".wav", "bytes": b"RIFF" + b"\x00" * 256}
+    assert observed == {
+        "suffix": ".wav",
+        "bytes": b"RIFF" + b"\x00" * 256,
+        "full_ogg_exists": False,
+    }
     with zipfile.ZipFile(out) as zf:
         assert "stems/vocals.ogg" in zf.namelist()
         assert "stems/full.ogg" not in zf.namelist()

--- a/tests/test_psarc_to_sloppak.py
+++ b/tests/test_psarc_to_sloppak.py
@@ -264,6 +264,50 @@ def test_progress_callback_terminates_at_done(tmp_path: Path, monkeypatch):
     assert stages.index("extracting") < stages.index("packing") < stages.index("done")
 
 
+def test_split_during_conversion_uses_decoded_wav_without_packing_it(
+    tmp_path: Path, monkeypatch
+):
+    _require_fixture()
+    _apply_pony_stubs(monkeypatch)
+    observed = {}
+
+    def _stub_wem_to_wav(_wem_path, out_wav: Path) -> None:
+        out_wav.parent.mkdir(parents=True, exist_ok=True)
+        out_wav.write_bytes(b"RIFF" + b"\x00" * 256)
+
+    def _stub_encode_ogg(_wav_path: Path, out_ogg: Path) -> None:
+        out_ogg.parent.mkdir(parents=True, exist_ok=True)
+        out_ogg.write_bytes(b"OggS" + b"\x00" * 256)
+
+    def _stub_split(source_dir: Path, _model: str, _progress_cb, _base_frac,
+                    _span_frac, *, transcribe_lyrics=None,
+                    separation_audio: Path | None = None) -> None:
+        assert separation_audio is not None
+        observed["suffix"] = separation_audio.suffix
+        observed["bytes"] = separation_audio.read_bytes()
+        (source_dir / "stems" / "full.ogg").unlink()
+        vocals = source_dir / "stems" / "vocals.ogg"
+        vocals.write_bytes(b"OggS" + b"\x00" * 256)
+        sloppak_convert._rewrite_stems_manifest(
+            source_dir,
+            [{"id": "vocals", "file": "stems/vocals.ogg", "default": "on"}],
+            stem_separation={"engine": "demucs", "model": "test", "version": "1.0.0"},
+        )
+
+    monkeypatch.setattr(sloppak_convert, "_wem_to_wav", _stub_wem_to_wav)
+    monkeypatch.setattr(sloppak_convert, "_encode_ogg", _stub_encode_ogg)
+    monkeypatch.setattr(sloppak_convert, "_split_in_dir", _stub_split)
+
+    out = tmp_path / "split.sloppak"
+    convert_psarc_to_sloppak(FIXTURE, out, split_stems=True)
+
+    assert observed == {"suffix": ".wav", "bytes": b"RIFF" + b"\x00" * 256}
+    with zipfile.ZipFile(out) as zf:
+        assert "stems/vocals.ogg" in zf.namelist()
+        assert "stems/full.ogg" not in zf.namelist()
+        assert "full.wav" not in zf.namelist()
+
+
 # ── Atomic-write contract (issue topkoa/slopsmith-plugin-sloppak-converter#25) ─
 
 

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -774,6 +774,9 @@ def test_split_in_dir_prefers_explicit_lossless_audio(tmp_path, monkeypatch):
         return result_dir
 
     def _stub_encode(_wav_path, out_ogg):
+        # Mirror the real _encode_ogg, which mkdirs the parent before writing —
+        # _split_in_dir relies on that and does not create stems/ itself.
+        out_ogg.parent.mkdir(parents=True, exist_ok=True)
         out_ogg.write_bytes(b"OggS" + b"\x00" * 256)
 
     monkeypatch.setattr(sloppak_convert, "_get_demucs_server_url",

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -743,6 +743,87 @@ def test_stem_separation_constants_are_stable():
     assert sloppak_convert.STEM_SEPARATION_SCHEMA_VERSION == "1.0.0"
 
 
+def test_split_in_dir_prefers_explicit_lossless_audio(tmp_path, monkeypatch):
+    stems_dir = tmp_path / "stems"
+    stems_dir.mkdir()
+    full_ogg = stems_dir / "full.ogg"
+    full_ogg.write_bytes(b"OggS" + b"\x00" * 256)
+    lossless_wav = tmp_path / "full.wav"
+    lossless_wav.write_bytes(b"RIFF" + b"\x00" * 256)
+    _write_minimal_manifest(tmp_path)
+    observed = {}
+
+    def _stub_remote(audio_path, out_dir, model):
+        observed["audio_path"] = audio_path
+        observed["model"] = model
+        result_dir = out_dir / "remote_stems"
+        result_dir.mkdir()
+        (result_dir / "vocals.wav").write_bytes(b"RIFF" + b"\x00" * 256)
+        return result_dir
+
+    def _stub_encode(_wav_path, out_ogg):
+        out_ogg.write_bytes(b"OggS" + b"\x00" * 256)
+
+    monkeypatch.setattr(sloppak_convert, "_get_demucs_server_url",
+                        lambda: "http://separator.test")
+    monkeypatch.setattr(sloppak_convert, "_get_whisperx_config",
+                        lambda: {"enabled": False})
+    monkeypatch.setattr(sloppak_convert, "_get_pitch_config",
+                        lambda: {"enabled": False})
+    monkeypatch.setattr(sloppak_convert, "_run_demucs_remote", _stub_remote)
+    monkeypatch.setattr(sloppak_convert, "_encode_ogg", _stub_encode)
+
+    sloppak_convert._split_in_dir(
+        tmp_path, "test-model", None, 0.0, 1.0,
+        separation_audio=lossless_wav,
+    )
+
+    assert observed == {"audio_path": lossless_wav, "model": "test-model"}
+    assert (stems_dir / "vocals.ogg").is_file()
+    assert not full_ogg.exists()
+
+
+def test_run_demucs_remote_uploads_wav_with_wav_content_type(tmp_path, monkeypatch):
+    audio_path = tmp_path / "full.wav"
+    audio_path.write_bytes(b"RIFF" + b"\x00" * 256)
+    observed = {}
+
+    class _Response:
+        status_code = 200
+        content = b"RIFF" + b"\x00" * 256
+        text = ""
+
+        @staticmethod
+        def json():
+            return {"stems": {"vocals": "/download/job/vocals.wav"}}
+
+    def _stub_post(url, *, files, params, timeout):
+        filename, file_obj, content_type = files["file"]
+        observed["url"] = url
+        observed["filename"] = filename
+        observed["content_type"] = content_type
+        observed["content"] = file_obj.read()
+        return _Response()
+
+    import requests
+    monkeypatch.setattr(sloppak_convert, "_get_demucs_server_url",
+                        lambda: "http://separator.test")
+    monkeypatch.setattr(requests, "post", _stub_post)
+    monkeypatch.setattr(requests, "get", lambda *args, **kwargs: _Response())
+
+    result_dir = sloppak_convert._run_demucs_remote(
+        audio_path, tmp_path / "out", "test-model",
+    )
+
+    assert observed == {
+        "url": "http://separator.test/separate",
+        "filename": "full.wav",
+        "content_type": "audio/wav",
+        "content": b"RIFF" + b"\x00" * 256,
+    }
+    assert (result_dir / "vocals.wav").is_file()
+
+
 # ── _maybe_extract_pitch ────────────────────────────────────────────────────
 # The pitch path is best-effort and gated on multiple config + filesystem
 # conditions. These cover the skip gates + the happy-path write to make

--- a/tests/test_sloppak_convert.py
+++ b/tests/test_sloppak_convert.py
@@ -496,6 +496,21 @@ def test_ffmpeg_wav_to_ogg_does_not_retry_on_unrelated_error(tmp_path, monkeypat
     assert len(cmds) == 1  # no retry
 
 
+def test_encode_ogg_raises_runtime_error_when_ffmpeg_missing(tmp_path, monkeypatch):
+    wav = tmp_path / "in.wav"
+    wav.write_bytes(b"\x00" * 200)
+    out_ogg = tmp_path / "out.ogg"
+    monkeypatch.setattr(sloppak_convert, "_ffmpeg_cmd", lambda: None)
+    monkeypatch.setattr(
+        sloppak_convert,
+        "_ffmpeg_wav_to_ogg",
+        lambda *args, **kwargs: pytest.fail("_ffmpeg_wav_to_ogg should not run"),
+    )
+
+    with pytest.raises(RuntimeError, match="ffmpeg not found on PATH"):
+        sloppak_convert._encode_ogg(wav, out_ogg)
+
+
 # ── cleanup_stale_temp_dirs (issue topkoa/slopsmith-plugin-sloppak-converter#24) ─
 
 
@@ -745,9 +760,6 @@ def test_stem_separation_constants_are_stable():
 
 def test_split_in_dir_prefers_explicit_lossless_audio(tmp_path, monkeypatch):
     stems_dir = tmp_path / "stems"
-    stems_dir.mkdir()
-    full_ogg = stems_dir / "full.ogg"
-    full_ogg.write_bytes(b"OggS" + b"\x00" * 256)
     lossless_wav = tmp_path / "full.wav"
     lossless_wav.write_bytes(b"RIFF" + b"\x00" * 256)
     _write_minimal_manifest(tmp_path)
@@ -780,7 +792,7 @@ def test_split_in_dir_prefers_explicit_lossless_audio(tmp_path, monkeypatch):
 
     assert observed == {"audio_path": lossless_wav, "model": "test-model"}
     assert (stems_dir / "vocals.ogg").is_file()
-    assert not full_ogg.exists()
+    assert not (stems_dir / "full.ogg").exists()
 
 
 def test_run_demucs_remote_uploads_wav_with_wav_content_type(tmp_path, monkeypatch):


### PR DESCRIPTION
Fixes #340

NOTE: need to apply my PR fix I made in [slopsmith-plugin-sloppak-converter  ](https://github.com/topkoa/slopsmith-plugin-sloppak-converter) after merging this PR.  Merge this PR first before doing sloppak converter.

 ## Summary

  Route conversion-time stem separation through the decoded WEM WAV instead of the lossy `stems/full.ogg` derivative.

  ## Problem

  PSARC conversion previously followed this pipeline:

  `WEM -> WAV -> OGG -> stem separator -> split stems`

  The intermediate Vorbis encode introduced unnecessary quality loss before Demucs or a remote separator received the
  full mix.

  ## Changes

  - Add a reusable WEM-to-WAV helper.
  - Allow `convert_psarc_to_sloppak()` to split stems before packaging.
  - Pass the temporary decoded WAV to local or remote separation.
  - Upload WAV inputs to remote separators with the `audio/wav` content type.
  - Preserve the existing `full.ogg` split path for previously converted sloppaks.
  - Remove the temporary WAV before writing the final `.sloppak`.

  ## Result

  New conversion-time splits use:

  `WEM -> WAV -> stem separator -> OGG stems`

  Existing `.sloppak` files remain compatible.

  ## Testing

  - Added regression coverage proving conversion-time separation receives a WAV.
  - Added regression coverage proving remote WAV uploads use `audio/wav`.
  - Ran conversion and splitting tests:
    - `89 passed`
    - `1 skipped`
    - `1 unrelated Windows PATH-casing test deselected`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional stem splitting during PSARC→sloppak conversion with selectable separation model and optional lyric transcription
  * Stem separation runs from decoded lossless audio to improve split quality and progress reporting

* **Bug Fixes**
  * Remote separation uploads WAV inputs with correct content type and consistent fallback behavior
  * Encoding now fails loudly when required encoder is missing

* **Tests**
  * Added end-to-end and unit tests covering split flow, upload behavior, and encoder error handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/slopsmith/slopsmith/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->