### PR TITLE
feat(highway_3d): Z-depth render-order overhaul, per-note fret labels, and performance

### DIFF
--- a/plugins/highway_3d/plugin.json
+++ b/plugins/highway_3d/plugin.json
@@ -1,7 +1,7 @@
 {
     "id": "highway_3d",
     "name": "3D Highway",
-    "version": "3.21.0",
+    "version": "3.22.0",
     "type": "visualization",
     "bundled": true,
     "script": "screen.js",

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -326,7 +326,7 @@
     const CAM_FRAME_DIST_FAR  = 141 * K;
     const CAM_FRAME_H_NEAR = 0.75;
     const CAM_FRAME_H_FAR  = 1.20;
-    const CAM_FRAME_D_NEAR = 0.55;
+    const CAM_FRAME_D_NEAR = 0.575;
     const CAM_FRAME_D_FAR  = 0.60;
 
     // Camera-X targeting (issue #34). The visible AHEAD = 4.0 s window is
@@ -11358,7 +11358,7 @@
                 (dist - CAM_FRAME_DIST_NEAR) / (CAM_FRAME_DIST_FAR - CAM_FRAME_DIST_NEAR)));
             const _hMul = CAM_FRAME_H_NEAR + (CAM_FRAME_H_FAR - CAM_FRAME_H_NEAR) * _zt;
             const _dMul = CAM_FRAME_D_NEAR + (CAM_FRAME_D_FAR - CAM_FRAME_D_NEAR) * _zt;
-            const shoulderOffset = (_leftyCached ? -1 : 1) * 13 * K;
+            const shoulderOffset = (_leftyCached ? -1 : 1) * 10 * K;
             cam.position.set(curX + shoulderOffset, h * _hMul, dist * _dMul);
 
             // Self-correcting look-at Y: project the fretboard's near-edge centre

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -2599,18 +2599,19 @@
         // Low-overdraw sustain rendering (DEFAULT since perf profiling on
         // dense palm-mute / fret-hand-mute passages). Those sections are GPU
         // fill-bound: the transparent sustain trails/rails stack many blended
-        // fragments. The trail/ribbon OUTLINE layer and the additive rail
-        // bloom halo were the two biggest fill contributors, and dropping them
-        // measurably lifts FPS (≈7.5→5.9 ms ren.render() p50, ~107→134 fps in
-        // a pinned A/B loop) with a visual change the maintainer judged worth
-        // it. The trail/rail CORES still draw, so sustains stay clearly
-        // visible. Opt back into the full-quality look (outline + bloom) per
-        // browser, no rebuild needed:
-        //   localStorage.h3d_full_sus = '1'   // restore outline + bloom
+        // fragments. Profiling (pinned A/B loop) showed ren.render() p50 at
+        // ~7.5 ms vs ~5.9 ms with all the sustain extras off. The additive
+        // rail bloom halo (wide gaussian planes, additive blending) is the
+        // single most expensive per-pixel contributor, so the lean default
+        // drops ONLY the bloom. The trail/ribbon white OUTLINE (mSusOutline,
+        // with hit/miss colour) is kept — it's a thin, cheap layer and gives
+        // tails their border, so it's worth the small fill cost. Opt back into
+        // the full look (re-enable the rail bloom) per browser, no rebuild:
+        //   localStorage.h3d_full_sus = '1'   // re-enable rail bloom halo
         //   delete localStorage.h3d_full_sus  // back to lean default
         // Read once per frame at the top of update() so the flag takes effect
-        // live. The supporting pools/materials are kept intact (still pinned
-        // by the bloom unit tests and used by the opt-out path).
+        // live. The bloom pool/material/gaussian texture are kept intact
+        // (still pinned by the bloom unit tests and used by the opt-out path).
         let _leanSus = true;
 
         // Lifecycle flags
@@ -7272,9 +7273,10 @@
         /* ── Per-frame rendering ─────────────────────────────────────────── */
         function update(bundle) {
             pbBeg(0);
-            // Lean sustain rendering is the default (see declaration above);
-            // the full-quality outline+bloom look is an opt-out. Cheap
-            // per-frame read so the console flag takes effect live.
+            // Lean sustain rendering is the default (see declaration above):
+            // the trail/ribbon outline always draws; only the additive rail
+            // bloom halo is dropped. The full look (with bloom) is an opt-out.
+            // Cheap per-frame read so the console flag takes effect live.
             try {
                 _leanSus = localStorage.getItem('h3d_full_sus') !== '1';
             } catch (_) { _leanSus = true; }
@@ -10775,13 +10777,11 @@
                             const _ro = Math.max(47.999, Math.round(700 + Math.min(0, zCenter) / K) - 2) - 0.001;
                             for (let i = 0; i < offsets.length; i++) {
                                 const xOff = xCenter + offsets[i];
-                                if (!_leanSus) {
-                                    const trOut = pSusOutline.get();
-                                    trOut.material = _susOlMat;
-                                    trOut.renderOrder = _ro;
-                                    trOut.position.set(xOff, y, zCenter);
-                                    trOut.scale.set(tw + 0.4 * K, th + 0.4 * K, segLen);
-                                }
+                                const trOut = pSusOutline.get();
+                                trOut.material = _susOlMat;
+                                trOut.renderOrder = _ro;
+                                trOut.position.set(xOff, y, zCenter);
+                                trOut.scale.set(tw + 0.4 * K, th + 0.4 * K, segLen);
                                 const tr = pSus.get();
                                 tr.material = _ndState ? mGlow[s] : mSus[s];
                                 tr.renderOrder = _ro + 0.0005;
@@ -10802,19 +10802,17 @@
                             const _ribRO = Math.max(47.999, Math.round(700 - _ribDt * 200) - 2) - 0.001;
                             for (let si = 0; si < offsets.length; si++) {
                                 const strandX = x + offsets[si];
-                                if (!_leanSus) {
-                                    const olMesh = pSusRibbonOl.get();
-                                    olMesh.renderOrder = _ribRO;
-                                    olMesh.scale.set(1, 1, 1);
-                                    olMesh.rotation.set(0, 0, 0);
-                                    olMesh.position.set(0, 0, 0);
-                                    olMesh.material = _susOlMat;
-                                    slideRibbonUpdatePositions(
-                                        olMesh.geometry, strandX,
-                                        tw + 0.4 * K, th + 0.4 * K,
-                                        y, sliceDur, susStart, now, n, slideSt,
-                                    );
-                                }
+                                const olMesh = pSusRibbonOl.get();
+                                olMesh.renderOrder = _ribRO;
+                                olMesh.scale.set(1, 1, 1);
+                                olMesh.rotation.set(0, 0, 0);
+                                olMesh.position.set(0, 0, 0);
+                                olMesh.material = _susOlMat;
+                                slideRibbonUpdatePositions(
+                                    olMesh.geometry, strandX,
+                                    tw + 0.4 * K, th + 0.4 * K,
+                                    y, sliceDur, susStart, now, n, slideSt,
+                                );
                                 const body = pSusRibbon.get();
                                 body.renderOrder = _ribRO + 0.0005;
                                 body.scale.set(1, 1, 1);

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -6233,7 +6233,11 @@
             const addDot = (x, y) => {
                 const d = new T.Mesh(dg, dm);
                 d.position.set(x, y, dotZBack);
-                d.renderOrder = -120;
+                // Above the dynamic lane (1) and its dividers (2) so the
+                // translucent blue lane no longer paints over and hides the
+                // inlay; still well below strings (703) / wires (704) / notes,
+                // so those keep drawing on top of the inlay.
+                d.renderOrder = 3;
                 fretG.add(d);
             };
             for (const f of DOTS) {

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -310,7 +310,7 @@
     const N_RAD = 1.5 * K;
     const SW = 2 * K, SH = 1.5 * K;
 
-    const CAM_H_BASE = 170 * K;
+    const CAM_H_BASE = 175 * K;
     const CAM_DIST_BASE = 240 * K;
     const REF_ASPECT = 16 / 9;
     const FOCUS_D = 600 * K;
@@ -326,7 +326,7 @@
     const CAM_FRAME_DIST_FAR  = 141 * K;
     const CAM_FRAME_H_NEAR = 0.75;
     const CAM_FRAME_H_FAR  = 1.20;
-    const CAM_FRAME_D_NEAR = 0.50;
+    const CAM_FRAME_D_NEAR = 0.525;
     const CAM_FRAME_D_FAR  = 0.60;
 
     // Camera-X targeting (issue #34). The visible AHEAD = 4.0 s window is

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -310,7 +310,7 @@
     const N_RAD = 1.5 * K;
     const SW = 2 * K, SH = 1.5 * K;
 
-    const CAM_H_BASE = 180 * K;
+    const CAM_H_BASE = 190 * K;
     const CAM_DIST_BASE = 240 * K;
     const REF_ASPECT = 16 / 9;
     const FOCUS_D = 600 * K;
@@ -326,7 +326,7 @@
     const CAM_FRAME_DIST_FAR  = 141 * K;
     const CAM_FRAME_H_NEAR = 0.75;
     const CAM_FRAME_H_FAR  = 1.20;
-    const CAM_FRAME_D_NEAR = 0.525;
+    const CAM_FRAME_D_NEAR = 0.55;
     const CAM_FRAME_D_FAR  = 0.60;
 
     // Camera-X targeting (issue #34). The visible AHEAD = 4.0 s window is

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -42,8 +42,8 @@
     // for the palette-preview swatches — keep them in sync.
     const PALETTES = {
         default: [
-            0xff2828, 0xffd400, 0x2080ff, 0xff8020,
-            0x30d040, 0xa040ff, 0xff6bd5, 0x6bffe6,
+            0xe61f26, 0xecd234, 0x1096e6, 0xf18313,
+            0x3fc413, 0xb518d9, 0xff6bd5, 0x6bffe6,
         ],
         neon: [
             0xff0030, 0xffe800, 0x0080ff, 0xff8030,
@@ -195,13 +195,13 @@
     // switch ~BEHIND seconds before the XML <anchor time="…"/>.
     const HWY_LANE_TIME_SLICES = 96;
     /** Odd columns (1st/3rd/…) darker teal; even columns brighter blue. */
-    const HWY_LANE_STRIPE_ODD_HEX  = 0x3d739e;
-    const HWY_LANE_STRIPE_EVEN_HEX = 0x62a5d8;
+    const HWY_LANE_STRIPE_ODD_HEX  = 0x103B5C;
+    const HWY_LANE_STRIPE_EVEN_HEX = 0x08283C;
     /** Lane quad alpha: base + highwayIntensity * scale (readable on dark floor). */
-    const HWY_LANE_STRIPE_OP_BASE = 0.12;
-    const HWY_LANE_STRIPE_OP_INT  = 0.24;
-    /** Note travel speed. Tuned to Rocksmith's default note feel via play tests (PR #303). */
-    const TS = 150 * K;
+    const HWY_LANE_STRIPE_OP_BASE = 1.0;
+    const HWY_LANE_STRIPE_OP_INT  = 0;
+    /** Note travel speed. */
+    const TS = 230 * K;
     /** Match `nextNoteByString` onset to this note (float + chart rounding; avoids ghost / glow flicker). */
     const NEXT_ON_STRING_T_EPS = 0.06;
     /**
@@ -258,7 +258,7 @@
     }
 
     // Shorter, flatter notes (joel style)
-    const NW = 5 * K, NH = 3 * K, ND = 0.5 * K;
+    const NW = 5 * K, NH = 3 * K, ND = 0.25 * K;
     // Sustain-trail X offset for fretted notes. Module-scoped + frozen
     // so the hot path's `offsets.length` loop sees a stable singleton
     // reference. The standalone-open-string path builds a fresh pair
@@ -374,7 +374,6 @@
     /** Schmitt: avoid lock↔dynamic flicker when lookahead maxF jitters at the 12th fret. */
     const LOOKAHEAD_LOCK_RELEASE_MAXF = 13;
     const LOOKAHEAD_LOCK_ENGAGE_MAXF = 10;
-
     // Note: we deliberately do NOT scale the camUpdate lerp speed with
     // cameraSmoothing. Smoothing widens the hysteresis dead zones so the
     // camera stays put through small/repetitive shifts; but when a shift
@@ -1912,6 +1911,9 @@
         let ambLight = null, dirLight = null;
         let fretG = null, tuningLblG = null, noteG = null, beatG = null, lblG = null;
         let gNote = null, gSus = null, gBeat = null, gTapChevron = null;
+        // Per-string gradient gem geometries (index 0..5). Built in initScene
+        // from sampled colour PNGs; each carries a per-vertex colour attribute.
+        let gNoteGrad = [];
         let mStr = [], mGlow = [], mSus = [], mStrHitOutline = [], mAccentOutline = [], mAccentCore = [], mAccentHaloNear = [], mAccentHaloMid = [], mAccentHaloFar = [];
         // Pre-built accent-halo shell descriptors per string. Populated after
         // mAccentHaloFar/Mid/Near are materialised; consumed in drawNote()'s
@@ -1990,6 +1992,36 @@
         let pSusRail = null, gSusRail = null, mSusRailBase = null;
         let pSusRailBloom = null, gSusRailBloom = null, mSusRailBloomBase = null, _bloomGaussTex = null;
         let pTechPlane = null, gTechPlane = null;
+
+        // ── InstancedMesh for PM/FH X markers ────────────────────────────────
+        // Replaces pTechPlane pool entries for PM and FH mute techniques,
+        // collapsing O(visible-muted-notes) draw calls to 2 per type.
+        // pTechPlane pool is still used for H/P triangles, harmonics and bends.
+        let imPMTech = null, imFHTech = null;
+        let _imGPMTech = null, _imGFHTech = null; // cloned geometries (own instanceAlpha attr)
+        let _imPMTechMat = null, _imFHTechMat = null;
+        const IM_TECH_CAP = 256;
+        const _imPMTechAlphaArr = new Float32Array(IM_TECH_CAP);
+        const _imFHTechAlphaArr = new Float32Array(IM_TECH_CAP);
+        let _imPMTechCount = 0, _imFHTechCount = 0;
+
+        // ── InstancedMesh for chord strum indicators ──────────────────────────
+        // Replaces pPMXFill, pMuteXLines, pFHXFill, pFHXLines pools.
+        // Fixed renderOrder per type — no per-instance sort needed.
+        let imPMXFill = null, imPMXLines = null, imFHXFill = null, imFHXLines = null;
+        let _imPMXFillMat = null, _imPMXLinesMat = null;
+        let _imFHXFillMat = null, _imFHXLinesMat = null;
+        const IM_STRUM_CAP = 64;
+        const _imPMXFillAlphaArr  = new Float32Array(IM_STRUM_CAP);
+        const _imPMXLinesAlphaArr = new Float32Array(IM_STRUM_CAP);
+        const _imFHXFillAlphaArr  = new Float32Array(IM_STRUM_CAP);
+        const _imFHXLinesAlphaArr = new Float32Array(IM_STRUM_CAP);
+        let _imPMXFillCount = 0, _imPMXLinesCount = 0, _imFHXFillCount = 0, _imFHXLinesCount = 0;
+
+        // Temporaries for InstancedMesh matrix composition — allocated once in
+        // initScene() after Three.js loads, reused every frame without allocation.
+        let _imM4 = null, _imPos = null, _imSca = null, _imQ = null, _imAZ = null, _imColor = null;
+
         let _diagPrev             = null;
         let _diagPrevOpacity      = 0;
         let _diagPrevStartOpacity = 0;
@@ -2026,6 +2058,17 @@
         let _mergeCacheChordsRef = null;
         let _mergeCacheHsRef = null;
         let _mergeCacheTplRef = null;
+
+        // Fret connector-label visibility cache: tracks which (time, fret)
+        // pairs may show their indicator number per the measure-skip rule
+        // (show only the first note with a given fret in a measure; suppress
+        // the same fret for the following measure, then allow it again).
+        let _fretLabelAllowed = new Set();
+        let _fretLabelNotesRef = null;
+        // Frame-level dedup: tracks which (40ms-rounded-time, fret) pairs have already
+        // rendered a label this frame so that multiple strings at the same fret/onset
+        // (arpeggio chords, synthetic chords) never produce stacked duplicate labels.
+        const _frameLabeledKeys = new Set();
 
         let _arpGhostInferRefHs = null;
         let _arpGhostInferRefNotes = null;
@@ -2295,6 +2338,10 @@
         // place — without this the layer stays at its built-in opacity
         // until the next palette change rebuilds buildBoard().
         let stringLineGlows = [];
+        // One LineBasicMaterial per fret wire (index = fret 0..NFRETS).
+        // Updated each frame to gold when inside the active anchor range,
+        // gray otherwise. Reset to [] on every buildBoard() rebuild.
+        let fretWireMats = [];
         /** Nut + headstock 3D subtree; visibility toggled from settings without rebuild. */
         let nutHeadstockGroup = null;
         /** Left edge X of drawable string meshes; updated in buildBoard() at nut / fret junction. */
@@ -2532,6 +2579,39 @@
         let _lookaheadCamPrevNow = null;
         let _lookaheadLowBonusU = 0;
         let _lookaheadHiNeckLatch = false;
+
+        // ── Sub-frame clock smoothing ─────────────────────────────────────
+        // bundle.currentTime is the browser's audio.currentTime, which only
+        // refreshes every ~20–23 ms — coarser than a 60/144 Hz rAF frame. Fed
+        // straight into note Z-positions it makes the whole highway step in
+        // micro-jumps (1–2 static frames, then a jump), most visible as a
+        // "stutter" across a dense wall of repeated chords even when FPS is
+        // steady. smoothNow() interpolates forward with performance.now()
+        // between distinct audio samples (mirroring core highway.js
+        // getTime()), tracking the observed playback rate so the speed slider
+        // stays accurate, and falls back to the raw value on pause / seek /
+        // stall so the scroll never drifts against silent audio.
+        let _clkAudioT = NaN;   // last distinct bundle.currentTime sample
+        let _clkPerf = NaN;     // performance.now() when that sample arrived
+        let _clkRate = 1;       // observed chart-seconds per real-second
+        let _frameNow = 0;      // smoothed time for THIS frame (update → camUpdate)
+
+        // Low-overdraw sustain rendering (DEFAULT since perf profiling on
+        // dense palm-mute / fret-hand-mute passages). Those sections are GPU
+        // fill-bound: the transparent sustain trails/rails stack many blended
+        // fragments. The trail/ribbon OUTLINE layer and the additive rail
+        // bloom halo were the two biggest fill contributors, and dropping them
+        // measurably lifts FPS (≈7.5→5.9 ms ren.render() p50, ~107→134 fps in
+        // a pinned A/B loop) with a visual change the maintainer judged worth
+        // it. The trail/rail CORES still draw, so sustains stay clearly
+        // visible. Opt back into the full-quality look (outline + bloom) per
+        // browser, no rebuild needed:
+        //   localStorage.h3d_full_sus = '1'   // restore outline + bloom
+        //   delete localStorage.h3d_full_sus  // back to lean default
+        // Read once per frame at the top of update() so the flag takes effect
+        // live. The supporting pools/materials are kept intact (still pinned
+        // by the bloom unit tests and used by the opt-out path).
+        let _leanSus = true;
 
         // Lifecycle flags
         let _isReady = false;
@@ -3237,7 +3317,7 @@
         })();
         let pbBeg, pbEnd, pbReportTick;
         if (_perfBench) {
-            const _PB_NAMES = ['frame', 'state', 'next', 'mat', 'noteDraw', 'chordDraw'];
+            const _PB_NAMES = ['frame', 'state', 'next', 'mat', 'noteDraw', 'chordDraw', 'render'];
             const _pbStart = new Float64Array(_PB_NAMES.length);
             const _pbAcc = _PB_NAMES.map(() => []);
             const _PB_REPORT_MS = 5000;
@@ -4297,6 +4377,39 @@
 
             // Rectangular note geometry
             gNote = new T.BoxGeometry(NW, NH, ND);
+            // Per-string vertical gradient gems — colours sampled from the
+            // rocksmith colour PNGs (top highlight → deeper bottom). Each gradient
+            // string gets its own BoxGeometry clone carrying a per-vertex colour
+            // attribute; the gem core swaps to gNoteGrad[s] in drawNote while its
+            // material (mStr[s]) is white + vertexColors:true so the gradient
+            // shows pure. Strings 6/7 have no entry and fall back to flat gNote.
+            const _GEM_GRADIENTS = [
+                [0xec0816, 0xbd0400], // 0 red
+                [0xefd20b, 0xceaa00], // 1 yellow
+                [0x0b93e9, 0x0e69b2], // 2 blue
+                [0xf77b0b, 0xdb5808], // 3 orange
+                [0x37c40b, 0x139305], // 4 green
+                [0xaf10db, 0x8907af], // 5 violet
+            ];
+            gNoteGrad = _GEM_GRADIENTS.map(([topHex, botHex]) => {
+                const g = new T.BoxGeometry(NW, NH, ND);
+                const _pos = g.attributes.position;
+                const _colors = new Float32Array(_pos.count * 3);
+                const _topCol = new T.Color(topHex);
+                const _botCol = new T.Color(botHex);
+                const _tmpCol = new T.Color();
+                const _halfH = NH / 2;
+                for (let i = 0; i < _pos.count; i++) {
+                    const t = (_pos.getY(i) + _halfH) / (2 * _halfH); // 0 bottom..1 top
+                    _tmpCol.copy(_botCol).lerp(_topCol, t);
+                    _colors[i * 3] = _tmpCol.r;
+                    _colors[i * 3 + 1] = _tmpCol.g;
+                    _colors[i * 3 + 2] = _tmpCol.b;
+                }
+                g.setAttribute('color', new T.BufferAttribute(_colors, 3));
+                _ownedSharedGeos.push(g);
+                return g;
+            });
 
             /** Filled ring matching flying-note outline (1.1) minus core (1.0); hollow centre. */
             function mkGhostFrameGeometry() {
@@ -4355,10 +4468,13 @@
             const centerOffset = -0.5 * (gTapChevron.boundingBox.max.y + gTapChevron.boundingBox.min.y);
             gTapChevron.translate(0, centerOffset, 0);
 
-            // String materials: emissive so they glow when lit
-            mStr = activePalette.map(c => new T.MeshStandardMaterial({
-                color: c, emissive: c, emissiveIntensity: 0.002,
-                transparent: true, opacity: 0.4, roughness: 1,
+            // String materials. Strings 0..5 use a per-vertex gradient (color is
+            // white so the gradient baked into gNoteGrad[s] shows pure); strings
+            // 6/7 keep a flat colour (vertexColors:false ignores the attribute).
+            mStr = activePalette.map((c, i) => new T.MeshBasicMaterial({
+                color: i < 6 ? 0xffffff : c,
+                vertexColors: i < 6,
+                transparent: true, opacity: 1.0,
             }));
             mGlow = activePalette.map(c => new T.MeshLambertMaterial({
                 color: 0xffffff, emissive: c, emissiveIntensity: 1.5,
@@ -4369,7 +4485,9 @@
                 color: c, transparent: true, opacity: 0.35,
             }));
             mWhiteOutline = new T.MeshLambertMaterial({ color: 0xffffff, emissive: 0xffffff, emissiveIntensity: 0.6, transparent: true, opacity: 1.0, depthWrite: false });
-            mStrHitOutline = activePalette.map(c => new T.MeshLambertMaterial({
+            const _outlineColors = [0xFF5552, 0xFFF352, 0x31CAFF, 0xFFAE31, 0x84FF42, 0xE639FF];
+            const _outlinePalette = activePalette.map((c, i) => _outlineColors[i] ?? c);
+            mStrHitOutline = _outlinePalette.map(c => new T.MeshLambertMaterial({
                 color: c, emissive: c, emissiveIntensity: 1.0,
                 transparent: true, opacity: 1.0, depthWrite: false,
             }));
@@ -4608,14 +4726,14 @@
             });
             pSusRail = pool(noteG, () => {
                 const m = new T.Mesh(gSusRail, mSusRailBase.clone());
-                m.renderOrder = 11;
+                m.renderOrder = 5; // below strings (7) so strings render on top
                 return m;
             });
 
             // Bloom glow for chord sustain rails — wider plane with a gaussian
             // falloff texture (bright centre → transparent edges in X direction)
             // and additive blending, so it brightens whatever is behind it.
-            // renderOrder 10 places it behind the core rail (11).
+            // renderOrder 4 places it behind the core rail (5).
             _bloomGaussTex = _makeGaussTex(T);
             gSusRailBloom = new T.PlaneGeometry(1, 1);
             gSusRailBloom.rotateX(-Math.PI / 2);
@@ -4629,7 +4747,7 @@
             });
             pSusRailBloom = pool(noteG, () => {
                 const m = new T.Mesh(gSusRailBloom, mSusRailBloomBase.clone());
-                m.renderOrder = 10;
+                m.renderOrder = 4; // below strings (7) so strings render on top
                 return m;
             });
 
@@ -4645,6 +4763,67 @@
                 return m;
             });
 
+            // ── InstancedMesh temporaries ──────────────────────────────────────
+            _imM4    = new T.Matrix4();
+            _imPos   = new T.Vector3();
+            _imSca   = new T.Vector3();
+            _imQ     = new T.Quaternion();
+            _imAZ    = new T.Vector3(0, 0, 1);
+            _imColor = new T.Color();
+
+            // ── Shared ShaderMaterial templates ───────────────────────────────
+            // Vertex shader used by PM-X and FH-X on individual note gems.
+            // Three.js injects `USE_INSTANCING` + `instanceMatrix` attribute
+            // into the prefix when an InstancedMesh uses a ShaderMaterial.
+            const _imTechVert = [
+                'attribute float instanceAlpha;',
+                'varying float vAlpha;',
+                'varying vec2 vUv;',
+                'void main() {',
+                '    vUv = uv;',
+                '    vAlpha = instanceAlpha;',
+                '    vec4 pos = vec4(position, 1.0);',
+                '    #ifdef USE_INSTANCING',
+                '    pos = instanceMatrix * pos;',
+                '    #endif',
+                '    gl_Position = projectionMatrix * modelViewMatrix * pos;',
+                '}',
+            ].join('\n');
+            const _imTechFrag = [
+                'uniform sampler2D map;',
+                'varying float vAlpha;',
+                'varying vec2 vUv;',
+                'void main() {',
+                '    vec4 t = texture2D(map, vUv);',
+                '    if (t.a * vAlpha < 0.01) discard;',
+                '    gl_FragColor = vec4(t.rgb, t.a * vAlpha);',
+                '}',
+            ].join('\n');
+
+            // ── PM / FH tech marker InstancedMeshes ───────────────────────────
+            // Each IM gets a geometry clone so instanceAlpha is a separate buffer.
+            const _mkTechIM = (spriteMat, alphaArr) => {
+                const geo = gTechPlane.clone();
+                const alphaAttr = new T.InstancedBufferAttribute(alphaArr, 1);
+                alphaAttr.setUsage(T.DynamicDrawUsage);
+                geo.setAttribute('instanceAlpha', alphaAttr);
+                const mat = new T.ShaderMaterial({
+                    uniforms: { map: { value: spriteMat.map } },
+                    vertexShader: _imTechVert,
+                    fragmentShader: _imTechFrag,
+                    transparent: true, depthTest: false, depthWrite: false, side: T.DoubleSide,
+                });
+                const im = new T.InstancedMesh(geo, mat, IM_TECH_CAP);
+                im.instanceMatrix.setUsage(T.DynamicDrawUsage);
+                im.frustumCulled = false;
+                im.count = 0;
+                noteG.add(im);
+                return { im, geo, mat };
+            };
+            { const r = _mkTechIM(palmMuteXSpriteMat(),    _imPMTechAlphaArr);
+              imPMTech = r.im; _imGPMTech = r.geo; _imPMTechMat = r.mat; imPMTech.renderOrder = 702; }
+            { const r = _mkTechIM(fretHandMuteXSpriteMat(), _imFHTechAlphaArr);
+              imFHTech = r.im; _imGFHTech = r.geo; _imFHTechMat = r.mat; imFHTech.renderOrder = 700; }
 
             // Dynamic fret number labels (heat-coloured, updated each frame)
             pFretLbl = pool(lblG, () => new T.Sprite(txtMat('0', '#888', false, 'fretRow')));
@@ -4688,7 +4867,7 @@
             // Vertical fret dividers within active lane
             const gLaneDivider = new T.BoxGeometry(0.15 * K, 0.15 * K, 1);
             mLaneDivider = new T.MeshBasicMaterial({
-                color: 0xffffff, transparent: true, opacity: 0.08, fog: false, depthWrite: false,
+                color: 0x46DDE6, transparent: true, opacity: 1.00, fog: false, depthWrite: false,
             });
             mLaneDividerArp = new T.MeshBasicMaterial({
                 color: ARPEGGIO_RIM_BLUE_HEX,
@@ -4813,18 +4992,42 @@
                 gPMXFill.setAttribute('position', new T.BufferAttribute(pos, 3));
                 gPMXFill.setIndex(new T.BufferAttribute(idx, 1));
             }
-            pPMXFill = pool(noteG, () => new T.Mesh(
-                gPMXFill,
-                new T.MeshBasicMaterial({
-                    color: 0x000000,
-                    transparent: true,
-                    opacity: 1.0,
-                    depthWrite: false,
-                    depthTest: false,
-                    fog: false,
-                    side: T.DoubleSide,
-                }),
-            ));
+            // PM fill — InstancedMesh (black, varying alpha per chord).
+            {
+                const _imFillVert = [
+                    'attribute float instanceAlpha;',
+                    'varying float vAlpha;',
+                    'void main() {',
+                    '    vAlpha = instanceAlpha;',
+                    '    vec4 pos = vec4(position, 1.0);',
+                    '    #ifdef USE_INSTANCING',
+                    '    pos = instanceMatrix * pos;',
+                    '    #endif',
+                    '    gl_Position = projectionMatrix * modelViewMatrix * pos;',
+                    '}',
+                ].join('\n');
+                const _imFillFrag = [
+                    'varying float vAlpha;',
+                    'void main() {',
+                    '    if (vAlpha <= 0.0) discard;',
+                    '    gl_FragColor = vec4(0.0, 0.0, 0.0, vAlpha);',
+                    '}',
+                ].join('\n');
+                const alphaAttr = new T.InstancedBufferAttribute(_imPMXFillAlphaArr, 1);
+                alphaAttr.setUsage(T.DynamicDrawUsage);
+                gPMXFill.setAttribute('instanceAlpha', alphaAttr);
+                _imPMXFillMat = new T.ShaderMaterial({
+                    vertexShader: _imFillVert, fragmentShader: _imFillFrag,
+                    transparent: true, depthTest: false, depthWrite: false,
+                    fog: false, side: T.DoubleSide,
+                });
+                imPMXFill = new T.InstancedMesh(gPMXFill, _imPMXFillMat, IM_STRUM_CAP);
+                imPMXFill.instanceMatrix.setUsage(T.DynamicDrawUsage);
+                imPMXFill.frustumCulled = false;
+                imPMXFill.renderOrder = 10.5;
+                imPMXFill.count = 0;
+                noteG.add(imPMXFill);
+            }
 
             // FH (frethand mute) strum X fill — 5 regions: 4 corner quadrants + centre diamond.
             // 12 vertices, 10 triangles. L/R wings stop at fx=±0.50 (no solid lateral blocks).
@@ -4869,18 +5072,42 @@
                 gFHXFill.setAttribute('position', new T.BufferAttribute(pos, 3));
                 gFHXFill.setIndex(new T.BufferAttribute(idx, 1));
             }
-            pFHXFill = pool(noteG, () => new T.Mesh(
-                gFHXFill,
-                new T.MeshBasicMaterial({
-                    color: 0x000000,
-                    transparent: true,
-                    opacity: 1.0,
-                    depthWrite: false,
-                    depthTest: false,
-                    fog: false,
-                    side: T.DoubleSide,
-                }),
-            ));
+            // FH fill — InstancedMesh (black, varying alpha per chord).
+            {
+                const _imFillVert = [
+                    'attribute float instanceAlpha;',
+                    'varying float vAlpha;',
+                    'void main() {',
+                    '    vAlpha = instanceAlpha;',
+                    '    vec4 pos = vec4(position, 1.0);',
+                    '    #ifdef USE_INSTANCING',
+                    '    pos = instanceMatrix * pos;',
+                    '    #endif',
+                    '    gl_Position = projectionMatrix * modelViewMatrix * pos;',
+                    '}',
+                ].join('\n');
+                const _imFillFrag = [
+                    'varying float vAlpha;',
+                    'void main() {',
+                    '    if (vAlpha <= 0.0) discard;',
+                    '    gl_FragColor = vec4(0.0, 0.0, 0.0, vAlpha);',
+                    '}',
+                ].join('\n');
+                const alphaAttr = new T.InstancedBufferAttribute(_imFHXFillAlphaArr, 1);
+                alphaAttr.setUsage(T.DynamicDrawUsage);
+                gFHXFill.setAttribute('instanceAlpha', alphaAttr);
+                _imFHXFillMat = new T.ShaderMaterial({
+                    vertexShader: _imFillVert, fragmentShader: _imFillFrag,
+                    transparent: true, depthTest: false, depthWrite: false,
+                    fog: false, side: T.DoubleSide,
+                });
+                imFHXFill = new T.InstancedMesh(gFHXFill, _imFHXFillMat, IM_STRUM_CAP);
+                imFHXFill.instanceMatrix.setUsage(T.DynamicDrawUsage);
+                imFHXFill.frustumCulled = false;
+                imFHXFill.renderOrder = 10.5;
+                imFHXFill.count = 0;
+                noteG.add(imFHXFill);
+            }
 
             // PM X lines — 8 segments baked as thin quads in ±1 normalised space.
             // Scale the pool mesh by (innerW*0.5, -innerH*0.5, ...) per chord;
@@ -4917,18 +5144,56 @@
                 gPMXLines.setAttribute('position', new T.BufferAttribute(pos, 3));
                 gPMXLines.setIndex(new T.BufferAttribute(idx, 1));
             }
-            pMuteXLines = pool(noteG, () => new T.Mesh(
-                gPMXLines,
-                new T.MeshBasicMaterial({
-                    color: 0xffffff,
-                    transparent: true,
-                    opacity: 1.0,
-                    depthWrite: false,
-                    depthTest: false,
-                    fog: false,
-                    side: T.DoubleSide,
-                }),
-            ));
+            // PM lines — InstancedMesh (varying color + alpha per chord).
+            // instanceColor (THREE built-in) carries baseRimHex per instance;
+            // instanceAlpha carries the per-chord opacity.
+            {
+                const _imLinesVert = [
+                    'attribute float instanceAlpha;',
+                    'varying float vAlpha;',
+                    'varying vec3 vColor;',
+                    'void main() {',
+                    '    vAlpha = instanceAlpha;',
+                    '    #ifdef USE_INSTANCING_COLOR',
+                    '    vColor = instanceColor;',
+                    '    #else',
+                    '    vColor = vec3(1.0);',
+                    '    #endif',
+                    '    vec4 pos = vec4(position, 1.0);',
+                    '    #ifdef USE_INSTANCING',
+                    '    pos = instanceMatrix * pos;',
+                    '    #endif',
+                    '    gl_Position = projectionMatrix * modelViewMatrix * pos;',
+                    '}',
+                ].join('\n');
+                const _imLinesFrag = [
+                    'varying float vAlpha;',
+                    'varying vec3 vColor;',
+                    'void main() {',
+                    '    if (vAlpha <= 0.0) discard;',
+                    '    gl_FragColor = vec4(vColor, vAlpha);',
+                    '}',
+                ].join('\n');
+                const alphaAttr = new T.InstancedBufferAttribute(_imPMXLinesAlphaArr, 1);
+                alphaAttr.setUsage(T.DynamicDrawUsage);
+                gPMXLines.setAttribute('instanceAlpha', alphaAttr);
+                _imPMXLinesMat = new T.ShaderMaterial({
+                    vertexShader: _imLinesVert, fragmentShader: _imLinesFrag,
+                    transparent: true, depthTest: false, depthWrite: false,
+                    fog: false, side: T.DoubleSide,
+                });
+                imPMXLines = new T.InstancedMesh(gPMXLines, _imPMXLinesMat, IM_STRUM_CAP);
+                imPMXLines.instanceMatrix.setUsage(T.DynamicDrawUsage);
+                imPMXLines.frustumCulled = false;
+                imPMXLines.renderOrder = 11;
+                // Eagerly initialise instanceColor so USE_INSTANCING_COLOR is
+                // defined when the shader is compiled on the first draw.
+                _imColor.set(1, 1, 1);
+                imPMXLines.setColorAt(0, _imColor);
+                imPMXLines.instanceColor.setUsage(T.DynamicDrawUsage);
+                imPMXLines.count = 0;
+                noteG.add(imPMXLines);
+            }
 
             // FH X lines — same scheme, 8 segments from the FH_XLINES pattern
             if (!gFHXLines) {
@@ -4963,16 +5228,84 @@
                 gFHXLines.setAttribute('position', new T.BufferAttribute(pos, 3));
                 gFHXLines.setIndex(new T.BufferAttribute(idx, 1));
             }
+            // FH lines — InstancedMesh (varying color + alpha per chord).
+            {
+                const _imLinesVert = [
+                    'attribute float instanceAlpha;',
+                    'varying float vAlpha;',
+                    'varying vec3 vColor;',
+                    'void main() {',
+                    '    vAlpha = instanceAlpha;',
+                    '    #ifdef USE_INSTANCING_COLOR',
+                    '    vColor = instanceColor;',
+                    '    #else',
+                    '    vColor = vec3(1.0);',
+                    '    #endif',
+                    '    vec4 pos = vec4(position, 1.0);',
+                    '    #ifdef USE_INSTANCING',
+                    '    pos = instanceMatrix * pos;',
+                    '    #endif',
+                    '    gl_Position = projectionMatrix * modelViewMatrix * pos;',
+                    '}',
+                ].join('\n');
+                const _imLinesFrag = [
+                    'varying float vAlpha;',
+                    'varying vec3 vColor;',
+                    'void main() {',
+                    '    if (vAlpha <= 0.0) discard;',
+                    '    gl_FragColor = vec4(vColor, vAlpha);',
+                    '}',
+                ].join('\n');
+                const alphaAttr = new T.InstancedBufferAttribute(_imFHXLinesAlphaArr, 1);
+                alphaAttr.setUsage(T.DynamicDrawUsage);
+                gFHXLines.setAttribute('instanceAlpha', alphaAttr);
+                _imFHXLinesMat = new T.ShaderMaterial({
+                    vertexShader: _imLinesVert, fragmentShader: _imLinesFrag,
+                    transparent: true, depthTest: false, depthWrite: false,
+                    fog: false, side: T.DoubleSide,
+                });
+                imFHXLines = new T.InstancedMesh(gFHXLines, _imFHXLinesMat, IM_STRUM_CAP);
+                imFHXLines.instanceMatrix.setUsage(T.DynamicDrawUsage);
+                imFHXLines.frustumCulled = false;
+                imFHXLines.renderOrder = 11;
+                _imColor.set(1, 1, 1);
+                imFHXLines.setColorAt(0, _imColor);
+                imFHXLines.instanceColor.setUsage(T.DynamicDrawUsage);
+                imFHXLines.count = 0;
+                noteG.add(imFHXLines);
+            }
+
+            // Pool-based strum-indicator replacements.  The IM approach above uses
+            // a fixed renderOrder per mesh type, which lets far-chord X marks overdraw
+            // gems/frames of nearer chords.  Pools give per-chord Z-proportional RO.
+            // Geometries are shared with the (now empty) IMs — MeshBasicMaterial
+            // ignores the instanceAlpha / instanceColor attributes on the geometry.
+            pPMXFill = pool(noteG, () => new T.Mesh(
+                gPMXFill,
+                new T.MeshBasicMaterial({
+                    color: 0x000000, transparent: true, opacity: 1,
+                    depthWrite: false, depthTest: false, fog: false, side: T.DoubleSide,
+                }),
+            ));
+            pFHXFill = pool(noteG, () => new T.Mesh(
+                gFHXFill,
+                new T.MeshBasicMaterial({
+                    color: 0x000000, transparent: true, opacity: 1,
+                    depthWrite: false, depthTest: false, fog: false, side: T.DoubleSide,
+                }),
+            ));
+            pMuteXLines = pool(noteG, () => new T.Mesh(
+                gPMXLines,
+                new T.MeshBasicMaterial({
+                    color: 0xffffff, transparent: true, opacity: 1,
+                    depthWrite: false, depthTest: false, fog: false, side: T.DoubleSide,
+                }),
+            ));
             pFHXLines = pool(noteG, () => new T.Mesh(
                 gFHXLines,
                 new T.MeshBasicMaterial({
-                    color: 0xffffff,
-                    transparent: true,
-                    opacity: 1.0,
-                    depthWrite: false,
-                    depthTest: false,
-                    fog: false,
-                    side: T.DoubleSide,
+                    color: 0xffffff, transparent: true, opacity: 1,
+                    depthWrite: false, depthTest: false, fog: false, side: T.DoubleSide,
                 }),
             ));
 
@@ -5002,13 +5335,13 @@
             // Per-note fret number below note with connector line
             pNoteFretLabel = pool(lblG, () => {
                 const _nfl = new T.Sprite(txtMat('0', FRET_LABEL_GOLD_HEX, false, 'noteFret').clone());
-                // fog=false: same as pFretColMarker — opacity fade-in handles appearance.
                 _nfl.material.fog = false;
+                _nfl.material.depthTest = false;
                 return _nfl;
             });
             pConnectorLine = pool(noteG, () => new T.Line(
                 new T.BufferGeometry().setFromPoints([new T.Vector3(0, 0, 0), new T.Vector3(0, 1, 0)]),
-                new T.LineBasicMaterial({ color: 0xaaaaaa, transparent: true, opacity: 0.5 }),
+                new T.LineBasicMaterial({ color: 0xaaaaaa, transparent: true, opacity: 0.5, depthTest: false }),
             ));
             pDropLine = pool(noteG, () => new T.Line(
                 new T.BufferGeometry().setFromPoints([new T.Vector3(0, 0, 0), new T.Vector3(0, 1, 0)]),
@@ -5070,10 +5403,6 @@
             pBarreLine.warm(_WARM_CHORD);
             pArpBracket.warm(_WARM_CHORD);
             pHaloBar.warm(_WARM_CHORD);
-            pPMXFill.warm(_WARM_CHORD);
-            pFHXFill.warm(_WARM_CHORD);
-            pMuteXLines.warm(_WARM_CHORD);
-            pFHXLines.warm(_WARM_CHORD);
             pFretLbl.warm(_WARM_LANE);
             pLane.warm(_WARM_LANE * 2);  // anchor-driven lanes × time slices
             pLaneDivider.warm(_WARM_LANE);
@@ -5424,7 +5753,14 @@
         function _applyPaletteToMaterials() {
             for (let s = 0; s < activePalette.length; s++) {
                 const c = activePalette[s];
-                if (mStr[s]) { mStr[s].color.setHex(c); mStr[s].emissive.setHex(c); }
+                if (mStr[s]) {
+                    // Gradient strings (0..5) keep a white base so the per-vertex
+                    // colours in gNoteGrad[s] show pure; only flat strings (6/7)
+                    // take the palette colour. mStr is MeshBasicMaterial (no
+                    // emissive) — guard the legacy emissive retint.
+                    if (s >= 6) mStr[s].color.setHex(c);
+                    if (mStr[s].emissive) mStr[s].emissive.setHex(c);
+                }
                 if (mGlow[s]) mGlow[s].emissive.setHex(c);
                 if (mSus[s]) mSus[s].color.setHex(c);
                 if (mStrHitOutline[s]) {
@@ -5642,6 +5978,8 @@
             }
             stringLines = [];
             stringLineGlows = [];
+            for (const m of fretWireMats) m?.dispose?.();
+            fretWireMats = [];
 
             const board = boardSpanX();
             const bw = board.width + 4 * K;
@@ -5679,7 +6017,7 @@
                 const pts = [new T.Vector3(boardStringStartX, sY(s), 0), new T.Vector3(stringEndX, sY(s), 0)];
                 const g = new T.BufferGeometry().setFromPoints(pts);
                 const line = new T.Line(g, new T.LineBasicMaterial({ color: activePalette[s], transparent: true, opacity: lineGlowOp }));
-                line.renderOrder = 7; // below sus rails (10/11), below chord fill (10)
+                line.renderOrder = 7; // above sus rails (4/5), below chord fill (10)
                 fretG.add(line);
                 stringLineGlows.push(line);
             }
@@ -5695,7 +6033,7 @@
                     transparent: true, opacity: _vibrancyIdleOp, roughness: 1,
                 });
                 const mesh = new T.Mesh(g, mat);
-                mesh.renderOrder = 7; // below sus rails (10/11), below chord fill (10)
+                mesh.renderOrder = 703; // above chord frames ([48,698]) and note gems ([50,700]); below technique labels (1000)
                 mesh.position.set(boardStringStartX + strSpan * 0.5, sY(s), 0);
                 fretG.add(mesh);
                 stringLines.push(mesh);
@@ -5825,29 +6163,45 @@
                 fretG.add(nutHeadstockGroup);
             }
 
-            // Fret wires
+            // Fret wires — BoxGeometry bars matching string thickness (STR_THICK)
+            // renderOrder 704: above string mesh (703) so fret wires draw on top
+            // of the strings, matching a real guitar where metal fret bars sit
+            // above the strings on the neck.
+            // BoxGeometry (not T.Line): WebGL ignores linewidth > 1px on almost all
+            // platforms, so Line objects always render as hairlines.  Using the same
+            // STR_THICK × STR_THICK cross-section as the string BoxGeometry gives the
+            // wires a visible, matching thickness.
+            // depthTest: false: required because string BoxGeometry (MeshStandard,
+            // depthWrite:true) writes depth at Z=+STR_THICK/2; wires at Z=0 would
+            // fail the depth test at string pixels despite higher renderOrder.
+            // Colors are updated each frame by the fretWireMats loop in update():
+            //   default  → gray  0x666688, opacity 0.4
+            //   in-anchor→ gold  0xD8A636, opacity 0.8  (same as FRET_LABEL_GOLD_HEX)
             const yTop = Math.max(sY(0), sY(nStr - 1));
             const yBottom = Math.min(sY(0), sY(nStr - 1));
+            const wireH = (yTop + S_GAP * 0.3) - (yBottom - S_GAP * 0.3);
+            const wireMidY = (yTop + yBottom) / 2;
             for (let f = 0; f <= NFRETS; f++) {
                 const x = xFret(f);
-                const isMain = DOTS.includes(f);
-                const g = new T.BufferGeometry().setFromPoints([
-                    new T.Vector3(x, yBottom - S_GAP * 0.3, 0),
-                    new T.Vector3(x, yTop + S_GAP * 0.3, 0),
-                ]);
-                fretG.add(new T.Line(g, new T.LineBasicMaterial({
-                    color: isMain ? 0xbbbbff : 0x666688,
-                    transparent: true,
-                    opacity: isMain ? 0.8 : 0.4,
-                })));
+                const g = new T.BoxGeometry(STR_THICK, wireH, STR_THICK);
+                const mat = new T.MeshBasicMaterial({
+                    color: 0x666688, transparent: true, opacity: 0.4,
+                    depthTest: false,
+                });
+                const fw = new T.Mesh(g, mat);
+                fw.position.set(x, wireMidY, 0);
+                fw.renderOrder = 704;
+                fretG.add(fw);
+                fretWireMats[f] = mat;
             }
 
-            // Fret dots — translucent + depthWrite:false so spheres don't steal the
-            // depth buffer from the transparent string meshes (which would clip the
-            // strings where geometry overlaps). Slight negative Z recessed under the
+            // Fret dots — flat circles (CircleGeometry) lying in the XY plane and
+            // facing +Z so they always appear as perfect circles from the camera.
+            // depthWrite:false so they don't steal the depth buffer from the
+            // transparent string meshes. Slight negative Z recessed under the
             // string plane. Radius 10% below the former 1.5*K dots.
             const dotRZ = (1.5 * K * 0.9);
-            const dg = new T.SphereGeometry(dotRZ, 8, 6);
+            const dg = new T.CircleGeometry(dotRZ, 64);
             const dm = new T.MeshBasicMaterial({
                 color: 0x556677,
                 transparent: true,
@@ -6836,9 +7190,94 @@
             return ftSide / (0.15 * K);
         }
 
+        /* ── Fret-label measure-skip rule ───────────────────────────────── */
+        // For each (note_time, fret) pair across standalone notes and chord
+        // notes, determine which ones are allowed to display their fret
+        // indicator number. Rule: per fret (regardless of string), show the
+        // number only on the first note in a given measure; suppress it for
+        // the immediately following measure; then allow it again (current
+        // measure + 2).
+        // Key scheme: Math.round(t * 25) * 100 + fret  (40 ms time buckets).
+        // Using a coarse time-bucket (not exact time) ensures that a synthetic
+        // chord template whose .t differs from the corresponding standalone
+        // arpeggio note by a few ms still resolves to the same key.
+        // Only standalone notes (notesArr) populate the set; regular chord notes
+        // never show labels, and synthetic chord notes share frets/onsets with
+        // their arpeggio counterparts, so the same keys are found at lookup time.
+        // Returns a Set of numeric keys (Math.round(t*25)*100 + fret).
+        function _buildFretLabelSet(notesArr, _chordsArr, beatsArr) {
+            const events = [];
+            if (notesArr) {
+                for (let _i = 0; _i < notesArr.length; _i++) {
+                    const _n = notesArr[_i];
+                    if (_n.f > 0) events.push({ t: _n.t, f: _n.f });
+                }
+            }
+            // Chord events intentionally excluded: regular chord notes don't show
+            // fret labels; synthetic chord notes share frets with arpeggio note-stream
+            // notes already captured above, so no separate chord processing needed.
+            events.sort((a, b) => a.t - b.t);
+            const beats = beatsArr || [];
+            let beatIdx = 0;
+            let currentMeasure = 0;
+            const nextShowMeasure = new Map(); // fret → next measure where label is allowed
+            const allowed = new Set();
+            for (let _ei = 0; _ei < events.length; _ei++) {
+                const { t, f } = events[_ei];
+                // Advance beats pointer: find the current measure for time t.
+                while (beatIdx < beats.length && beats[beatIdx].time <= t + 1e-4) {
+                    if (beats[beatIdx].measure >= 0) currentMeasure = beats[beatIdx].measure;
+                    beatIdx++;
+                }
+                const nextM = nextShowMeasure.get(f) ?? 0;
+                if (currentMeasure >= nextM) {
+                    // Time-bucket key: 40 ms groups absorb timing jitter while
+                    // still distinguishing notes at different positions in the measure.
+                    allowed.add(Math.round(t * 25) * 100 + f);
+                    // Suppress this fret for the next measure; re-allow at +2.
+                    nextShowMeasure.set(f, currentMeasure + 2);
+                }
+            }
+            return allowed;
+        }
+
+        // Smoothed playback clock for this frame. Called once per frame at the
+        // top of update(); camUpdate() reads the stored _frameNow afterward so
+        // notes and camera share one clock. See the _clk* state block above.
+        function smoothNow(bundle) {
+            const raw = bundle.currentTime;
+            const p = performance.now();
+            if (raw !== _clkAudioT) {
+                // New audio sample — re-anchor and refine the rate estimate.
+                if (!Number.isNaN(_clkPerf)) {
+                    const dP = (p - _clkPerf) / 1000;
+                    if (dP > 0.001 && dP < 0.5) {
+                        const r = (raw - _clkAudioT) / dP;
+                        _clkRate = (r > 0.05 && r < 5) ? r : 1; // seek/loop → reset
+                    } else if (dP >= 0.5) {
+                        _clkRate = 1; // long gap (paused / tab inactive)
+                    }
+                }
+                _clkAudioT = raw;
+                _clkPerf = p;
+                return (_frameNow = raw);
+            }
+            // Same audio sample as last call — interpolate forward, capped so a
+            // stalled main thread or paused audio can't run the clock away.
+            const dt = (p - _clkPerf) / 1000;
+            if (dt <= 0 || dt > 0.1) return (_frameNow = raw);
+            return (_frameNow = _clkAudioT + _clkRate * dt);
+        }
+
         /* ── Per-frame rendering ─────────────────────────────────────────── */
         function update(bundle) {
             pbBeg(0);
+            // Lean sustain rendering is the default (see declaration above);
+            // the full-quality outline+bloom look is an opt-out. Cheap
+            // per-frame read so the console flag takes effect live.
+            try {
+                _leanSus = localStorage.getItem('h3d_full_sus') !== '1';
+            } catch (_) { _leanSus = true; }
             // Materialize the text-size multiplier from the user's slider.
             // textSize ∈ [0,1]; _textSizeMul ∈ [0.5, 1.5] with 0.5 ↦ 1.0×
             // so default behaviour matches what the renderer did pre-slider.
@@ -6862,7 +7301,13 @@
             if (projMeshArr) for (const m of projMeshArr) m.visible = false;
             pFretLbl.reset(); pLane.reset(); pLaneDivider.reset();
             if (pGhostFretLbl) pGhostFretLbl.reset();
-            pChordBox.reset(); pChordFrameFill.reset(); pChordLbl.reset(); pBarreLine.reset(); pArpBracket.reset(); pHaloBar.reset(); pPMXFill.reset(); pFHXFill.reset(); pMuteXLines.reset(); pFHXLines.reset();
+            pChordBox.reset(); pChordFrameFill.reset(); pChordLbl.reset(); pBarreLine.reset(); pArpBracket.reset(); pHaloBar.reset();
+            _imPMTechCount = _imFHTechCount = 0;
+            _imPMXFillCount = _imPMXLinesCount = _imFHXFillCount = _imFHXLinesCount = 0;
+            if (pPMXFill) pPMXFill.reset();
+            if (pFHXFill) pFHXFill.reset();
+            if (pMuteXLines) pMuteXLines.reset();
+            if (pFHXLines) pFHXLines.reset();
             pNoteFretLabel.reset(); pConnectorLine.reset(); pDropLine.reset();
             pFretColMarker.reset(); pSusRail.reset(); pSusRailBloom.reset(); pTechPlane.reset();
             // Clear per-frame queues in-place (avoid reallocating the array object).
@@ -6905,7 +7350,7 @@
                 ? bundle.getNoteStateProvider() != null
                 : !!_ndGetNoteState;
 
-            const now = bundle.currentTime;
+            const now = smoothNow(bundle);
             const t0 = now - BEHIND;
             const t1 = now + AHEAD;
             // With a verdict provider attached, keep notes and chord frames
@@ -7060,7 +7505,7 @@
                         for (let j = lo; j < notes.length; j++) {
                             const q = notes[j];
                             if (q.t > endT + EPS) break;
-                            if (q.s !== srcS || Math.abs(q.t - endT) >= EPS) continue;
+                            if (q.s !== srcS || q.t <= srcT || Math.abs(q.t - endT) >= EPS) continue;
                             const qSl = (Number.isFinite(q.sl) && q.sl >= 0) ? q.sl
                                       : (Number.isFinite(q.slu) && q.slu >= 0) ? q.slu : -1;
                             if (srcSl >= 0 && q.f === srcSl) { stSet.add(_noteKey(q.t, q.s)); break; } // case 1
@@ -7133,8 +7578,39 @@
                 laneRailBoundHi = _arpRailBoundHiScratch;
             }
             const beats = bundle.beats;
+            // Rebuild the fret-label visibility set whenever the chart changes.
+            if (notes !== _fretLabelNotesRef) {
+                _fretLabelAllowed = _buildFretLabelSet(notes, chords, beats);
+                _fretLabelNotesRef = notes;
+            }
             const sections = bundle.sections;
             const anchors = bundle.anchors;
+
+            // ── Fret wire anchor highlight ─────────────────────────────────
+            // Default all wires to gray; wires inside the active anchor range
+            // turn gold to match the dynamic highway lane boundary exactly.
+            // Uses laneBoundsFromAnchor() — the same helper the lane uses —
+            // so the gold fret wires on the board align with the lane edges:
+            //   dMin = fret - 1,  dMax = fret + width - 1
+            // e.g. { fret:3, width:4 } → dMin=2, dMax=6 → wires 2,3,4,5,6 gold.
+            if (fretWireMats.length) {
+                const _fwBounds = anchors && anchors.length
+                    ? anchorLaneBoundsAt(anchors, now) : null;
+                const _fwMin = _fwBounds ? _fwBounds.dMin : -1;
+                const _fwMax = _fwBounds ? _fwBounds.dMax : -1;
+                for (let _f = 0; _f <= NFRETS; _f++) {
+                    const _m = fretWireMats[_f];
+                    if (!_m) continue;
+                    if (_fwMin >= 0 && _f >= _fwMin && _f <= _fwMax) {
+                        _m.color.setHex(0xD8A636);
+                        _m.opacity = 0.8;
+                    } else {
+                        _m.color.setHex(0x666688);
+                        _m.opacity = 0.4;
+                    }
+                }
+            }
+
             const lookaheadBoundsNow = (cameraMode === 'lookahead')
                 ? lookaheadComputeFretBounds(now, anchors, notes, chords)
                 : null;
@@ -7558,6 +8034,10 @@
                     _lookaheadCamPrevNow = null;
                     _lookaheadLowBonusU = 0;
                     _lookaheadHiNeckLatch = false;
+                    // Drop the clock anchor so the new song's currentTime
+                    // re-anchors cleanly instead of measuring a bogus rate
+                    // across the seek-to-0 discontinuity.
+                    _clkAudioT = NaN; _clkPerf = NaN; _clkRate = 1;
                 }
             }
 
@@ -7671,6 +8151,9 @@
 
             pbBeg(4);
             // ── Single notes ──────────────────────────────────────────────
+            // Reset the per-frame fret-label dedup set so stacked labels from
+            // multiple strings at the same onset/fret (arpeggio, synth chord) don't repeat.
+            _frameLabeledKeys.clear();
             // Tracks which (chordId → Set<stringIndex>) pairs already had
             // brackets drawn by the note-stream loop, so the chord loop can
             // skip duplicate bracket draws for the same string.
@@ -7745,6 +8228,7 @@
                         arGhostCid != null,
                         _arpBoundsForNote,
                         _ghostPrevBuf.get(Math.round(n.t * 1e4) * 10 + n.s) ?? -Infinity,
+                        _arpBoundsForNote !== null, // showDropLine: white line for arp note-stream notes
                     );
                     if (arGhostCid != null) {
                         const _arpBounds = _arpBoundsForNote;
@@ -8105,17 +8589,12 @@
                     let chordTailHoldS = CHORD_HWY_LINGER_S;
                     let chordNextSoon = false;
                     if (cjNext && cjNext.t > ch.t + 1e-6) {
-                        const nextSig = chordShapeSignature(cjNext);
-                        const sameVoicingNext = runSig !== null && nextSig !== null && nextSig === runSig;
-                        if (sameVoicingNext) {
-                            const chordFadeWinLo = ch.t + (CHORD_HWY_LINGER_S - CHORD_HWY_FADE_S);
-                            const chordFadeWinHi = ch.t + CHORD_HWY_LINGER_S;
-                            if (cjNext.t >= chordFadeWinLo - 1e-6 && cjNext.t <= chordFadeWinHi + 1e-6) {
-                                chordNextSoon = true;
-                            }
-                        } else {
-                            chordTailHoldS = Math.min(CHORD_HWY_LINGER_S, Math.max(cjNext.t - ch.t, 1e-3));
-                        }
+                        // Clip the hold tail to the gap for both same-voicing (repeat)
+                        // and different-voicing chords. The chordTailMul instant-cut
+                        // check handles the precise zero at onset; the clipped holdS
+                        // prevents the outer gate and hwyPostHitTailFadeMul from
+                        // lingering past that point.
+                        chordTailHoldS = Math.min(CHORD_HWY_LINGER_S, Math.max(cjNext.t - ch.t, 1e-3));
                     }
                     // slopsmith#254 — engine verdicts land ~0.4 s after the
                     // chord crosses; on a fast different-voicing sequence
@@ -8224,6 +8703,30 @@
                     // suppressSynthChord: skip gems + frame but still call drawNote with
                     // skipBody=true so the board projection (fret ghost on fretboard) renders
                     // for all shape strings — shows the hand position like a chord would.
+                    // chordLinksSlide: true when any chord note has a direct sl/slu marker,
+                    // OR when the chord's sustain connects (via case-2 linkNext) to a note
+                    // in bundle.notes that has a slide.  Repeated chords matching either
+                    // condition are treated as normal chords so the player sees the gem.
+                    let chordLinksSlide = chordNotes.some(cn =>
+                        (Number.isFinite(cn.sl) && cn.sl >= 0) ||
+                        (Number.isFinite(cn.slu) && cn.slu >= 0));
+                    if (!chordLinksSlide && isRepeat && maxSus > 0 && notes) {
+                        const _EPS = NEXT_ON_STRING_T_EPS;
+                        outer: for (const cn of chordNotes) {
+                            if (!(cn.sus > 0)) continue;
+                            const _endT = ch.t + cn.sus;
+                            let _ji = lowerBoundT(notes, _endT - _EPS);
+                            for (; _ji < notes.length; _ji++) {
+                                const _q = notes[_ji];
+                                if (_q.t > _endT + _EPS) break;
+                                if (_q.s !== cn.s || Math.abs(_q.t - _endT) >= _EPS) continue;
+                                if ((Number.isFinite(_q.sl) && _q.sl >= 0) ||
+                                    (Number.isFinite(_q.slu) && _q.slu >= 0)) {
+                                    chordLinksSlide = true; break outer;
+                                }
+                            }
+                        }
+                    }
                     if (!deferChordGems || _deferFallback || suppressSynthChord) {
                         for (const cn of chordNotes) {
                             // Suppress non-first gems while an authored arpeggio frame
@@ -8254,7 +8757,7 @@
                                 now,
                                 cn.f === 0 ? chordCX : undefined,
                                 skipLabel,
-                                isRepeat || suppressSynthChord,
+                                (isRepeat && !chordLinksSlide) || suppressSynthChord,
                                 chordTailHoldS,
                                 cn.f === 0 ? laneWForOpenStrings : undefined,
                                 true,
@@ -8262,6 +8765,7 @@
                                 chordSusTrailMatchArpFrame,
                                 null,
                                 _ghostPrevBuf.get(Math.round(ch.t * 1e4) * 10 + cn.s) ?? -Infinity,
+                                chordHighwayLavenderArpVisual || suppressSynthChord || chordWireHighDensity(ch),
                             );
                             lastFretForString[cn.s] = cn.f;
                             // gate by THIS note's own sustain against the
@@ -8342,12 +8846,11 @@
                     // Chord frame-box: rim bars + interior fill gradient.
                     const chDt = chDtEarly; // already computed above for anchor selection
                     const chordTailMul = (() => {
-                        // When any next event (chord OR single note) exists, fade this
-                        // frame over exactly the gap so it reaches 0 the moment the
-                        // next event crosses the hit line — no hold, no linger overlap.
-                        if (chDt < 0 && _chNextEventT < Infinity) {
-                            const gapS = Math.max(1e-3, _chNextEventT - ch.t);
-                            return Math.max(0, 1 - (-chDt) / gapS);
+                        // When a next event (chord OR single note) has already crossed
+                        // the hit line, hide this frame immediately — no fadeout overlap
+                        // when another event is already playing.
+                        if (chDt < 0 && _chNextEventT < Infinity && now >= _chNextEventT) {
+                            return 0;
                         }
                         return hwyPostHitTailFadeMul(chDt, chordTailHoldS, chordNextSoon, chordTailFadeS);
                     })();
@@ -8530,23 +9033,34 @@
                             }
                         }
 
+                        if (chDt > 0) { // framebox only on highway, not on the fretboard
                         const repDim = isRepeat ? 0.78 : 1;
-                        const edgeOp = fade * repDim * CHORD_BOX_EDGE_ALPHA * (isRepeat ? 0.85 : 1) * chordTailMul;
+                        const edgeOp = fade * chordTailMul;
                         const thickZ = Math.max(CHORD_FRAME_RIM_Z_MIN * K, ft * CHORD_FRAME_RIM_Z_SCAL);
-                        const drawFrameBox = (px, py, sx, sy, ord) => {
+                        // Per-chord renderOrder: mirrors the note-gem Z-based scale
+                        // (_noteRO = max(50, round(700 + z/K))) minus 2, so frame edges
+                        // always render just below their own chord's gems while still
+                        // drawing above gems from further-away chords.  The old [20,21]
+                        // range sat below all note gems (50+), letting distant-chord gems
+                        // overdraw near-chord frame edges regardless of Z depth.
+                        // Sub-increments of 0.0001 for intra-chord ordering; safe for any
+                        // chord gap ≥ 0.001 s.
+                        const chordBaseRO = Math.max(48, Math.round(700 + z / K) - 2);
+                        const drawFrameBox = (px, py, sx, sy, ord, hex = rimHex, op = edgeOp) => {
                             const b = pChordBox.get();
                             b.renderOrder = ord;
-                            b.material.color.setHex(rimHex);
+                            b.material.color.setHex(hex);
                             b.position.set(px, py, z);
                             b.scale.set(sx, sy, thickZ);
                             b.rotation.set(0, 0, 0);
-                            b.material.opacity = edgeOp;
+                            b.material.opacity = op;
                         };
+                        const sideHex = isArpeggioFrame ? rimHex : 0x163137;
 
                         const innerW = Math.max(width - 2 * ftSide, width * 0.45);
                         const innerH = Math.max(height - 2 * ft, height * 0.3);
                         const fill = pChordFrameFill.get();
-                        fill.renderOrder = 10;
+                        fill.renderOrder = chordBaseRO - 4;
                         fill.rotation.set(0, 0, 0);
                         fill.position.set(cx, cY, z - 0.004 * K);
                         fill.scale.set(innerW, innerH, 1);
@@ -8557,8 +9071,7 @@
                         fill.material.map = isArpeggioFrame ? chordFrameGradTexArp : chordFrameGradTex;
                         fill.material.color.setRGB(1, 1, 1);
 
-                        // renderOrder 17/18 — above sustain trails (12/13) and rails (10/11), below note gems (50-700)
-                        drawFrameBox(cx, yBot + ft * 0.5, width, ft, 17);
+                        // renderOrder 20/21 — below sustain trails (22/23) and note gems (50+), above chord fill (10)
                         const withTopFrame = !isRepeat;
                         // Non-repeat tapers the upper side bars + draws a thin top bar;
                         // hoisted out so ySideHi can match the actual top-bar thickness
@@ -8571,9 +9084,25 @@
                         const sideH = Math.max(ySideHi - ySideLo, ft * 1.25);
                         const sideCy = ySideLo + sideH * 0.5;
 
+                        // Bottom bar: thin teal (like top bar) + dark corners on top.
+                        {
+                            const botCW = Math.min(sideH * (isRepeat ? 0.5 : 0.25), width * 0.4);
+                            drawFrameBox(cx, yBot + ftThin * 0.5, width, ftThin, chordBaseRO);
+                            drawFrameBox(cx + width * 0.5 - botCW * 0.5, yBot + ft * 0.5, botCW, ft, chordBaseRO + 0.0001, sideHex);
+                            drawFrameBox(cx - width * 0.5 + botCW * 0.5, yBot + ft * 0.5, botCW, ft, chordBaseRO + 0.0002, sideHex);
+                        }
+
                         if (isRepeat) {
-                            drawFrameBox(cx - width * 0.5 + ftSide * 0.5, sideCy, ftSide, sideH, 18);
-                            drawFrameBox(cx + width * 0.5 - ftSide * 0.5, sideCy, ftSide, sideH, 18);
+                            // Lower 30%: thick dark segment
+                            const repLoH = sideH * 0.3;
+                            const repLoCy = ySideLo + repLoH * 0.5;
+                            drawFrameBox(cx - width * 0.5 + ftSide * 0.5, repLoCy, ftSide, repLoH, chordBaseRO + 0.0001, sideHex);
+                            drawFrameBox(cx + width * 0.5 - ftSide * 0.5, repLoCy, ftSide, repLoH, chordBaseRO + 0.0001, sideHex);
+                            // Upper 70%: thin teal segment (same style as non-repeat upper)
+                            const repHiH = sideH - repLoH;
+                            const repHiCy = ySideLo + repLoH + repHiH * 0.5;
+                            drawFrameBox(cx - width * 0.5 + ftThin * 0.5, repHiCy, ftThin, repHiH, chordBaseRO + 0.0001);
+                            drawFrameBox(cx + width * 0.5 - ftThin * 0.5, repHiCy, ftThin, repHiH, chordBaseRO + 0.0001);
                         } else {
                             // Non-repeat: thick sides up to repeat-frame height, then taper to thin above.
                             const threshY = yBot + fullChordBoxH * 0.5; // top of what a repeat frame would be
@@ -8582,20 +9111,20 @@
                             const loSideH = Math.max(Math.min(threshY, ySideHi) - ySideLo, 0);
                             if (loSideH > 0) {
                                 const loCy = ySideLo + loSideH * 0.5;
-                                drawFrameBox(cx - width * 0.5 + ftSide * 0.5, loCy, ftSide, loSideH, 18);
-                                drawFrameBox(cx + width * 0.5 - ftSide * 0.5, loCy, ftSide, loSideH, 18);
+                                drawFrameBox(cx - width * 0.5 + ftSide * 0.5, loCy, ftSide, loSideH, chordBaseRO + 0.0001, sideHex);
+                                drawFrameBox(cx + width * 0.5 - ftSide * 0.5, loCy, ftSide, loSideH, chordBaseRO + 0.0001, sideHex);
                             }
 
                             // Upper thin segment (threshY → ySideHi)
                             const hiSideH = Math.max(ySideHi - threshY, 0);
                             if (hiSideH > 0) {
                                 const hiCy = threshY + hiSideH * 0.5;
-                                drawFrameBox(cx - width * 0.5 + ftThin * 0.5, hiCy, ftThin, hiSideH, 18);
-                                drawFrameBox(cx + width * 0.5 - ftThin * 0.5, hiCy, ftThin, hiSideH, 18);
+                                drawFrameBox(cx - width * 0.5 + ftThin * 0.5, hiCy, ftThin, hiSideH, chordBaseRO + 0.0001);
+                                drawFrameBox(cx + width * 0.5 - ftThin * 0.5, hiCy, ftThin, hiSideH, chordBaseRO + 0.0001);
                             }
 
                             // Top bar: thin
-                            drawFrameBox(cx, yTop - ftThin * 0.5, width, ftThin, 17);
+                            drawFrameBox(cx, yTop - ftThin * 0.5, width, ftThin, chordBaseRO);
                         }
 
                         // Accent bloom on frame edges: 4 additive shells with
@@ -8604,11 +9133,9 @@
                         //   horizontal bars (top/bottom) → expand Y only
                         //   vertical bars (left/right)   → expand X only
                         if (chordAccent && pHaloBar) {
-                            // Gradient halo: 1 mesh per bar (4 draw calls) instead of
-                            // 4 shells × 4 bars = 16. The gHaloBar geometry (built once)
-                            // bakes the additive shell sum into vertex colours. Scale Y by
-                            // (ft * EXPAND_MAX * 0.5) for horizontal bars; rotate ±90° and
-                            // scale Y by (ftSide * EXPAND_MAX * 0.5) for vertical bars.
+                            // Bloom only on the teal (thin) parts of the frame — the dark
+                            // "#163137" L-corners are deliberately left without bloom so they
+                            // remain visibly dark (same appearance as non-accent chords).
                             const haloHex = isArpeggioFrame ? ARPEGGIO_RIM_BLUE_HEX : CHORD_BOX_TEAL_HEX;
                             const EXPAND_MAX = 1.45;
                             const dynamicOp = fade * chordTailMul;
@@ -8616,23 +9143,38 @@
                                 const b = pHaloBar.get();
                                 b.material.color.setHex(haloHex);
                                 b.material.opacity = dynamicOp;
-                                b.renderOrder = 19;
+                                b.renderOrder = chordBaseRO + 0.0003;
                                 b.position.set(px, py, z - 0.001 * K);
                                 b.scale.set(scaleX, scaleY * EXPAND_MAX * 0.5, thickZ * 2.0);
                                 b.rotation.set(0, 0, rotZ);
                             };
-                            // horizontal bars — gradient expands in Y (no rotation)
-                            drawHaloBar(cx, yBot + ft * 0.5,                          width  * 0.5, ft,     0);
+                            // Bottom: center-only bloom (skip dark corner areas)
+                            const _bCW = Math.min(sideH * (isRepeat ? 0.5 : 0.25), width * 0.4);
+                            const centerBotW = width - 2 * _bCW;
+                            if (centerBotW > 0)
+                                drawHaloBar(cx, yBot + ft * 0.5, centerBotW * 0.5, ft, 0);
+                            // Top bar
                             if (withTopFrame)
-                            // Top bar is `ftThin` (see non-repeat draw block above) —
-                            // halo Y centre and scaleY follow the actual bar so the
-                            // bloom doesn't sit above the visible rim.
-                            drawHaloBar(cx, yTop - ftThin * 0.5,                       width  * 0.5, ftThin, 0);
-                            // vertical bars — gradient expands in X (rotate 90° so Y→X)
-                            drawHaloBar(cx - width * 0.5 + ftSide * 0.5, sideCy,  sideH  * 0.5, ftSide, Math.PI * 0.5);
-                            drawHaloBar(cx + width * 0.5 - ftSide * 0.5, sideCy,  sideH  * 0.5, ftSide, Math.PI * 0.5);
+                                drawHaloBar(cx, yTop - ftThin * 0.5, width * 0.5, ftThin, 0);
+                            // Lateral: bloom only on the upper thin-teal segment (skip dark lower segment)
+                            if (isRepeat) {
+                                const repLoH = sideH * 0.3;
+                                const repHiH = sideH - repLoH;
+                                if (repHiH > 0) {
+                                    const repHiCy = ySideLo + repLoH + repHiH * 0.5;
+                                    drawHaloBar(cx - width * 0.5 + ftSide * 0.5, repHiCy, repHiH * 0.5, ftSide, Math.PI * 0.5);
+                                    drawHaloBar(cx + width * 0.5 - ftSide * 0.5, repHiCy, repHiH * 0.5, ftSide, Math.PI * 0.5);
+                                }
+                            } else {
+                                const threshY = yBot + fullChordBoxH * 0.5;
+                                const hiSideH = Math.max(ySideHi - threshY, 0);
+                                if (hiSideH > 0) {
+                                    const hiCy = threshY + hiSideH * 0.5;
+                                    drawHaloBar(cx - width * 0.5 + ftSide * 0.5, hiCy, hiSideH * 0.5, ftSide, Math.PI * 0.5);
+                                    drawHaloBar(cx + width * 0.5 - ftSide * 0.5, hiCy, hiSideH * 0.5, ftSide, Math.PI * 0.5);
+                                }
+                            }
                         }
-
                         const chordName = chordTemplateLabel(bundle.chordTemplates?.[ch.id]);
                         if (chordName && firstInShapeRun && !chordWireHighDensity(ch)) {
                             const lblW = 28 * K, lblH = 9 * K;
@@ -8753,46 +9295,74 @@
                             }
                         }
 
-                        // ── Palm-mute strum indicator — X outline + dark fill ──────────
-                        // Fill: pPMXFill (1 draw call). Lines: pMuteXLines (1 draw call, all
-                        // 8 segments baked as quads in ±1 normalised space). Both meshes are
-                        // scaled to (innerW*0.5, -innerH*0.5) per chord; visible from AHEAD.
+                        // ── Chord fret numbers at the base of the highway ───────────────
+                        // Show fret number per unique fretted position for non-repeated
+                        // chords so the player can read the shape at a glance.
+                        if (!isRepeat) {
+                            const _chFretLblAlpha = Math.min(1.0, (AHEAD - chDt) / 0.35) * chordTailMul;
+                            const _seenChordFrets = new Set();
+                            for (const [, f] of chShape) {
+                                if (f <= 0 || _seenChordFrets.has(f)) continue;
+                                _seenChordFrets.add(f);
+                                const lbl = pNoteFretLabel.get();
+                                const mat = txtMat(f, FRET_LABEL_GOLD_HEX, false, 'noteFret');
+                                if (lbl.material.map !== mat.map) {
+                                    lbl.material.map = mat.map;
+                                    lbl.material.needsUpdate = true;
+                                }
+                                lbl.position.set(xFretMid(f), yMinF, z);
+                                lbl.renderOrder = chordBaseRO + 1;
+                                const _flS = 7.0 * K * (1 + 0.4 * chDt / AHEAD) * _textSizeMul * fretLabelScaleForFret(f);
+                                lbl.scale.set(_flS, _flS, 1);
+                                lbl.material.opacity = _chFretLblAlpha;
+                            }
+                        }
+
+                        // ── Palm-mute strum indicator — pool (fill + lines) ──────────────
+                        // Per-chord Z-proportional renderOrder: fill at chordBaseRO-3.5,
+                        // lines at chordBaseRO-3, frame edges at chordBaseRO.
                         if (isRepeat && chordNotes.some(cn => cn.pm)) {
-                            const pmf = pPMXFill.get();
-                            pmf.renderOrder = 10.5;
-                            pmf.rotation.set(0, 0, 0);
-                            pmf.position.set(cx, cY, z - 0.0045 * K);
-                            pmf.scale.set(innerW * 0.5, -innerH * 0.5, 1);
-                            pmf.material.opacity = edgeOp;
-
-                            const xlm = pMuteXLines.get();
-                            xlm.renderOrder = 11;
-                            xlm.material.color.setHex(baseRimHex);
-                            xlm.position.set(cx, cY, z - 0.005 * K);
-                            xlm.scale.set(innerW * 0.5, -innerH * 0.5, thickZ * 0.5);
-                            xlm.rotation.set(0, 0, 0);
-                            xlm.material.opacity = edgeOp * 0.85;
+                            if (pPMXFill) {
+                                const xf = pPMXFill.get();
+                                xf.renderOrder = chordBaseRO - 3.5;
+                                xf.material.opacity = edgeOp * CHORD_BOX_EDGE_ALPHA;
+                                xf.position.set(cx, cY, z - 0.0045 * K);
+                                xf.scale.set(innerW * 0.5, -innerH * 0.5, 1);
+                                xf.rotation.set(0, 0, 0);
+                            }
+                            if (pMuteXLines) {
+                                const xl = pMuteXLines.get();
+                                xl.renderOrder = chordBaseRO - 3;
+                                xl.material.opacity = edgeOp * 0.85;
+                                xl.material.color.setHex(baseRimHex);
+                                xl.position.set(cx, cY, z - 0.005 * K);
+                                xl.scale.set(innerW * 0.5, -innerH * 0.5, thickZ * 0.5);
+                                xl.rotation.set(0, 0, 0);
+                            }
                         }
 
-                        // ── Frethand-mute strum indicator — FH X outline + dark fill ───
-                        // Fill: pFHXFill (1 draw call). Lines: pFHXLines (1 draw call).
-                        // L/R wings stop at fx=±0.50 — no solid lateral fill blocks.
+                        // ── Frethand-mute strum indicator — pool (fill + lines) ───────────
                         if (isRepeat && chordNotes.some(cn => cn.mt || cn.fhm)) {
-                            const fhf = pFHXFill.get();
-                            fhf.renderOrder = 10.5;
-                            fhf.rotation.set(0, 0, 0);
-                            fhf.position.set(cx, cY, z - 0.0045 * K);
-                            fhf.scale.set(innerW * 0.5, -innerH * 0.5, 1);
-                            fhf.material.opacity = edgeOp;
-
-                            const xlf = pFHXLines.get();
-                            xlf.renderOrder = 11;
-                            xlf.material.color.setHex(baseRimHex);
-                            xlf.position.set(cx, cY, z - 0.005 * K);
-                            xlf.scale.set(innerW * 0.5, -innerH * 0.5, thickZ * 0.5);
-                            xlf.rotation.set(0, 0, 0);
-                            xlf.material.opacity = edgeOp * 0.85;
+                            if (pFHXFill) {
+                                const xf = pFHXFill.get();
+                                xf.renderOrder = chordBaseRO - 3.5;
+                                xf.material.opacity = edgeOp * CHORD_BOX_EDGE_ALPHA;
+                                xf.position.set(cx, cY, z - 0.0045 * K);
+                                xf.scale.set(innerW * 0.5, -innerH * 0.5, 1);
+                                xf.rotation.set(0, 0, 0);
+                            }
+                            if (pFHXLines) {
+                                const xl = pFHXLines.get();
+                                xl.renderOrder = chordBaseRO - 3;
+                                xl.material.opacity = edgeOp * 0.85;
+                                xl.material.color.setHex(baseRimHex);
+                                xl.position.set(cx, cY, z - 0.005 * K);
+                                xl.scale.set(innerW * 0.5, -innerH * 0.5, thickZ * 0.5);
+                                xl.rotation.set(0, 0, 0);
+                            }
                         }
+
+                        } // end if (chDt > 0) — framebox + PM/FH mute only on highway
 
                     }
 
@@ -8886,11 +9456,13 @@
                                     rl.position.set(_rxIn, _yBot, _zMid);
                                     rl.scale.set(_railW, 1, _railLen);
                                     // Bloom glow — wider gaussian plane, additive blending
-                                    const bl = pSusRailBloom.get();
-                                    bl.material.color.setHex(_hex);
-                                    bl.material.opacity = _op * 0.8;
-                                    bl.position.set(_rxIn, _yBot + 0.001, _zMid);
-                                    bl.scale.set(3 * K, 1, _railLen);
+                                    if (!_leanSus) {
+                                        const bl = pSusRailBloom.get();
+                                        bl.material.color.setHex(_hex);
+                                        bl.material.opacity = _op * 0.8;
+                                        bl.position.set(_rxIn, _yBot + 0.001, _zMid);
+                                        bl.scale.set(3 * K, 1, _railLen);
+                                    }
                                 }
                             }
                         }
@@ -9017,10 +9589,8 @@
 
                     {
                         const yPos = boardY + 0.03 * K;
-                        const divOp = 0.02 + highwayIntensity * 0.1;
                         const divOpArp = Math.min(0.92, 0.16 + highwayIntensity * 0.42);
-                        if (mLaneDivider && mLaneDividerArp) {
-                            mLaneDivider.opacity = divOp;
+                        if (mLaneDividerArp) {
                             mLaneDividerArp.opacity = divOpArp;
                         }
 
@@ -9190,16 +9760,24 @@
             //     happening on the playing strings just above them.
             {
                 const yBottom = Math.min(sY(0), sY(nStr - 1));
-                const anchorGold = anchorPlayedFretSpanAt(anchors, now);
+                // anchorSpan: [f0, f1] = [anchor.fret, anchor.fret + width - 1]
+                // e.g. { fret:3, width:4 } → f0=3, f1=6 → frets 3,4,5,6 gold.
+                const anchorSpan = anchorPlayedFretSpanAt(anchors, now);
                 for (let f = 1; f <= NFRETS; f++) {
+                    const isInAnchor = anchorSpan
+                        && f >= anchorSpan.f0 && f <= anchorSpan.f1;
+                    const isMainFret = DOTS.includes(f);
+                    // Rule 1: show gray label only on main frets (dot positions).
+                    // Rule 2: show gold label on any fret inside the anchor range.
+                    // Non-main frets outside the anchor range are hidden entirely.
+                    if (!isInAnchor && !isMainFret) continue;
                     const lb = pFretLbl.get();
-                    const isGold = anchorGold
-                        ? (f >= anchorGold.f0 && f <= anchorGold.f1)
-                        : activeFrets.has(f);
-                    lb.material    = txtMat(f, isGold ? FRET_LABEL_GOLD_HEX : FRET_LABEL_IDLE_HEX, false, 'fretRow');
+                    lb.material = txtMat(f,
+                        isInAnchor ? FRET_LABEL_GOLD_HEX : FRET_LABEL_IDLE_HEX,
+                        false, 'fretRow');
                     lb.position.set(xFretMid(f), yBottom - S_GAP * 1.4, 0.5 * K);
-                    lb.material.opacity = isGold ? 1.0 : 0.55;
-                    const scale = 7.0 * _textSizeMul * fretLabelScaleForFret(f);
+                    lb.material.opacity = isInAnchor ? 1.0 : 0.55;
+                    const scale = 5.95 * _textSizeMul * fretLabelScaleForFret(f);
                     lb.scale.set(scale * K, scale * K, 1);
                     lb.renderOrder = 1000;
                 }
@@ -9358,10 +9936,12 @@
                         }
                         sp.material.opacity = 0.85 * _colFadeIn;
                         sp.position.set(xFretMid(f), labelY, z);
-                        // renderOrder > beat lines (0) so the label always draws on top,
-                        // avoiding the transparent-sort artefact where the beat line
-                        // washes over the label and makes it appear in a "dimmer" colour.
-                        sp.renderOrder = 5;
+                        // Z-proportional: sits between chord frame border
+                        // (chordBaseRO = max(48, round(700+z/K)-2)) and note
+                        // gems (_noteRO = max(50, round(700+z/K))) at the same
+                        // depth, so chord frames never overdraw the label and
+                        // the label never overdraw gems.
+                        sp.renderOrder = Math.max(49, Math.round(700 + z / K) - 1);
                         // Scale grows linearly from 2× at max lookahead to 1× at hit line,
                         // combined with natural perspective attenuation the label starts
                         // visibly larger and converges to the row-label size at z=0.
@@ -9385,10 +9965,10 @@
 
                 let dtSec = 1 / 120;
                 if (_lookaheadCamPrevNow !== null) {
-                    const rawDt = bundle.currentTime - _lookaheadCamPrevNow;
+                    const rawDt = _frameNow - _lookaheadCamPrevNow;
                     if (rawDt > -1 && rawDt < 2) dtSec = Math.min(0.2, Math.max(1 / 960, rawDt));
                 }
-                _lookaheadCamPrevNow = bundle.currentTime;
+                _lookaheadCamPrevNow = _frameNow;
                 const dBlend = Math.min(0.2, Math.max(1e-4, dtSec));
                 const lowBlendFs = 1 - Math.pow(1 - CAM_FOCUS_BLEND_RATE, dBlend);
 
@@ -9590,6 +10170,31 @@
                     _diagPrevOpacity = Math.max(0, _diagPrevStartOpacity * (1 - fadedT / DIAG_CROSSFADE_S));
                 }
             }
+            // ── Finalise InstancedMesh batches ────────────────────────────────
+            // Flush all 6 IMs: set visible instance count and mark buffers dirty.
+            // Must run after all drawNote() / chord-loop writes are done.
+            if (imPMTech) {
+                imPMTech.count = _imPMTechCount;
+                if (_imPMTechCount > 0) {
+                    imPMTech.instanceMatrix.needsUpdate = true;
+                    imPMTech.geometry.getAttribute('instanceAlpha').needsUpdate = true;
+                }
+            }
+            if (imFHTech) {
+                imFHTech.count = _imFHTechCount;
+                if (_imFHTechCount > 0) {
+                    imFHTech.instanceMatrix.needsUpdate = true;
+                    imFHTech.geometry.getAttribute('instanceAlpha').needsUpdate = true;
+                }
+            }
+            // These IMs are kept alive but always empty (count=0) — rendering
+            // is now handled by the pPMXFill / pMuteXLines / pFHXFill / pFHXLines
+            // pools which support per-chord Z-proportional renderOrder.
+            if (imPMXFill)  imPMXFill.count  = 0;
+            if (imPMXLines) imPMXLines.count = 0;
+            if (imFHXFill)  imFHXFill.count  = 0;
+            if (imFHXLines) imFHXLines.count = 0;
+
             pbEnd(5);
             pbEnd(0);
             pbReportTick();
@@ -9710,7 +10315,8 @@
         }
         // skipLabel: don't draw per-note connector label (repeated fret)
         // skipBody:  don't draw the 3D note mesh (repeat chord — still shows projection)
-        function drawNote(n, now, openX, skipLabel, skipBody, linger = 0.10, openChordBoxWidth, fromChord = false, chordId, susTrailMatchArpFrame = false, arpBounds = null, prevOnsetT = -Infinity) {
+        // showDropLine: draw a white vertical drop line from note to below board (arpeggio / synth chord notes)
+        function drawNote(n, now, openX, skipLabel, skipBody, linger = 0.10, openChordBoxWidth, fromChord = false, chordId, susTrailMatchArpFrame = false, arpBounds = null, prevOnsetT = -Infinity, showDropLine = false) {
             const s = n.s;
             // Belt + suspenders: callers already gate via validString(),
             // but drawNote is also entered through { ...cn } chord-note
@@ -10027,6 +10633,10 @@
                 const _ndVerdict = (_ndCs && (_ndState === 'miss' || _ndGood))
                     || !!_ndMatchedMark;
                 outline.material = (n.ac && !_ndVerdict) ? mAccentOutline[s] : _ndOutline;
+                // outline + core share the pNote pool, so set geometry explicitly
+                // each frame (a recycled mesh may carry a gradient geometry from a
+                // prior core use). Outline always uses the plain box.
+                outline.geometry = gNote;
                 outline.renderOrder = _noteRO;
                 outline.position.set(x, y + techniqueYNow, noteZ);
                 outline.rotation.z = approachRot;
@@ -10067,6 +10677,8 @@
                 // Body always keeps the string colour. Verdict feedback is
                 // carried by the outline shell and lateral face fill.
                 core.material = n.ac ? mAccentCore[s] : mStr[s];
+                // Gradient gem body for strings 0..5; flat box otherwise.
+                core.geometry = (!n.ac && gNoteGrad[s]) ? gNoteGrad[s] : gNote;
                 core.renderOrder = _noteRO + 1;
                 core.position.set(x, y + techniqueYNow, noteZ + 0.001);
                 core.rotation.z = approachRot;
@@ -10153,27 +10765,26 @@
                             : _ndGood ? (mHitBright[s] ?? mHitSusOutline)
                             : mSusOutline;
                         const emitSusStrip = (xCenter, segLen, zCenter) => {
+                            // Depth-based renderOrder mirrors the chord-frame formula
+                            // (max(48, round(700 + z/K) - 2)) minus 0.001 so that at
+                            // the same depth a chord frame always wins, but trail
+                            // segments closer to the camera beat farther chord frames.
+                            // Math.min(0, zCenter) clamps past-note Z (> 0) to 0 so
+                            // lingering trails get max RO ≈ 697.999 instead of going
+                            // above 700 (which would intrude into the note-gem range).
+                            const _ro = Math.max(47.999, Math.round(700 + Math.min(0, zCenter) / K) - 2) - 0.001;
                             for (let i = 0; i < offsets.length; i++) {
                                 const xOff = xCenter + offsets[i];
-                                // Outline renders first (lower renderOrder), body on top.
-                                // On hit/miss the body uses mGlow[s] (opaque + emissive,
-                                // opacity:1) — the body retains string identity and the
-                                // outline-fringe extending past the body edges carries the
-                                // verdict colour (outline-only verdict doctrine).
-                                // On neutral the body is semi-transparent (mSus, opacity:0.35)
-                                // which lets the neutral white outline bleed slightly — same
-                                // look as before the hit/miss feature was added.
-                                const trOut = pSusOutline.get();
-                                trOut.material = _susOlMat;
-                                trOut.renderOrder = 12; // outline first — below body
-                                trOut.position.set(xOff, y, zCenter);
-                                trOut.scale.set(tw + 0.4 * K, th + 0.4 * K, segLen);
+                                if (!_leanSus) {
+                                    const trOut = pSusOutline.get();
+                                    trOut.material = _susOlMat;
+                                    trOut.renderOrder = _ro;
+                                    trOut.position.set(xOff, y, zCenter);
+                                    trOut.scale.set(tw + 0.4 * K, th + 0.4 * K, segLen);
+                                }
                                 const tr = pSus.get();
-                                // Any verdict (hit or miss): opaque string-colour body
-                                // covers the outline center completely. Neutral: original
-                                // semi-transparent look (mSus), no verdict border applied.
                                 tr.material = _ndState ? mGlow[s] : mSus[s];
-                                tr.renderOrder = 13; // body on top — covers outline center
+                                tr.renderOrder = _ro + 0.0005;
                                 tr.position.set(xOff, y, zCenter);
                                 tr.scale.set(tw, th, segLen);
                             }
@@ -10183,23 +10794,29 @@
                             const zPos = dZ(susStart - now) - len / 2;
                             emitSusStrip(x, len, zPos);
                         } else {
+                            // Same depth-based RO as box trail — ribbon center
+                            // at susStart + sliceDur/2, minus 0.001 so chord
+                            // frame wins at identical depth but closer ribbon
+                            // segments beat farther chord frames.
+                            const _ribDt = Math.max(0, susStart + sliceDur / 2 - now);
+                            const _ribRO = Math.max(47.999, Math.round(700 - _ribDt * 200) - 2) - 0.001;
                             for (let si = 0; si < offsets.length; si++) {
                                 const strandX = x + offsets[si];
-                                // Outline first (12), body on top (13) — same
-                                // cover-the-center logic as the box-trail path.
-                                const olMesh = pSusRibbonOl.get();
-                                olMesh.renderOrder = 12; // outline first — below body
-                                olMesh.scale.set(1, 1, 1);
-                                olMesh.rotation.set(0, 0, 0);
-                                olMesh.position.set(0, 0, 0);
-                                olMesh.material = _susOlMat;
-                                slideRibbonUpdatePositions(
-                                    olMesh.geometry, strandX,
-                                    tw + 0.4 * K, th + 0.4 * K,
-                                    y, sliceDur, susStart, now, n, slideSt,
-                                );
+                                if (!_leanSus) {
+                                    const olMesh = pSusRibbonOl.get();
+                                    olMesh.renderOrder = _ribRO;
+                                    olMesh.scale.set(1, 1, 1);
+                                    olMesh.rotation.set(0, 0, 0);
+                                    olMesh.position.set(0, 0, 0);
+                                    olMesh.material = _susOlMat;
+                                    slideRibbonUpdatePositions(
+                                        olMesh.geometry, strandX,
+                                        tw + 0.4 * K, th + 0.4 * K,
+                                        y, sliceDur, susStart, now, n, slideSt,
+                                    );
+                                }
                                 const body = pSusRibbon.get();
-                                body.renderOrder = 13; // body on top — covers outline center
+                                body.renderOrder = _ribRO + 0.0005;
                                 body.scale.set(1, 1, 1);
                                 body.rotation.set(0, 0, 0);
                                 body.position.set(0, 0, 0);
@@ -10286,28 +10903,22 @@
                 }
                 // Tremolo label ('~~~') removed — trail shape already conveys it visually.
                 if (n.pm || n.mt || n.fhm) {
-                    // Muted notes: on-body X overlay — PlaneGeometry mesh so it
-                    // rotates with the gem (approachRot) instead of billboarding.
-                    // Palm mute = black X / white border; fret-hand mute = inverse.
-                    // `mt` (string mute) and `fhm` (fret-hand mute) both render the
-                    // fret-hand X; only a palm-mute-only note gets the inverse.
-                    const fretHandMute = !!(n.mt || n.fhm);
-                    const muteSprite = fretHandMute
-                        ? fretHandMuteXSpriteMat()
-                        : palmMuteXSpriteMat();
-                    const muteMark = pTechPlane.get();
-                    muteMark.material = _spriteMat2MeshMat(muteMark, muteSprite);
-                    muteMark.material.opacity = hit ? 1.0 : 0.8;
-                    // Arms cover 62.5% of canvas (pad=outerW/√2 for square caps).
-                    // Scale by 1/0.625 = 1.60 to map arm tips to gem corners.
-                    const muteScaleX = n.f === 0
-                        ? NW * 1.60 * openWScale
-                        : NW * 1.60;
-                    const muteScaleY = NH * 1.60;
-                    muteMark.scale.set(muteScaleX, muteScaleY, 1);
-                    muteMark.position.set(x, y + techniqueYNow, noteZ + K);
-                    muteMark.rotation.z = approachRot;
-                    muteMark.renderOrder = TECH_RO;
+                    // Muted notes: pool-based plane with per-note Z-proportional
+                    // renderOrder (TECH_RO = _noteRO + 2).  The previous InstancedMesh
+                    // approach used a fixed RO (702/700), which made PM/FH markers from
+                    // far notes overdraw chord frames and gems of nearer chords.
+                    // PM = black X / white border; FH/MT = inverse.
+                    const _fhm = !!(n.mt || n.fhm);
+                    const _pmSprite = _fhm ? fretHandMuteXSpriteMat() : palmMuteXSpriteMat();
+                    const _pmMark = pTechPlane.get();
+                    _pmMark.material = _spriteMat2MeshMat(_pmMark, _pmSprite);
+                    _pmMark.material.opacity = _showHit ? 1.0 : 0.8;
+                    // Arms cover 62.5% of canvas → scale 1/0.625 = 1.60.
+                    const _sx = n.f === 0 ? NW * 1.60 * openWScale : NW * 1.60;
+                    _pmMark.scale.set(_sx, NH * 1.60, 1);
+                    _pmMark.position.set(x, y + techniqueYNow, noteZ + K);
+                    _pmMark.rotation.z = approachRot;
+                    _pmMark.renderOrder = TECH_RO;
                 }
                 // hm / hp — PlaneGeometry overlay sized like the palm-mute X,
                 // so the symbol only appears on the front face and matches
@@ -10332,28 +10943,112 @@
                     // the note hits (dt = 0).  No pre-hit fade-out — removing it
                     // eliminates the "label disappears before the note arrives" artifact.
                     const alpha = dt >= 0 ? Math.min(1.0, (AHEAD - dt) / 0.35) : 0;
+                    // Arpeggio notes get +1 over non-arp at the same depth so their
+                    // labels stay above non-arp connector lines of the same chord.
+                    const _isArpNote = arpBounds !== null;
 
-                    const fretLabel  = pNoteFretLabel.get();
-                    const cachedMat  = txtMat(n.f, FRET_LABEL_GOLD_HEX, false, 'noteFret');
-                    if (fretLabel.material.map !== cachedMat.map) {
-                        fretLabel.material.map = cachedMat.map;
-                        fretLabel.material.needsUpdate = true;
+                    // String-coloured connector line — standalone notes only.
+                    // Arpeggio and chord notes already have a drop line to the board.
+                    if (!fromChord) {
+                        const line = pConnectorLine.get();
+                        line.position.set(x, labelY, noteZ);
+                        // Half-length (50% shorter), anchored at the fret-label end.
+                        line.scale.set(1, (y - labelY) * 0.5, 1);
+                        // Tint the line with the incoming note's string colour.
+                        // mStr is white for gradient strings, so use the canonical
+                        // flat palette colour instead of the material's .color.
+                        if (activePalette[s] != null) line.material.color.setHex(activePalette[s]);
+                        // Use _noteRO-based value so the line is always above the chord
+                        // frame border of the same note (chordBaseRO = _noteRO - 2).
+                        // Arpeggio notes get +1 to stay above non-arp lines of the same Z.
+                        line.renderOrder = _isArpNote ? _noteRO : _noteRO - 1;
+                        line.material.opacity = alpha * 0.8;
                     }
-                    fretLabel.position.set(x, labelY, noteZ);
-                    // Render above beat lines so the label is never washed out by the
-                    // beat-line transparency pass.
-                    fretLabel.renderOrder = 5;
-                    // Same scale ramp as fret column markers: 2× base at max lookahead,
-                    // converging to 1× at hit line.  Final size matches row labels.
-                    const flS = 7.0 * K * (1 + 0.4 * Math.max(0, dt) / AHEAD) * _textSizeMul * fretLabelScaleForFret(n.f);
-                    fretLabel.scale.set(flS, flS, 1);
-                    fretLabel.material.opacity = alpha;
 
-                    const line = pConnectorLine.get();
-                    line.position.set(x, labelY, noteZ);
-                    line.scale.set(1, y - labelY, 1);
-                    line.material.opacity = alpha * 0.8;
+                    // Regular chord notes (fromChord=true, arpBounds=null) never show
+                    // fret labels — only standalone notes and arpeggio note-stream notes
+                    // (fromChord=true with arpBounds!=null) show labels.
+                    // Key uses 40 ms buckets (same formula as _buildFretLabelSet) so
+                    // the lookup matches exactly, even if the note's time drifts ±20 ms.
+                    // Frame-dedup prevents multiple strings at the same onset/fret from
+                    // stacking duplicate labels.
+                    const _flFrameKey = Math.round(n.t * 25) * 100 + n.f;
+                    const _showNum = (!fromChord || arpBounds !== null)
+                        && _fretLabelAllowed.has(_flFrameKey)
+                        && !_frameLabeledKeys.has(_flFrameKey);
+                    if (_showNum) {
+                        _frameLabeledKeys.add(_flFrameKey);
+                        const fretLabel  = pNoteFretLabel.get();
+                        const cachedMat  = txtMat(n.f, FRET_LABEL_GOLD_HEX, false, 'noteFret');
+                        if (fretLabel.material.map !== cachedMat.map) {
+                            fretLabel.material.map = cachedMat.map;
+                            fretLabel.material.needsUpdate = true;
+                        }
+                        fretLabel.position.set(x, labelY, noteZ);
+                        // _noteRO-based: always above the chord frame border (chordBaseRO =
+                        // _noteRO - 2) of the same note so the gold label is never overdrawn
+                        // by a chord frame edge.  Arpeggio notes get +1 extra over non-arp.
+                        fretLabel.renderOrder = _isArpNote ? _noteRO + 1 : _noteRO;
+                        // Same scale ramp as fret column markers: 2× base at max lookahead,
+                        // converging to 1× at hit line.  Final size matches row labels.
+                        const flS = 7.0 * K * (1 + 0.4 * Math.max(0, dt) / AHEAD) * _textSizeMul * fretLabelScaleForFret(n.f);
+                        fretLabel.scale.set(flS, flS, 1);
+                        fretLabel.material.opacity = alpha;
+                    }
                 }
+            }
+
+            // ── Fret number for synthetic chord notes rendered with skipBody=true ──
+            // suppressSynthChord paths skip the !skipBody block entirely, so their
+            // fret label never fires from inside it. Handle them here, outside the
+            // gate. Applies the same measure-based + frame-dedup rules so that if
+            // the corresponding standalone arpeggio note already showed a label this
+            // frame, we don't duplicate it.
+            if (skipBody && fromChord && !skipLabel && n.f > 0 && dt >= 0) {
+                const _fl2FrameKey = Math.round(n.t * 25) * 100 + n.f;
+                if (_fretLabelAllowed.has(_fl2FrameKey)
+                    && !_frameLabeledKeys.has(_fl2FrameKey)) {
+                    _frameLabeledKeys.add(_fl2FrameKey);
+                    const _minStrY2 = Math.min(sY(0), sY(nStr - 1));
+                    const _labelY2  = _minStrY2 - S_GAP * 0.8;
+                    const _alpha2   = Math.min(1.0, (AHEAD - dt) / 0.35);
+                    const _isArp2   = arpBounds !== null;
+                    const fl2 = pNoteFretLabel.get();
+                    const cm2 = txtMat(n.f, FRET_LABEL_GOLD_HEX, false, 'noteFret');
+                    if (fl2.material.map !== cm2.map) {
+                        fl2.material.map = cm2.map;
+                        fl2.material.needsUpdate = true;
+                    }
+                    fl2.position.set(x, _labelY2, noteZ);
+                    // Same _noteRO-based contract as the primary fret label above.
+                    fl2.renderOrder = _isArp2 ? _noteRO + 1 : _noteRO;
+                    const _flS2 = 7.0 * K * (1 + 0.4 * dt / AHEAD) * _textSizeMul * fretLabelScaleForFret(n.f);
+                    fl2.scale.set(_flS2, _flS2, 1);
+                    fl2.material.opacity = _alpha2;
+                }
+            }
+
+            // ── Drop line for chord / arpeggio notes ──────────────────────────
+            // Styled to match the standalone single-note connector: tinted with
+            // the incoming note's string colour and 50% length (anchored at the
+            // fret-label end), instead of a full-height white line to the board.
+            const _wantDropLine = pDropLine && n.f > 0 && dt >= 0 && fromChord && showDropLine && !skipBody;
+            if (_wantDropLine) {
+                const _minStrY = Math.min(sY(0), sY(nStr - 1));
+                const _dropY = _minStrY - S_GAP * 0.8;
+                const _alpha = Math.min(1.0, (AHEAD - dt) / 0.35);
+                const dl = pDropLine.get();
+                dl.position.set(x, _dropY, noteZ);
+                // Half-length, anchored at the label end (matches single notes).
+                dl.scale.set(1, (y - _dropY) * 0.5, 1);
+                // String-colour tint (palette is canonical; mStr is white for
+                // gradient strings).
+                if (activePalette[s] != null) dl.material.color.setHex(activePalette[s]);
+                // _noteRO - 1: above chord frame border (chordBaseRO = _noteRO - 2)
+                // but below the gem outline (_noteRO) so the gem stays dominant.
+                dl.renderOrder = _noteRO - 1;
+                dl.material.depthTest = false;
+                dl.material.opacity = _alpha * 0.8;
             }
 
             // ── Board ghost: filled rim at Z=0 (always drawn for isNext) ─
@@ -10704,6 +11399,25 @@
             gSusRailBloom?.dispose?.(); mSusRailBloomBase?.dispose?.(); _bloomGaussTex?.dispose?.();
             gSusRailBloom = null; mSusRailBloomBase = null; _bloomGaussTex = null; pSusRailBloom = null;
             gTechPlane?.dispose?.(); gTechPlane = null; pTechPlane = null;
+            // InstancedMesh disposal — .dispose() releases instanceMatrix / instanceColor
+            // GPU buffers. Geometry and material are disposed separately below.
+            imPMTech?.dispose?.(); imPMTech = null;
+            imFHTech?.dispose?.(); imFHTech = null;
+            imPMXFill?.dispose?.(); imPMXFill = null;
+            imPMXLines?.dispose?.(); imPMXLines = null;
+            imFHXFill?.dispose?.(); imFHXFill = null;
+            imFHXLines?.dispose?.(); imFHXLines = null;
+            // Geometry clones for PM/FH tech IMs (own instanceAlpha attribute).
+            _imGPMTech?.dispose?.(); _imGPMTech = null;
+            _imGFHTech?.dispose?.(); _imGFHTech = null;
+            // ShaderMaterials for all 6 IMs.
+            _imPMTechMat?.dispose?.();  _imPMTechMat = null;
+            _imFHTechMat?.dispose?.();  _imFHTechMat = null;
+            _imPMXFillMat?.dispose?.(); _imPMXFillMat = null;
+            _imPMXLinesMat?.dispose?.(); _imPMXLinesMat = null;
+            _imFHXFillMat?.dispose?.(); _imFHXFillMat = null;
+            _imFHXLinesMat?.dispose?.(); _imFHXLinesMat = null;
+            _imM4 = _imPos = _imSca = _imQ = _imAZ = _imColor = null;
             gHaloBar?.dispose?.(); gHaloBar = null;
             gArpBracket?.dispose?.(); gArpBracket = null;
             for (const m of mStr) m?.dispose?.();
@@ -10761,7 +11475,7 @@
             if (ren) { ren.dispose(); ren = null; }
             scene = cam = noteG = beatG = lblG = fretG = tuningLblG = null;
             ambLight = dirLight = null;
-            mStr = []; mGlow = []; mSus = []; mStrHitOutline = []; mAccentOutline = []; mAccentCore = []; mAccentHaloNear = []; mAccentHaloMid = []; mAccentHaloFar = []; _accentShellsByString = []; mWhiteOutline = mSusOutline = null; mMissOutline = null; mHitSusOutline = null; stringLines = []; stringLineGlows = [];
+            mStr = []; mGlow = []; mSus = []; mStrHitOutline = []; mAccentOutline = []; mAccentCore = []; mAccentHaloNear = []; mAccentHaloMid = []; mAccentHaloFar = []; _accentShellsByString = []; mWhiteOutline = mSusOutline = null; mMissOutline = null; mHitSusOutline = null; stringLines = []; stringLineGlows = []; fretWireMats = [];
             for (const m of _inlayMats) m?.dispose?.(); _inlayMats = []; _inlayLabels = [];
             // mTapChevron: dispose explicitly — if no tap marker ever
             // spawned a pooled mesh, the scene.traverse() pass above never
@@ -10804,6 +11518,7 @@
             _lookaheadCamPrevNow = null;
             _lookaheadLowBonusU = 0;
             _lookaheadHiNeckLatch = false;
+            _clkAudioT = NaN; _clkPerf = NaN; _clkRate = 1; _frameNow = 0;
             prevLowFretBonus = 0;
             prevLockActive = false;
             _camSnapped = false;
@@ -10975,7 +11690,7 @@
                     }
                 }
 
-                ren.render(scene, cam);
+                pbBeg(6); ren.render(scene, cam); pbEnd(6);
                 if (lyricsCtx && lyricsCanvas) {
                     lyricsCtx.clearRect(0, 0, lyricsCanvas.width, lyricsCanvas.height);
                     // Capture the actual lyrics-banner bottom so overlay cards

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -325,7 +325,7 @@
     const CAM_FRAME_DIST_NEAR = 93 * K;
     const CAM_FRAME_DIST_FAR  = 141 * K;
     const CAM_FRAME_H_NEAR = 0.75;
-    const CAM_FRAME_H_FAR  = 1.20;
+    const CAM_FRAME_H_FAR  = 1.00;
     const CAM_FRAME_D_NEAR = 0.575;
     const CAM_FRAME_D_FAR  = 0.60;
 

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -7301,6 +7301,20 @@
         function smoothNow(bundle) {
             const raw = bundle.currentTime;
             const p = performance.now();
+            // Host pause signal (slopsmith core's bundle.isPlaying): when the
+            // chart clock isn't advancing (paused / stalled / mid-seek), don't
+            // extrapolate forward against a frozen audio sample — that creeps
+            // the highway ahead by up to the interp cap and then snaps back
+            // when dt finally crosses 0.1. Re-anchor to raw so the next
+            // playing frame resumes from a clean segment. `=== false` so
+            // downlevel hosts (isPlaying undefined) fall through to the
+            // staleness-based cap below, preserving prior behavior there.
+            if (bundle.isPlaying === false) {
+                _clkAudioT = raw;
+                _clkPerf = p;
+                _clkRate = 1;
+                return (_frameNow = raw);
+            }
             if (raw !== _clkAudioT) {
                 // New audio sample — re-anchor and refine the rate estimate.
                 if (!Number.isNaN(_clkPerf)) {

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -310,7 +310,7 @@
     const N_RAD = 1.5 * K;
     const SW = 2 * K, SH = 1.5 * K;
 
-    const CAM_H_BASE = 175 * K;
+    const CAM_H_BASE = 180 * K;
     const CAM_DIST_BASE = 240 * K;
     const REF_ASPECT = 16 / 9;
     const FOCUS_D = 600 * K;
@@ -8091,6 +8091,15 @@
                     _lookaheadCamPrevNow = null;
                     _lookaheadLowBonusU = 0;
                     _lookaheadHiNeckLatch = false;
+                    // Drop the previous song's measure-start cache. Otherwise
+                    // lookaheadEndTime() would size the lookahead window off the
+                    // old measure grid (with the new song's now reset to ~0 this
+                    // yields a wrong/huge tEnd) until the new beats arrive and
+                    // rebuild it — the resulting huge fret span over-zooms the
+                    // first-data snap and stays latched. Clearing it falls back
+                    // to the seconds window for this frame; the rebuild repopulates
+                    // it next frame once bundle.beats is the new array.
+                    _measureStarts = []; _measureStartsRef = null;
                     // Drop the clock anchor so the new song's currentTime
                     // re-anchors cleanly instead of measuring a bogus rate
                     // across the seek-to-0 discontinuity.
@@ -11579,6 +11588,7 @@
             _lookaheadCamPrevNow = null;
             _lookaheadLowBonusU = 0;
             _lookaheadHiNeckLatch = false;
+            _measureStarts = []; _measureStartsRef = null;
             _clkAudioT = NaN; _clkPerf = NaN; _clkRate = 1; _frameNow = 0;
             prevLowFretBonus = 0;
             prevLockActive = false;

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -310,7 +310,7 @@
     const N_RAD = 1.5 * K;
     const SW = 2 * K, SH = 1.5 * K;
 
-    const CAM_H_BASE = 150 * K;
+    const CAM_H_BASE = 170 * K;
     const CAM_DIST_BASE = 240 * K;
     const REF_ASPECT = 16 / 9;
     const FOCUS_D = 600 * K;
@@ -11349,7 +11349,7 @@
                 (dist - CAM_FRAME_DIST_NEAR) / (CAM_FRAME_DIST_FAR - CAM_FRAME_DIST_NEAR)));
             const _hMul = CAM_FRAME_H_NEAR + (CAM_FRAME_H_FAR - CAM_FRAME_H_NEAR) * _zt;
             const _dMul = CAM_FRAME_D_NEAR + (CAM_FRAME_D_FAR - CAM_FRAME_D_NEAR) * _zt;
-            const shoulderOffset = (_leftyCached ? -1 : 1) * 15 * K;
+            const shoulderOffset = (_leftyCached ? -1 : 1) * 14 * K;
             cam.position.set(curX + shoulderOffset, h * _hMul, dist * _dMul);
 
             // Self-correcting look-at Y: project the fretboard's near-edge centre

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -316,6 +316,19 @@
     const FOCUS_D = 600 * K;
     const CAM_LERP_BASE = 0.02;
 
+    // Zoom-dependent framing — height (h*) and depth (dist*) multipliers
+    // applied to cam.position. Interpolated by `dist`:
+    //   NEAR = tight view (nut position, span<=4 -> dist~=93*K): lower/closer.
+    //   FAR  = wide view (midpoint fret 1<->20 -> dist~=141*K): higher/pulled back
+    //          to fit the whole neck.
+    // Outside this range the values clamp at the endpoints.
+    const CAM_FRAME_DIST_NEAR = 93 * K;
+    const CAM_FRAME_DIST_FAR  = 141 * K;
+    const CAM_FRAME_H_NEAR = 0.75;
+    const CAM_FRAME_H_FAR  = 1.20;
+    const CAM_FRAME_D_NEAR = 0.50;
+    const CAM_FRAME_D_FAR  = 0.60;
+
     // Camera-X targeting (issue #34). The visible AHEAD = 4.0 s window is
     // far too coarse for picking where the camera should sit — a single
     // 17th-fret bend 2.5 s away yanks tgtX several frets even though the
@@ -367,7 +380,8 @@
     // ── 3D preview: lookahead fret bounds + smoothed focal X / span ─────────
     /** User-selectable via `cameraMode`. Legacy `classic` in storage maps to `steady`. */
     const CAMERA_MODE_IDS = ['steady', 'lookahead'];
-    const CAM_LOOKAHEAD_SEC = 3.0;
+    const CAM_LOOKAHEAD_SEC = 3.0;       // fallback when no beats/measures are available
+    const CAM_LOOKAHEAD_MEASURES = 9;    // lookahead window = N measures ahead
     const CAM_FOCUS_BLEND_RATE = 0.7;
     const CAM_FRET_EDGE_BLEND = 0.1;
     const DEFAULT_LOOKAHEAD_FRET_SPAN = 4;
@@ -2065,6 +2079,11 @@
         // the same fret for the following measure, then allow it again).
         let _fretLabelAllowed = new Set();
         let _fretLabelNotesRef = null;
+        // Cache of measure-start times (beats with measure !== -1), rebuilt when
+        // the beats array changes. Drives the camera lookahead window
+        // (CAM_LOOKAHEAD_MEASURES measures instead of a fixed number of seconds).
+        let _measureStarts = [];
+        let _measureStartsRef = null;
         // Frame-level dedup: tracks which (40ms-rounded-time, fret) pairs have already
         // rendered a label this frame so that multiple strings at the same fret/onset
         // (arpeggio chords, synthetic chords) never produce stacked duplicate labels.
@@ -6296,8 +6315,30 @@
         }
 
         /* ── Lookahead fret bounds + smooth camera ───────────────────────── */
+        // End time of the lookahead window = start of the measure that is
+        // CAM_LOOKAHEAD_MEASURES measures ahead of the current one. Uses the
+        // _measureStarts cache (times of beats with measure !== -1). With no
+        // beats it falls back to CAM_LOOKAHEAD_SEC seconds. Past the last known
+        // measure it extrapolates using the average measure duration.
+        function lookaheadEndTime(now) {
+            const ms = _measureStarts;
+            if (!ms || ms.length === 0) return now + CAM_LOOKAHEAD_SEC;
+            // Binary search: lo = first index with ms[lo] > now.
+            let lo = 0, hi = ms.length;
+            while (lo < hi) { const mid = (lo + hi) >> 1; if (ms[mid] <= now) lo = mid + 1; else hi = mid; }
+            const curIdx = lo - 1;                       // current measure (-1 if before the first)
+            const targetIdx = curIdx + CAM_LOOKAHEAD_MEASURES;
+            if (targetIdx >= 0 && targetIdx < ms.length) return ms[targetIdx];
+            // Past the last measure: extrapolate using the average measure duration.
+            if (ms.length >= 2) {
+                const avg = (ms[ms.length - 1] - ms[0]) / (ms.length - 1);
+                if (avg > 0) return ms[ms.length - 1] + (targetIdx - (ms.length - 1)) * avg;
+            }
+            return now + CAM_LOOKAHEAD_SEC;
+        }
+
         function lookaheadComputeFretBounds(now, anchors, notes, chords) {
-            const tEnd = now + CAM_LOOKAHEAD_SEC;
+            const tEnd = lookaheadEndTime(now);
             let minF = 99;
             let maxF = 0;
             let any = false;
@@ -7584,6 +7625,20 @@
             if (notes !== _fretLabelNotesRef) {
                 _fretLabelAllowed = _buildFretLabelSet(notes, chords, beats);
                 _fretLabelNotesRef = notes;
+            }
+            // Rebuild the measure-start time cache whenever beats change. Only
+            // beats that begin a measure carry measure >= 0; intra-measure beats
+            // (measure === -1) are skipped. Drives the lookahead window.
+            if (beats !== _measureStartsRef) {
+                _measureStartsRef = beats;
+                const _ms = [];
+                if (beats) {
+                    for (let _bi = 0; _bi < beats.length; _bi++) {
+                        const _b = beats[_bi];
+                        if (_b && Number.isFinite(_b.measure) && _b.measure >= 0) _ms.push(_b.time);
+                    }
+                }
+                _measureStarts = _ms;
             }
             const sections = bundle.sections;
             const anchors = bundle.anchors;
@@ -11282,12 +11337,38 @@
         function camUpdate(bundle) {
             const bpm = computeBPM(bundle.beats, bundle.currentTime);
             const lerp = CAM_LERP_BASE * Math.max(bpm, 60) / 120;
+
+            // ── DEBUG: manual camera test (remove after tuning) ──────────────
+            // In the browser console:
+            //   window.h3dCamDebug = { forceFrets: [1, 20], hMul: 1.20, dMul: 0.60 };
+            // forceFrets pins the target at the midpoint between the two frets
+            // (reproduces the wide view without needing a song with that spread).
+            // Omitting hMul/dMul uses the zoom-based interpolation (CAM_FRAME_*).
+            // shoulderMul tweaks the lateral offset. Disable: window.h3dCamDebug = null;
+            const _dbg = window.h3dCamDebug || null;
+            if (_dbg && Array.isArray(_dbg.forceFrets)) {
+                const lo = _dbg.forceFrets[0], hi = _dbg.forceFrets[1];
+                tgtX = lookaheadTargetWorldX(lo, hi);
+                tgtDist = (camBaseDistU(hi - lo + 1) + camLowFretPullbackU(lo)) * K;
+            }
+
             curX += (tgtX - curX) * lerp;
             curDist += (tgtDist - curDist) * lerp;
             const dist = curDist * aspectScale;
             const h = CAM_H_BASE * (dist / CAM_DIST_BASE);
-            const shoulderOffset = (_leftyCached ? -1 : 1) * 20 * K;
-            cam.position.set(curX + shoulderOffset, h * 0.95, dist * 0.75);
+
+            // Zoom-interpolated framing multipliers: tight (NEAR) -> lower/closer;
+            // wide (FAR, fret 1<->20) -> higher/pulled back.
+            const _zt = Math.max(0, Math.min(1,
+                (dist - CAM_FRAME_DIST_NEAR) / (CAM_FRAME_DIST_FAR - CAM_FRAME_DIST_NEAR)));
+            const _hMulBase = CAM_FRAME_H_NEAR + (CAM_FRAME_H_FAR - CAM_FRAME_H_NEAR) * _zt;
+            const _dMulBase = CAM_FRAME_D_NEAR + (CAM_FRAME_D_FAR - CAM_FRAME_D_NEAR) * _zt;
+
+            const _hMul = (_dbg && _dbg.hMul != null) ? _dbg.hMul : _hMulBase;
+            const _dMul = (_dbg && _dbg.dMul != null) ? _dbg.dMul : _dMulBase;
+            const _shMul = (_dbg && _dbg.shoulderMul != null) ? _dbg.shoulderMul : 1;
+            const shoulderOffset = (_leftyCached ? -1 : 1) * 15 * K * _shMul;
+            cam.position.set(curX + shoulderOffset, h * _hMul, dist * _dMul);
 
             // Self-correcting look-at Y: project the fretboard's near-edge centre
             // to NDC space. If it drifts toward the frame edge, nudge tgtLookY

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -11338,20 +11338,6 @@
             const bpm = computeBPM(bundle.beats, bundle.currentTime);
             const lerp = CAM_LERP_BASE * Math.max(bpm, 60) / 120;
 
-            // ── DEBUG: manual camera test (remove after tuning) ──────────────
-            // In the browser console:
-            //   window.h3dCamDebug = { forceFrets: [1, 20], hMul: 1.20, dMul: 0.60 };
-            // forceFrets pins the target at the midpoint between the two frets
-            // (reproduces the wide view without needing a song with that spread).
-            // Omitting hMul/dMul uses the zoom-based interpolation (CAM_FRAME_*).
-            // shoulderMul tweaks the lateral offset. Disable: window.h3dCamDebug = null;
-            const _dbg = window.h3dCamDebug || null;
-            if (_dbg && Array.isArray(_dbg.forceFrets)) {
-                const lo = _dbg.forceFrets[0], hi = _dbg.forceFrets[1];
-                tgtX = lookaheadTargetWorldX(lo, hi);
-                tgtDist = (camBaseDistU(hi - lo + 1) + camLowFretPullbackU(lo)) * K;
-            }
-
             curX += (tgtX - curX) * lerp;
             curDist += (tgtDist - curDist) * lerp;
             const dist = curDist * aspectScale;
@@ -11361,13 +11347,9 @@
             // wide (FAR, fret 1<->20) -> higher/pulled back.
             const _zt = Math.max(0, Math.min(1,
                 (dist - CAM_FRAME_DIST_NEAR) / (CAM_FRAME_DIST_FAR - CAM_FRAME_DIST_NEAR)));
-            const _hMulBase = CAM_FRAME_H_NEAR + (CAM_FRAME_H_FAR - CAM_FRAME_H_NEAR) * _zt;
-            const _dMulBase = CAM_FRAME_D_NEAR + (CAM_FRAME_D_FAR - CAM_FRAME_D_NEAR) * _zt;
-
-            const _hMul = (_dbg && _dbg.hMul != null) ? _dbg.hMul : _hMulBase;
-            const _dMul = (_dbg && _dbg.dMul != null) ? _dbg.dMul : _dMulBase;
-            const _shMul = (_dbg && _dbg.shoulderMul != null) ? _dbg.shoulderMul : 1;
-            const shoulderOffset = (_leftyCached ? -1 : 1) * 15 * K * _shMul;
+            const _hMul = CAM_FRAME_H_NEAR + (CAM_FRAME_H_FAR - CAM_FRAME_H_NEAR) * _zt;
+            const _dMul = CAM_FRAME_D_NEAR + (CAM_FRAME_D_FAR - CAM_FRAME_D_NEAR) * _zt;
+            const shoulderOffset = (_leftyCached ? -1 : 1) * 15 * K;
             cam.position.set(curX + shoulderOffset, h * _hMul, dist * _dMul);
 
             // Self-correcting look-at Y: project the fretboard's near-edge centre

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -11349,7 +11349,7 @@
                 (dist - CAM_FRAME_DIST_NEAR) / (CAM_FRAME_DIST_FAR - CAM_FRAME_DIST_NEAR)));
             const _hMul = CAM_FRAME_H_NEAR + (CAM_FRAME_H_FAR - CAM_FRAME_H_NEAR) * _zt;
             const _dMul = CAM_FRAME_D_NEAR + (CAM_FRAME_D_FAR - CAM_FRAME_D_NEAR) * _zt;
-            const shoulderOffset = (_leftyCached ? -1 : 1) * 14 * K;
+            const shoulderOffset = (_leftyCached ? -1 : 1) * 13 * K;
             cam.position.set(curX + shoulderOffset, h * _hMul, dist * _dMul);
 
             // Self-correcting look-at Y: project the fretboard's near-edge centre

--- a/plugins/highway_3d/screen.js
+++ b/plugins/highway_3d/screen.js
@@ -2109,6 +2109,14 @@
         let _laneRailBoundsRefTpl = null;
         let _laneRailBoundsRefNotes = null;
         let _lastHwW = 0, _lastHwH = 0;
+        // Last logical (CSS px) size handed to applySize(). #highway is a
+        // flex:1 item, so its real rendered box (canvasSize()) can change as
+        // the player layout settles after a song opens WITHOUT the backing
+        // store (canvas.width) changing — which the _lastHwW/H check below
+        // would miss. Tracking the applied logical size lets draw() detect
+        // that CSS-box drift and re-frame, instead of the user having to
+        // un/re-maximize the window.
+        let _appliedW = 0, _appliedH = 0;
         let mBeatM = null, mBeatQ = null;
         let txtCache = {};
         // Cloned sprite materials cached on individual sprite instances
@@ -11408,6 +11416,7 @@
             cam.aspect = w / h;
             cam.updateProjectionMatrix();
             aspectScale = Math.max(1, REF_ASPECT / Math.max(cam.aspect, 0.5));
+            _appliedW = w; _appliedH = h;
         }
 
         /* ── Teardown ────────────────────────────────────────────────────── */
@@ -11738,14 +11747,29 @@
                     const s = canvasSize(highwayCanvas);
                     if (s.w > 0 && s.h > 0) applySize(s.w, s.h);
                 }
-                // Auto-resize lyricsCanvas when the highway canvas changes size.
-                // In splitscreen the hw.resize override resizes the canvas element
-                // but does not call renderer.resize(), so we detect the change here.
-                if (highwayCanvas && (highwayCanvas.width !== _lastHwW || highwayCanvas.height !== _lastHwH)) {
-                    _lastHwW = highwayCanvas.width;
-                    _lastHwH = highwayCanvas.height;
-                    const s = canvasSize(highwayCanvas);
-                    if (s.w > 0 && s.h > 0) applySize(s.w, s.h);
+                // Keep the render matched to the highway canvas's real box.
+                // Two independent drifts to catch each frame:
+                //  1. Backing store (canvas.width/height) changed out from under
+                //     us — e.g. the splitscreen hw.resize override resizes the
+                //     element but never calls renderer.resize(). Also re-sizes
+                //     the lyrics overlay canvas via applySize().
+                //  2. The CSS box (canvasSize()) drifted while the backing store
+                //     held. #highway is flex:1, so its rendered height changes as
+                //     the player layout settles right after a song opens — with
+                //     no backing-store change and no window 'resize' event, so the
+                //     check above never fires. Without this the camera stays framed
+                //     for the pre-settle (too-tall) size and crops the near strings
+                //     / fret numbers until the user un/re-maximizes the window.
+                if (highwayCanvas) {
+                    const box = canvasSize(highwayCanvas);
+                    if (highwayCanvas.width !== _lastHwW || highwayCanvas.height !== _lastHwH) {
+                        _lastHwW = highwayCanvas.width;
+                        _lastHwH = highwayCanvas.height;
+                        if (box.w > 0 && box.h > 0) applySize(box.w, box.h);
+                    } else if (box.w > 0 && box.h > 0 &&
+                            (Math.abs(box.w - _appliedW) > 1 || Math.abs(box.h - _appliedH) > 1)) {
+                        applySize(box.w, box.h);
+                    }
                 }
                 update(bundle);
                 camUpdate(bundle);
@@ -11920,6 +11944,7 @@
             destroy() {
                 _destroyed = true; _isReady = false; _diagChord = null; _diagPrev = null; _diagLastKey = null; _diagRenderCache.clear();
                 _lastHwW = 0; _lastHwH = 0;
+                _appliedW = 0; _appliedH = 0;
                 _unsubscribeFocus(); teardown();
                 highwayCanvas = null;
             },

--- a/static/highway.js
+++ b/static/highway.js
@@ -613,6 +613,18 @@ function createHighway() {
             currentTime,
             songInfo,
             isReady: ready,
+            // True while the chart clock is actively advancing; false when
+            // audio is paused / stalled / mid-seek (setTime has kept getting
+            // the same t for > _CHART_MAX_INTERP_MS). This is the same
+            // predicate getTime() uses to decide raw-vs-interpolated, and the
+            // no-anchor boot state reads as not-playing — matching getTime()
+            // returning raw chartTime there. Renderers that run their own
+            // sub-frame clock (highway_3d's smoothNow) gate on this to fall
+            // back to raw instead of extrapolating forward against a frozen
+            // audio sample. Undefined on downlevel hosts → those renderers
+            // keep their own staleness-based fallback.
+            isPlaying: !Number.isNaN(_chartAnchorPerfNow)
+                && (performance.now() - _chartLastAdvanceAt) <= _CHART_MAX_INTERP_MS,
 
             // Chart content (filter-aware — difficulty-filtered arrays
             // preferred; raw arrays are the fallback when no ladder data).

--- a/tests/js/highway_3d_camera_framing.test.js
+++ b/tests/js/highway_3d_camera_framing.test.js
@@ -1,0 +1,119 @@
+// Pins the camera framing + lookahead behaviour in
+// plugins/highway_3d/screen.js.
+//
+// Two independent pieces are covered:
+//   1. Zoom-dependent framing — the cam.position height/depth multipliers are
+//      interpolated by zoom distance between a NEAR (tight, nut-position) and a
+//      FAR (wide, whole-neck) view via the CAM_FRAME_* constants, instead of
+//      being fixed literals.
+//   2. Measure-based lookahead — the camera lookahead window spans
+//      CAM_LOOKAHEAD_MEASURES measures ahead (derived from the chart beats,
+//      ignoring intra-measure measure === -1 beats) instead of a fixed number
+//      of seconds.
+//
+// A refactor that re-hardcodes the framing multipliers, drops the measure
+// cache, or reverts the lookahead window to seconds would silently regress the
+// camera. Also guards that the temporary debug hook stayed removed.
+//
+// Source-level only — same strategy as the other tests/js/ files.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+const src = fs.readFileSync(SCREEN_JS, 'utf8');
+
+// ── Zoom-dependent framing ──────────────────────────────────────────────────
+
+test('framing NEAR/FAR multiplier constants are defined', () => {
+    for (const name of [
+        'CAM_FRAME_DIST_NEAR', 'CAM_FRAME_DIST_FAR',
+        'CAM_FRAME_H_NEAR', 'CAM_FRAME_H_FAR',
+        'CAM_FRAME_D_NEAR', 'CAM_FRAME_D_FAR',
+    ]) {
+        assert.match(src, new RegExp('const\\s+' + name + '\\s*='),
+            `${name} must be declared as a framing constant`);
+    }
+});
+
+test('cam.position uses interpolated framing multipliers, not literals', () => {
+    // The height/depth multipliers are computed (_hMul / _dMul), not inlined.
+    assert.match(
+        src,
+        /cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset\s*,\s*h\s*\*\s*_hMul\s*,\s*dist\s*\*\s*_dMul\s*\)/,
+        'cam.position.set must use the interpolated _hMul / _dMul multipliers',
+    );
+});
+
+test('framing multipliers are a clamped zoom-distance interpolation', () => {
+    // _zt is clamped to [0,1] and lerps each multiplier between NEAR and FAR.
+    assert.match(
+        src,
+        /Math\.max\(0,\s*Math\.min\(1,[\s\S]*?CAM_FRAME_DIST_NEAR[\s\S]*?CAM_FRAME_DIST_FAR/,
+        '_zt must clamp (dist - NEAR)/(FAR - NEAR) into [0,1]',
+    );
+    assert.match(
+        src,
+        /CAM_FRAME_H_NEAR\s*\+\s*\(\s*CAM_FRAME_H_FAR\s*-\s*CAM_FRAME_H_NEAR\s*\)\s*\*\s*_zt/,
+        'height multiplier must lerp NEAR->FAR by _zt',
+    );
+    assert.match(
+        src,
+        /CAM_FRAME_D_NEAR\s*\+\s*\(\s*CAM_FRAME_D_FAR\s*-\s*CAM_FRAME_D_NEAR\s*\)\s*\*\s*_zt/,
+        'depth multiplier must lerp NEAR->FAR by _zt',
+    );
+});
+
+// ── Measure-based lookahead window ──────────────────────────────────────────
+
+test('lookahead window is expressed in measures with a seconds fallback', () => {
+    assert.match(src, /const\s+CAM_LOOKAHEAD_MEASURES\s*=\s*9\b/,
+        'CAM_LOOKAHEAD_MEASURES must default to 9');
+    assert.match(src, /const\s+CAM_LOOKAHEAD_SEC\s*=\s*3\.0\b/,
+        'CAM_LOOKAHEAD_SEC must stay as the no-beats fallback');
+});
+
+test('measure-start cache only keeps beats with measure >= 0', () => {
+    // Intra-measure beats carry measure === -1 and must be skipped.
+    assert.match(
+        src,
+        /Number\.isFinite\(\s*_b\.measure\s*\)\s*&&\s*_b\.measure\s*>=\s*0[\s\S]*?_measureStarts\s*=\s*_ms/,
+        'only measure-start beats (measure >= 0) feed _measureStarts',
+    );
+});
+
+test('lookaheadEndTime targets the measure CAM_LOOKAHEAD_MEASURES ahead', () => {
+    assert.match(
+        src,
+        /function\s+lookaheadEndTime\s*\(\s*now\s*\)/,
+        'lookaheadEndTime(now) helper must exist',
+    );
+    assert.match(
+        src,
+        /const\s+targetIdx\s*=\s*curIdx\s*\+\s*CAM_LOOKAHEAD_MEASURES/,
+        'target measure index = current measure + CAM_LOOKAHEAD_MEASURES',
+    );
+    // No beats → seconds fallback.
+    assert.match(
+        src,
+        /if\s*\(\s*!ms\s*\|\|\s*ms\.length\s*===\s*0\s*\)\s*return\s+now\s*\+\s*CAM_LOOKAHEAD_SEC/,
+        'lookaheadEndTime must fall back to seconds when there are no measures',
+    );
+});
+
+test('fret-bounds scan drives its window off lookaheadEndTime, not fixed seconds', () => {
+    assert.match(
+        src,
+        /function\s+lookaheadComputeFretBounds[\s\S]*?const\s+tEnd\s*=\s*lookaheadEndTime\(\s*now\s*\)/,
+        'lookaheadComputeFretBounds must derive tEnd from lookaheadEndTime(now)',
+    );
+});
+
+// ── Debug hook stayed removed ───────────────────────────────────────────────
+
+test('temporary camera debug hook is not present', () => {
+    assert.doesNotMatch(src, /h3dCamDebug/,
+        'the window.h3dCamDebug tuning hook must not ship in the renderer');
+});

--- a/tests/js/highway_3d_camera_framing.test.js
+++ b/tests/js/highway_3d_camera_framing.test.js
@@ -111,6 +111,17 @@ test('fret-bounds scan drives its window off lookaheadEndTime, not fixed seconds
     );
 });
 
+test('measure-start cache is invalidated on song change', () => {
+    // The song-change reset (reconnect path) resets _camSnapped; it must also
+    // drop the measure-start cache, otherwise lookaheadEndTime sizes the window
+    // off the previous song's measure grid and over-zooms the first-data snap.
+    assert.match(
+        src,
+        /_camSnapped\s*=\s*false\s*;[\s\S]*?_measureStarts\s*=\s*\[\]\s*;\s*_measureStartsRef\s*=\s*null\s*;/,
+        'song-change reset must clear _measureStarts / _measureStartsRef alongside _camSnapped',
+    );
+});
+
 // ── Debug hook stayed removed ───────────────────────────────────────────────
 
 test('temporary camera debug hook is not present', () => {

--- a/tests/js/highway_3d_fret_label_render_order.test.js
+++ b/tests/js/highway_3d_fret_label_render_order.test.js
@@ -1,0 +1,176 @@
+// Pins the renderOrder of per-note fret connector labels and drop/connector
+// lines in plugins/highway_3d/screen.js.
+//
+// Problem: chord frame edges use a Z-proportional renderOrder
+//   chordBaseRO = Math.max(48, Math.round(700 + z / K) - 2)   →  range [48, 698]
+// Before this fix the fret connector labels used fixed values (15/16/22/23)
+// that are always below 48, so chord frame borders always overdrawn the gold
+// fret numbers below chord gems.
+//
+// Fix: all four elements now use _noteRO-based values (also Z-proportional):
+//   _noteRO       = Math.max(50, Math.round(700 + noteZ / K))  →  range [50, 700]
+//   chordBaseRO   = _noteRO - 2   (guaranteed by the formulas)
+//
+// New ordering (same note's Z):
+//   chordBaseRO       frame edge   (e.g. 698 at z=0)
+//   _noteRO - 1       connector line / drop line  (above frame, below gem)
+//   _noteRO           non-arp fret label / gem outline  (above frame)
+//   _noteRO + 1       arp fret label / gem core
+//   _noteRO + 2       TECH_RO — technique markers (PM cross, bend arrow, …)
+//
+// Source-level regex checks — no Three.js or DOM required.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+let _src;
+function src() {
+    if (!_src) _src = fs.readFileSync(SCREEN_JS, 'utf8');
+    return _src;
+}
+
+// ---------------------------------------------------------------------------
+// pConnectorLine — standalone notes only
+// ---------------------------------------------------------------------------
+
+test('connector line uses _noteRO-based renderOrder (non-arp: _noteRO-1, arp: _noteRO)', () => {
+    // Standalone-note connector: a thin vertical line from the label below the
+    // board up to the gem. Must be above chord frame border (chordBaseRO =
+    // _noteRO - 2) so it is not clipped by the frame edge of any chord that
+    // shares the same Z. Arpeggio gets +1 for intra-Z disambiguation.
+    assert.match(
+        src(),
+        /line\.renderOrder\s*=\s*_isArpNote\s*\?\s*_noteRO\s*:\s*_noteRO\s*-\s*1\s*;/,
+        'pConnectorLine renderOrder must be _isArpNote ? _noteRO : _noteRO - 1',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// pNoteFretLabel — primary fret number label below board
+// ---------------------------------------------------------------------------
+
+test('fret label (primary) uses _noteRO-based renderOrder (non-arp: _noteRO, arp: _noteRO+1)', () => {
+    // The gold fret number appearing below chord gems. Must be above the chord
+    // frame border of the same note (chordBaseRO = _noteRO - 2) so it is never
+    // overdrawn by the frame edge. Arpeggio gets +1 to stay above non-arp lines.
+    assert.match(
+        src(),
+        /fretLabel\.renderOrder\s*=\s*_isArpNote\s*\?\s*_noteRO\s*\+\s*1\s*:\s*_noteRO\s*;/,
+        'pNoteFretLabel renderOrder must be _isArpNote ? _noteRO + 1 : _noteRO',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// fl2 — synthetic chord-note fret label (skipBody path)
+// ---------------------------------------------------------------------------
+
+test('synthetic chord fret label (fl2) uses same _noteRO-based formula as primary', () => {
+    // fl2 renders the fret number for chord notes that went through the
+    // skipBody=true path. Same contract as the primary fretLabel block.
+    assert.match(
+        src(),
+        /fl2\.renderOrder\s*=\s*_isArp2\s*\?\s*_noteRO\s*\+\s*1\s*:\s*_noteRO\s*;/,
+        'fl2 renderOrder must be _isArp2 ? _noteRO + 1 : _noteRO',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// pDropLine — drop line for chord notes
+// ---------------------------------------------------------------------------
+
+test('drop line uses renderOrder _noteRO - 1, above frame (chordBaseRO) and below gem', () => {
+    // Chord notes draw a drop line from the gem down to the fretboard.
+    // _noteRO - 1 places it above the chord frame border (_noteRO - 2) but
+    // below the gem outline (_noteRO) so the gem stays visually dominant.
+    assert.match(
+        src(),
+        /dl\.renderOrder\s*=\s*_noteRO\s*-\s*1\s*;/,
+        'pDropLine renderOrder must be _noteRO - 1',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Relative-ordering invariants (structural)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// lbl — chord-loop fret number labels ("Chord fret numbers at the base of the highway")
+// ---------------------------------------------------------------------------
+
+test('chord-loop fret label (lbl) uses chordBaseRO + 1, above the frame edge', () => {
+    // The gold fret numbers rendered in the chord loop (one per unique fret in
+    // the chord shape) were using a hardcoded renderOrder = 21, which is always
+    // below chordBaseRO (min 48) — the frame edge overdrew the numbers.
+    // Fix: use chordBaseRO + 1 so the label is always 1 above the frame edge
+    // of its own chord, matching the relative ordering used by note labels.
+    assert.match(
+        src(),
+        /lbl\.renderOrder\s*=\s*chordBaseRO\s*\+\s*1\s*;/,
+        'chord-loop fret label (lbl) renderOrder must be chordBaseRO + 1',
+    );
+});
+
+test('no fixed low renderOrder assignments remain for fret labels or connector/drop lines', () => {
+    // Guard against regression: the old fixed values (15, 16, 21, 22, 23) must not
+    // appear as renderOrder assignments for any of the affected elements.
+    const s = src();
+
+    // fretLabel / fl2 at old fixed values
+    assert.doesNotMatch(
+        s,
+        /fretLabel\.renderOrder\s*=\s*(?:16|23)\s*;/,
+        'fretLabel must not use the old fixed renderOrder 16 or 23',
+    );
+    assert.doesNotMatch(
+        s,
+        /fl2\.renderOrder\s*=\s*(?:16|23)\s*;/,
+        'fl2 must not use the old fixed renderOrder 16 or 23',
+    );
+
+    // chord-loop label at old fixed value
+    assert.doesNotMatch(
+        s,
+        /lbl\.renderOrder\s*=\s*21\s*;/,
+        'chord-loop fret label (lbl) must not use the old fixed renderOrder 21',
+    );
+
+    // connector line at old fixed values
+    assert.doesNotMatch(
+        s,
+        /line\.renderOrder\s*=\s*_isArpNote\s*\?\s*22\s*:\s*15\s*;/,
+        'pConnectorLine must not use the old fixed renderOrder 22/15',
+    );
+
+    // drop line at old fixed value
+    assert.doesNotMatch(
+        s,
+        /dl\.renderOrder\s*=\s*22\s*;/,
+        'pDropLine must not use the old fixed renderOrder 22',
+    );
+});
+
+test('fret label RO (_noteRO) is above chord frame RO (chordBaseRO = _noteRO - 2)', () => {
+    // Numerical invariant: for any note at depth Z,
+    //   chordBaseRO = max(48, round(700 + z/K) - 2)
+    //   _noteRO     = max(50, round(700 + z/K))
+    //   _noteRO - chordBaseRO >= 2   always
+    // So fretLabel at _noteRO is always 2 above the chord frame edge.
+    // Verify the formulas carry the right constants.
+    const s = src();
+    assert.match(
+        s,
+        /const\s+chordBaseRO\s*=\s*Math\.max\(\s*48\s*,\s*Math\.round\(\s*700\s*\+\s*z\s*\/\s*K\s*\)\s*-\s*2\s*\)/,
+        'chordBaseRO formula must have floor 48 and -2 offset',
+    );
+    assert.match(
+        s,
+        /const\s+_noteRO\s*=\s*Math\.max\(\s*50\s*,\s*Math\.round\(\s*700\s*\+\s*noteZ\s*\/\s*K\s*\)\s*\)/,
+        '_noteRO formula must have floor 50 (= chordBaseRO floor 48 + 2)',
+    );
+    // Structural: floor(_noteRO) - floor(chordBaseRO) = 50 - 48 = 2
+    assert.strictEqual(50 - 48, 2, 'fret label floor (50) must be exactly 2 above frame floor (48)');
+});

--- a/tests/js/highway_3d_fret_row_labels.test.js
+++ b/tests/js/highway_3d_fret_row_labels.test.js
@@ -1,0 +1,80 @@
+// Pins the fret-row label visibility and color rules in
+// plugins/highway_3d/screen.js.
+//
+// Rules:
+//   1. Only main frets (DOTS: 3,5,7,9,12,…) show a gray label by default.
+//      Non-dot frets outside the anchor range are skipped entirely.
+//   2. Every fret inside the active anchor range [f0, f1] shows a gold label,
+//      even if it is not a dot fret.
+//      f0 = anchor.fret,  f1 = anchor.fret + anchor.width - 1
+//      e.g. { fret:3, width:4 } → 3,4,5,6 gold (4 is not a dot fret).
+//
+// Source-level regex checks — no Three.js or DOM required.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+let _src;
+function src() {
+    if (!_src) _src = fs.readFileSync(SCREEN_JS, 'utf8');
+    return _src;
+}
+
+test('fret row uses anchorPlayedFretSpanAt to get anchor range [f0, f1]', () => {
+    // anchorPlayedFretSpanAt returns { f0: anchor.fret, f1: anchor.fret+width-1 }.
+    // This is the correct span for note labels (the played zone), distinct from
+    // the wire span used by fret wires (anchorLaneBoundsAt: dMin=fret-1, dMax=fret+width-1).
+    assert.match(
+        src(),
+        /anchorPlayedFretSpanAt\(\s*anchors\s*,\s*now\s*\)/,
+        'fret row must call anchorPlayedFretSpanAt(anchors, now)',
+    );
+});
+
+test('non-main frets outside anchor range are skipped (continue)', () => {
+    // The loop must skip frets that are neither in the anchor range nor a
+    // DOTS (main) fret, so non-dot frets never show a gray ghost label.
+    assert.match(
+        src(),
+        /if\s*\(\s*!isInAnchor\s*&&\s*!isMainFret\s*\)\s*continue\s*;/,
+        'fret row loop must skip non-anchor non-dot frets with: if (!isInAnchor && !isMainFret) continue',
+    );
+});
+
+test('in-anchor frets use FRET_LABEL_GOLD_HEX color', () => {
+    assert.match(
+        src(),
+        /isInAnchor\s*\?\s*FRET_LABEL_GOLD_HEX\s*:\s*FRET_LABEL_IDLE_HEX/,
+        'fret row color must be FRET_LABEL_GOLD_HEX when in anchor, FRET_LABEL_IDLE_HEX otherwise',
+    );
+});
+
+test('in-anchor frets use opacity 1.0, idle frets use opacity 0.55', () => {
+    assert.match(
+        src(),
+        /lb\.material\.opacity\s*=\s*isInAnchor\s*\?\s*1\.0\s*:\s*0\.55\s*;/,
+        'fret row opacity must be 1.0 in anchor and 0.55 idle',
+    );
+});
+
+test('isMainFret uses DOTS.includes(f) — same dot positions as fret wires and inlays', () => {
+    // Main frets are the dot-inlay positions (3,5,7,9,12,15,17,19,21,24).
+    // Reusing DOTS keeps the visible set consistent across all fret indicators.
+    assert.match(
+        src(),
+        /const\s+isMainFret\s*=\s*DOTS\.includes\(\s*f\s*\)/,
+        'isMainFret must be defined as DOTS.includes(f)',
+    );
+});
+
+test('isInAnchor checks anchorSpan.f0 and anchorSpan.f1 inclusive bounds', () => {
+    assert.match(
+        src(),
+        /f\s*>=\s*anchorSpan\.f0\s*&&\s*f\s*<=\s*anchorSpan\.f1/,
+        'isInAnchor must check f >= anchorSpan.f0 && f <= anchorSpan.f1',
+    );
+});

--- a/tests/js/highway_3d_lean_sustain.test.js
+++ b/tests/js/highway_3d_lean_sustain.test.js
@@ -1,0 +1,82 @@
+// Pins the "lean sustain" rendering default in plugins/highway_3d/screen.js.
+//
+// Dense palm-mute / fret-hand-mute passages are GPU fill-bound: the
+// transparent sustain trails/rails stack many blended fragments. Profiling
+// (a pinned A/B loop) traced most of the cost to the additive rail BLOOM
+// halo, so by default the renderer skips ONLY the bloom (the most expensive
+// per-pixel layer) while KEEPING the thin trail/ribbon white outline that
+// gives tails their hit/miss-coloured border.
+//
+// A refactor that (a) flips the lean default off, (b) re-gates the trail or
+// ribbon outline behind the lean flag, or (c) stops feeding the outline the
+// hit/miss-aware material would silently regress the look or the perf win.
+//
+// Source-level only — same strategy as the other tests/js/ files.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+test('lean sustain rendering is the default (_leanSus starts true)', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /let\s+_leanSus\s*=\s*true\s*;/,
+        '_leanSus must default to true so lean rendering is the out-of-the-box behaviour',
+    );
+});
+
+test('the full-quality look is an opt-out via localStorage h3d_full_sus', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    assert.match(
+        src,
+        /_leanSus\s*=\s*localStorage\.getItem\(\s*['"]h3d_full_sus['"]\s*\)\s*!==\s*['"]1['"]/,
+        "lean must stay on unless localStorage.h3d_full_sus === '1' opts back into the full look",
+    );
+});
+
+test('exactly one element is gated behind the lean flag, and it is the rail bloom', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    // Only the additive rail bloom may hide behind the lean flag. If a future
+    // edit re-gates the trail or ribbon outline behind !_leanSus, this count
+    // climbs above 1 and the test fails — that's the regression guard.
+    const gates = src.match(/if\s*\(\s*!_leanSus\s*\)/g) || [];
+    assert.equal(
+        gates.length,
+        1,
+        'expected exactly one `if (!_leanSus)` gate (the rail bloom); the outline must stay ungated',
+    );
+    assert.match(
+        src,
+        /if\s*\(\s*!_leanSus\s*\)\s*\{[\s\S]{0,200}?pSusRailBloom\.get\(\)/,
+        'the single lean gate must be the one that wraps pSusRailBloom.get()',
+    );
+});
+
+test('the trail + ribbon outline always draw and use the hit/miss-aware material', () => {
+    const src = fs.readFileSync(SCREEN_JS, 'utf8');
+    // Outline material is hit/miss aware: miss -> mMissOutline, confirmed hit
+    // -> bright, otherwise the default mSusOutline white border.
+    assert.match(
+        src,
+        /_susOlMat\s*=\s*_ndState\s*===\s*'miss'\s*\?\s*mMissOutline[\s\S]*?:\s*mSusOutline\s*;/,
+        '_susOlMat must remain hit/miss aware so the tail border colours track note state',
+    );
+    // Box trail: the outline (trOut, pSusOutline) is drawn and fed _susOlMat,
+    // immediately followed by the coloured core (tr, pSus) — both ungated.
+    assert.match(
+        src,
+        /const\s+trOut\s*=\s*pSusOutline\.get\(\)\s*;[\s\S]*?trOut\.material\s*=\s*_susOlMat\s*;[\s\S]{0,400}?const\s+tr\s*=\s*pSus\.get\(\)/,
+        'the box-trail outline (pSusOutline + _susOlMat) must draw alongside the core trail',
+    );
+    // Ribbon trail (slide / bend / tremolo / vibrato): the outline (olMesh,
+    // pSusRibbonOl) is drawn and fed _susOlMat, then the ribbon body.
+    assert.match(
+        src,
+        /const\s+olMesh\s*=\s*pSusRibbonOl\.get\(\)\s*;[\s\S]*?olMesh\.material\s*=\s*_susOlMat\s*;[\s\S]*?const\s+body\s*=\s*pSusRibbon\.get\(\)/,
+        'the ribbon-trail outline (pSusRibbonOl + _susOlMat) must draw alongside the ribbon body',
+    );
+});

--- a/tests/js/highway_3d_lefty.test.js
+++ b/tests/js/highway_3d_lefty.test.js
@@ -71,7 +71,7 @@ test('draw(bundle) handles lefty changes by flipping camera X state and rebuildi
 test('camera shoulder offset follows the cached lefty orientation', () => {
     assert.match(
         src(SCREEN_JS),
-        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*20\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
+        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*15\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
         'camera shoulder offset must flip with _leftyCached',
     );
 });

--- a/tests/js/highway_3d_lefty.test.js
+++ b/tests/js/highway_3d_lefty.test.js
@@ -71,7 +71,7 @@ test('draw(bundle) handles lefty changes by flipping camera X state and rebuildi
 test('camera shoulder offset follows the cached lefty orientation', () => {
     assert.match(
         src(SCREEN_JS),
-        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*15\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
+        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*14\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
         'camera shoulder offset must flip with _leftyCached',
     );
 });

--- a/tests/js/highway_3d_lefty.test.js
+++ b/tests/js/highway_3d_lefty.test.js
@@ -71,7 +71,7 @@ test('draw(bundle) handles lefty changes by flipping camera X state and rebuildi
 test('camera shoulder offset follows the cached lefty orientation', () => {
     assert.match(
         src(SCREEN_JS),
-        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*13\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
+        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*10\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
         'camera shoulder offset must flip with _leftyCached',
     );
 });

--- a/tests/js/highway_3d_lefty.test.js
+++ b/tests/js/highway_3d_lefty.test.js
@@ -71,7 +71,7 @@ test('draw(bundle) handles lefty changes by flipping camera X state and rebuildi
 test('camera shoulder offset follows the cached lefty orientation', () => {
     assert.match(
         src(SCREEN_JS),
-        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*14\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
+        /const\s+shoulderOffset\s*=\s*\(\s*_leftyCached\s*\?\s*-1\s*:\s*1\s*\)\s*\*\s*13\s*\*\s*K\s*;[\s\S]*?cam\.position\.set\(\s*curX\s*\+\s*shoulderOffset/,
         'camera shoulder offset must flip with _leftyCached',
     );
 });

--- a/tests/js/highway_3d_render_order.test.js
+++ b/tests/js/highway_3d_render_order.test.js
@@ -1,0 +1,384 @@
+// Pins the renderOrder (RO) hierarchy in plugins/highway_3d/screen.js.
+//
+// Three.js renders transparent objects by renderOrder first, then back-to-front
+// Z sort within the same RO. All 3D-highway materials use depthTest:false, so
+// renderOrder is the *only* draw-order control — getting it wrong silently
+// causes one layer to bleed through another (gems clipping through chord frames,
+// strings buried under notes, etc.).
+//
+// Full hierarchy bottom → top:
+//
+//   -1   background stage traversal
+//    1   lane quads
+//    2   fret dividers
+//    4   sus-rail bloom (pSusRailBloom seed)           ← highway_3d_sustain_bloom.test.js
+//    5   sus-rail core (pSusRail seed)                 ← highway_3d_sustain_rail.test.js
+//    7   string-line glows (in-lane glow lines)
+//   14   board-projection frame
+//   [max(49, round(700+z/K)-1)]  fret-column markers (pFretColMarker) — between chord frame and gem
+//   [chordBaseRO-4]  chord fill interior (Z-proportional)
+//   [chordBaseRO-3.5] PM/FH X fill (Z-proportional)
+//   [chordBaseRO-3]  PM/FH X lines (Z-proportional)
+//   [chordBaseRO]    chord frame edges = max(48, round(700+z/K)-2)  → [48,698]
+//   [chordBaseRO+ε]  chord frame sub-layers (intra-chord 0.0003 step)
+//   [≤697.999]       sus-trail strip segments (Z-proportional, always < frame)
+//   [_noteRO]        note gem outline = max(50, round(700+noteZ/K)) → [50,700]
+//   [_noteRO+1]      note gem core
+//   [TECH_RO]        technique markers = _noteRO+2                  → [52,702]
+//   703              string mesh (drawn over gems but under fret wires)
+//   704              static fret wires (buildBoard T.Line — above strings, as on a real guitar)
+//   1000             technique labels, ghost-fret overlay
+//
+// Tests are source-level regex checks — no need to load Three.js or a DOM.
+//
+// Any PR that changes a renderOrder value must update the relevant test(s) here
+// and provide a visual justification in the PR description.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let _src;
+function src() {
+    if (!_src) _src = fs.readFileSync(SCREEN_JS, 'utf8');
+    return _src;
+}
+
+// ---------------------------------------------------------------------------
+// Static / fixed renderOrder values
+// ---------------------------------------------------------------------------
+
+test('lane quads use renderOrder 1', () => {
+    assert.match(
+        src(),
+        /lane\.renderOrder\s*=\s*1\s*;/,
+        'lane quads must use renderOrder = 1 (bottom-most visible layer)',
+    );
+});
+
+test('fret dividers use renderOrder 2', () => {
+    assert.match(
+        src(),
+        /div\.renderOrder\s*=\s*2\s*;/,
+        'fret dividers must use renderOrder = 2, above lane (1)',
+    );
+});
+
+test('string-line glows use renderOrder 7, above sus-rails (4/5)', () => {
+    // The in-lane string glow lines sit at 7 — above sus-rail bloom (4) and
+    // core (5) so the glow is visible, but below chord fill (chordBaseRO-4,
+    // min=44) so chord interiors don't disappear behind glow overdraw.
+    assert.match(
+        src(),
+        /line\.renderOrder\s*=\s*7\s*;/,
+        'string glow lines must use renderOrder = 7',
+    );
+});
+
+test('board-projection frame mesh uses renderOrder 14', () => {
+    // The fretboard projection plane sits above string glows (7) but below
+    // chord fill (min 44). Value 14 keeps it sandwiched cleanly.
+    assert.match(
+        src(),
+        /pSusRail\b[\s\S]{0,400}?m\.renderOrder\s*=\s*5\s*;|m\.renderOrder\s*=\s*14\s*;/,
+        'board-projection pool must seed meshes with renderOrder = 14',
+    );
+    // More targeted: the board projection pool assignment
+    const boardMatch = src().match(/m\.renderOrder\s*=\s*14\s*;/);
+    assert.ok(boardMatch, 'board projection mesh must be assigned renderOrder = 14');
+});
+
+test('string mesh in buildBoard uses renderOrder 703, above gem range [50,700]', () => {
+    // The physical string cylinders/planes rendered on the fretboard sit at
+    // 703 — above the note-gem ceiling (700) but below fret wires (704).
+    // This ensures strings are never occluded by flying gems.
+    assert.match(
+        src(),
+        /mesh\.renderOrder\s*=\s*703\s*;/,
+        'buildBoard string mesh must use renderOrder = 703',
+    );
+});
+
+test('static fret wires use BoxGeometry matching STR_THICK, renderOrder 704, depthTest: false, default gray 0x666688', () => {
+    // Fret wires are BoxGeometry bars with the same STR_THICK × STR_THICK
+    // cross-section as the string meshes — WebGL ignores linewidth > 1px so
+    // T.Line always renders as a hairline regardless of the value set.
+    // depthTest: false is required: the string BoxGeometry (MeshStandardMaterial,
+    // depthWrite:true default) writes depth at Z = +STR_THICK/2, so fret wires
+    // at Z=0 would fail the depth test at string pixels despite the higher RO.
+    const s = src();
+    assert.match(
+        s,
+        /new\s+T\.BoxGeometry\(\s*STR_THICK\s*,\s*wireH\s*,\s*STR_THICK\s*\)/,
+        'buildBoard fret wires must use BoxGeometry(STR_THICK, wireH, STR_THICK) to match string thickness',
+    );
+    assert.match(
+        s,
+        /new\s+T\.Mesh\(\s*g\s*,\s*mat\s*\)/,
+        'buildBoard fret wires must use T.Mesh (not T.Line)',
+    );
+    assert.match(
+        s,
+        /fw\.renderOrder\s*=\s*704\s*;/,
+        'buildBoard fret wire mesh must use renderOrder = 704',
+    );
+    assert.match(
+        s,
+        /color\s*:\s*0x666688[\s\S]{0,200}?depthTest\s*:\s*false|depthTest\s*:\s*false[\s\S]{0,200}?color\s*:\s*0x666688/,
+        'fret wire MeshBasicMaterial must have default color 0x666688 and depthTest: false',
+    );
+    assert.match(
+        s,
+        /fretWireMats\s*\[\s*f\s*\]\s*=\s*mat\s*;/,
+        'buildBoard must store each wire material in fretWireMats[f]',
+    );
+});
+
+test('update() sets fret wire gold (0xD8A636) for in-anchor frets, gray (0x666688) otherwise', () => {
+    // Uses anchorLaneBoundsAt() — the same helper the dynamic lane uses —
+    // so fret wire highlight aligns exactly with the lane edges:
+    //   dMin = fret - 1,  dMax = fret + width - 1
+    // Example: { fret: 3, width: 4 } → dMin=2, dMax=6 → wires 2..6 gold.
+    const s = src();
+    assert.match(
+        s,
+        /fretWireMats\.length/,
+        'update() must guard the per-frame fret wire loop on fretWireMats.length',
+    );
+    assert.match(
+        s,
+        /anchorLaneBoundsAt\(\s*anchors\s*,\s*now\s*\)/,
+        'update() must use anchorLaneBoundsAt(anchors, now) to get fret wire range',
+    );
+    assert.match(
+        s,
+        /_m\.color\.setHex\(\s*0xD8A636\s*\)/,
+        'update() must set gold 0xD8A636 for in-anchor fret wires',
+    );
+    assert.match(
+        s,
+        /_m\.color\.setHex\(\s*0x666688\s*\)/,
+        'update() must set gray 0x666688 for out-of-anchor fret wires',
+    );
+    assert.match(
+        s,
+        /_fwBounds\.dMin/,
+        'update() must use dMin from anchorLaneBoundsAt (= fret - 1)',
+    );
+    assert.match(
+        s,
+        /_fwBounds\.dMax/,
+        'update() must use dMax from anchorLaneBoundsAt (= fret + width - 1)',
+    );
+});
+
+test('fret-column markers use Z-proportional renderOrder between chord frame and gem', () => {
+    // pFretColMarker labels use max(49, round(700+z/K)-1) — one step above the
+    // chord frame border (chordBaseRO = max(48, round(700+z/K)-2)) and one step
+    // below the note gem (_noteRO = max(50, round(700+z/K))) at the same depth.
+    // This ensures chord frame borders never overdraw the label and the label
+    // never overdraws gems, at every Z position across the lookahead window.
+    assert.match(
+        src(),
+        /sp\.renderOrder\s*=\s*Math\.max\(\s*49\s*,\s*Math\.round\(\s*700\s*\+\s*z\s*\/\s*K\s*\)\s*-\s*1\s*\)\s*;/,
+        'pFretColMarker renderOrder must be Math.max(49, Math.round(700 + z / K) - 1)',
+    );
+});
+
+test('technique labels and ghost-fret overlay use renderOrder 1000', () => {
+    // 1000 is well above the entire Z-proportional range [48-702] and the
+    // string/cadence layer (703/704) — labels must always be readable.
+    const matches = src().match(/m\.renderOrder\s*=\s*1000\s*;/g) || [];
+    assert.ok(
+        matches.length >= 2,
+        'at least two renderOrder = 1000 assignments must exist (technique labels + ghost fret)',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Z-proportional formulas — chord frame / note gem / technique marker
+// ---------------------------------------------------------------------------
+
+test('chordBaseRO formula: max(48, round(700 + z/K) - 2)', () => {
+    // Per-chord frame renderOrder mirrors the note-gem scale but offset by -2
+    // so frame edges always render just below their own chord's gems while
+    // still drawing above gems from further-away chords.
+    // Floor 48 ensures frames always beat lane (1) and dividers (2).
+    // Ceiling: at z=0 → round(700)-2 = 698, which is 2 below gem ceiling (700).
+    assert.match(
+        src(),
+        /const\s+chordBaseRO\s*=\s*Math\.max\(\s*48\s*,\s*Math\.round\(\s*700\s*\+\s*z\s*\/\s*K\s*\)\s*-\s*2\s*\)/,
+        'chordBaseRO must be Math.max(48, Math.round(700 + z / K) - 2)',
+    );
+});
+
+test('_noteRO formula: max(50, round(700 + noteZ/K))', () => {
+    // Per-note gem renderOrder. noteZ is negative (ahead of hit line → negative
+    // Z in world space). At noteZ=0 (on the hit line) → 700; far notes → 50.
+    // Floor 50 keeps gems above chord frame floor (48) everywhere.
+    assert.match(
+        src(),
+        /const\s+_noteRO\s*=\s*Math\.max\(\s*50\s*,\s*Math\.round\(\s*700\s*\+\s*noteZ\s*\/\s*K\s*\)\s*\)/,
+        '_noteRO must be Math.max(50, Math.round(700 + noteZ / K))',
+    );
+});
+
+test('TECH_RO is _noteRO + 2, placing technique markers above gem core (_noteRO+1)', () => {
+    // Technique markers (PM cross, bend arrow, H/P chevron, etc.) must overlay
+    // the gem itself.  _noteRO+1 is the gem core; TECH_RO = _noteRO+2 clears it.
+    assert.match(
+        src(),
+        /const\s+TECH_RO\s*=\s*_noteRO\s*\+\s*2/,
+        'TECH_RO must equal _noteRO + 2',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Intra-chord layering (chord fill < PM/FH fill < PM/FH lines < frame edge)
+// ---------------------------------------------------------------------------
+
+test('chord fill interior uses chordBaseRO - 4', () => {
+    // The translucent chord-box fill sits 4 below the frame edge so the edge
+    // always wins when both cover the same pixel.
+    assert.match(
+        src(),
+        /fill\.renderOrder\s*=\s*chordBaseRO\s*-\s*4\s*;/,
+        'chord fill must use renderOrder = chordBaseRO - 4',
+    );
+});
+
+test('PM/FH X fill (pPMXFill / pFHXFill) uses chordBaseRO - 3.5', () => {
+    // The black background fill of the muted-note X symbol is above chord fill
+    // (-4) but below the X lines (-3) — same chord, so same chordBaseRO base.
+    const matches = src().match(/xf\.renderOrder\s*=\s*chordBaseRO\s*-\s*3\.5\s*;/g) || [];
+    assert.ok(
+        matches.length >= 2,
+        'both PM and FH X-fill meshes must set renderOrder = chordBaseRO - 3.5 (found ' + matches.length + ')',
+    );
+});
+
+test('PM/FH X lines (pMuteXLines / pFHXLines) use chordBaseRO - 3', () => {
+    // The coloured X stroke lines are above the black fill (-3.5) but below
+    // the chord frame border edge (chordBaseRO), so they don't escape the box.
+    const matches = src().match(/xl\.renderOrder\s*=\s*chordBaseRO\s*-\s*3\s*;/g) || [];
+    assert.ok(
+        matches.length >= 2,
+        'both PM and FH X-line meshes must set renderOrder = chordBaseRO - 3 (found ' + matches.length + ')',
+    );
+});
+
+test('chord frame edge sub-layers use chordBaseRO + 0.0003', () => {
+    // Individual box edges (top/bottom/left/right) get a tiny epsilon above
+    // chordBaseRO so intra-chord edge overdraw is deterministic.
+    assert.match(
+        src(),
+        /b\.renderOrder\s*=\s*chordBaseRO\s*\+\s*0\.0003\s*;/,
+        'chord frame edge slabs must use renderOrder = chordBaseRO + 0.0003',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Sustain-trail strip & ribbon — always below chord frame of same depth
+// ---------------------------------------------------------------------------
+
+test('sus-trail strip RO formula keeps trails strictly below chord frames at same Z', () => {
+    // The -0.001 ensures trails (≤ 697.999) never reach a chord frame at the
+    // same Z (chordBaseRO uses integer Math.round → 698 at z=0).
+    // Math.min(0, zCenter) clamps past-hit segments so they stay ≤ 697.999.
+    assert.match(
+        src(),
+        /const\s+_ro\s*=\s*Math\.max\(\s*47\.999\s*,\s*Math\.round\(\s*700\s*\+\s*Math\.min\(\s*0\s*,\s*zCenter\s*\)\s*\/\s*K\s*\)\s*-\s*2\s*\)\s*-\s*0\.001\s*;/,
+        'sus-trail strip _ro must be Math.max(47.999, Math.round(700 + Math.min(0, zCenter) / K) - 2) - 0.001',
+    );
+});
+
+test('sus-trail ribbon RO formula mirrors strip formula using time-based depth', () => {
+    // Ribbons use _ribDt (time from now to ribbon midpoint) converted to the
+    // same Z scale (×200 = TS/K) — matching how noteZ is computed — minus 2
+    // and -0.001 so ribbons stay below chord frames at the same depth.
+    assert.match(
+        src(),
+        /const\s+_ribRO\s*=\s*Math\.max\(\s*47\.999\s*,\s*Math\.round\(\s*700\s*-\s*_ribDt\s*\*\s*200\s*\)\s*-\s*2\s*\)\s*-\s*0\.001\s*;/,
+        'sus-trail ribbon _ribRO must be Math.max(47.999, Math.round(700 - _ribDt * 200) - 2) - 0.001',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Note gem ordering (outline < core, both driven by _noteRO)
+// ---------------------------------------------------------------------------
+
+test('note gem outline uses renderOrder = _noteRO', () => {
+    assert.match(
+        src(),
+        /outline\.renderOrder\s*=\s*_noteRO\s*;/,
+        'note gem outline must use renderOrder = _noteRO',
+    );
+});
+
+test('note gem core uses renderOrder = _noteRO + 1, above outline', () => {
+    assert.match(
+        src(),
+        /core\.renderOrder\s*=\s*_noteRO\s*\+\s*1\s*;/,
+        'note gem core must use renderOrder = _noteRO + 1',
+    );
+});
+
+// ---------------------------------------------------------------------------
+// Key relative-ordering invariants (derived constants)
+// ---------------------------------------------------------------------------
+
+test('chordBaseRO floor (48) is below _noteRO floor (50)', () => {
+    // Chord frames must always render below note gems, even at maximum depth
+    // (far end of the lookahead). Floor 48 < floor 50 guarantees this.
+    //
+    // Verified structurally: Math.max(48, ...) vs Math.max(50, ...) — the
+    // regex below just confirms both floors are present and in the right order
+    // by checking chordBaseRO (48) precedes _noteRO (50) in the source.
+    const s = src();
+    const cbIdx = s.search(/const\s+chordBaseRO\s*=\s*Math\.max\(\s*48/);
+    const nrIdx = s.search(/const\s+_noteRO\s*=\s*Math\.max\(\s*50/);
+    assert.ok(cbIdx !== -1, 'chordBaseRO formula with floor 48 must exist');
+    assert.ok(nrIdx !== -1, '_noteRO formula with floor 50 must exist');
+    // chordBaseRO is declared inside the chord loop (update()); _noteRO inside
+    // drawNote() — chord loop always comes first in the file.
+    assert.ok(cbIdx < nrIdx, 'chordBaseRO (floor 48) must be declared before _noteRO (floor 50) in source');
+});
+
+test('string mesh RO (703) is above gem ceiling (700) and below TECH_RO / labels (1000)', () => {
+    // 703 > 700: strings are never occluded by the tallest possible gem.
+    // 703 < 1000: technique labels and ghost-fret overlays still appear above strings.
+    const s = src();
+    assert.match(s, /mesh\.renderOrder\s*=\s*703\s*;/, 'string mesh must be 703');
+    // Confirm 1000 also exists (labels above strings)
+    assert.match(s, /m\.renderOrder\s*=\s*1000\s*;/, 'technique label RO 1000 must exist');
+    // Numerical check: 703 < 1000 — trivially true but documents intent
+    assert.ok(703 < 1000, 'string mesh RO must be below technique label RO');
+});
+
+test('fret-column marker RO is above chord frame floor (48) and below gem floor (50)', () => {
+    // Structural invariant for the Z-proportional formula max(49, round(700+z/K)-1):
+    // floor = 49, which is > chordBaseRO floor (48) and < _noteRO floor (50).
+    assert.ok(49 > 48, 'fret-column marker floor (49) must be above chord frame floor (48)');
+    assert.ok(49 < 50, 'fret-column marker floor (49) must be below gem floor (50)');
+    assert.match(
+        src(),
+        /Math\.max\(\s*49\s*,\s*Math\.round\(\s*700\s*\+\s*z\s*\/\s*K\s*\)\s*-\s*1\s*\)/,
+        'pFretColMarker formula must use floor 49 and offset -1',
+    );
+});
+
+test('static fret wire RO (704) is above string mesh (703) and gem ceiling (700)', () => {
+    // Structural invariant: fret wires must always draw after (on top of) strings.
+    assert.ok(704 > 703, 'fret wire (704) must be above string mesh (703)');
+    assert.ok(704 > 700, 'fret wire (704) must be above gem ceiling (700)');
+    assert.ok(704 < 1000, 'fret wire (704) must be below technique labels (1000)');
+    assert.match(src(), /fw\.renderOrder\s*=\s*704\s*;/, 'buildBoard fret wire must be 704');
+    assert.match(src(), /mesh\.renderOrder\s*=\s*703\s*;/, 'string mesh must be 703');
+});

--- a/tests/js/highway_3d_render_order.test.js
+++ b/tests/js/highway_3d_render_order.test.js
@@ -85,13 +85,16 @@ test('string-line glows use renderOrder 7, above sus-rails (4/5)', () => {
 test('board-projection frame mesh uses renderOrder 14', () => {
     // The fretboard projection plane sits above string glows (7) but below
     // chord fill (min 44). Value 14 keeps it sandwiched cleanly.
+    // Anchor to the board-projection pool (projMeshArr = activePalette.map(...))
+    // so the assertion only passes when THAT block seeds renderOrder = 14 —
+    // not any unrelated renderOrder = 14 elsewhere in the source.
+    const boardProjRO = /projMeshArr\s*=\s*activePalette\.map\b[\s\S]{0,1200}?m\.renderOrder\s*=\s*14\s*;/;
     assert.match(
         src(),
-        /pSusRail\b[\s\S]{0,400}?m\.renderOrder\s*=\s*5\s*;|m\.renderOrder\s*=\s*14\s*;/,
-        'board-projection pool must seed meshes with renderOrder = 14',
+        boardProjRO,
+        'board-projection pool (projMeshArr) must seed meshes with renderOrder = 14',
     );
-    // More targeted: the board projection pool assignment
-    const boardMatch = src().match(/m\.renderOrder\s*=\s*14\s*;/);
+    const boardMatch = src().match(boardProjRO);
     assert.ok(boardMatch, 'board projection mesh must be assigned renderOrder = 14');
 });
 

--- a/tests/js/highway_3d_render_order.test.js
+++ b/tests/js/highway_3d_render_order.test.js
@@ -71,6 +71,16 @@ test('fret dividers use renderOrder 2', () => {
     );
 });
 
+test('fret inlay dots use renderOrder 3, above lane (1) and dividers (2)', () => {
+    // The translucent lane would otherwise paint over and hide the inlay.
+    // The dots must draw after the lane/dividers but stay below strings (703).
+    assert.match(
+        src(),
+        /d\.renderOrder\s*=\s*3\s*;/,
+        'fret inlay dots must use renderOrder = 3 so the lane no longer hides them',
+    );
+});
+
 test('string-line glows use renderOrder 7, above sus-rails (4/5)', () => {
     // The in-lane string glow lines sit at 7 — above sus-rail bloom (4) and
     // core (5) so the glow is visible, but below chord fill (chordBaseRO-4,

--- a/tests/js/highway_3d_resize_reframe.test.js
+++ b/tests/js/highway_3d_resize_reframe.test.js
@@ -1,0 +1,92 @@
+// Pins the auto-reframe-on-layout-settle behaviour in
+// plugins/highway_3d/screen.js.
+//
+// Bug it guards against: when a song opens, the player screen may not have
+// its final dimensions yet (controls / sections bar still laying out). The
+// highway canvas is `#highway { flex: 1; min-height: 0 }`, so its real
+// rendered box (canvasSize() via getBoundingClientRect) is temporarily too
+// tall — applySize() then frames cam.aspect for the wrong height and the
+// camera crops the near strings / fret-number row. Once the layout settles
+// the flex box shrinks to the correct size, but the backing store
+// (canvas.width/height) does NOT change, so the splitscreen-oriented
+// `_lastHwW/_lastHwH` check never fires and the framing stays wrong until the
+// user un/re-maximizes the window (which fires a real `resize`).
+//
+// The fix makes draw() additionally compare the live canvas box against the
+// last logical size handed to applySize() (_appliedW/_appliedH) and re-apply
+// on >1px drift even when the backing store is unchanged. A refactor that
+// drops the CSS-box comparison, stops recording _appliedW/_appliedH, or
+// reverts to backing-store-only detection would silently bring the bug back.
+//
+// Source-level only — same strategy as the other tests/js/ files.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SCREEN_JS = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+const src = fs.readFileSync(SCREEN_JS, 'utf8');
+
+// ── Applied-size tracking ───────────────────────────────────────────────────
+
+test('the last applied logical size is tracked as instance state', () => {
+    assert.match(
+        src,
+        /let\s+_appliedW\s*=\s*0\s*,\s*_appliedH\s*=\s*0\s*;/,
+        '_appliedW / _appliedH must be declared as per-instance state',
+    );
+});
+
+test('applySize records the logical w/h it applied', () => {
+    // Recorded right after the aspect/aspectScale update so the draw() drift
+    // check can compare against the size actually framed for.
+    assert.match(
+        src,
+        /aspectScale\s*=\s*Math\.max\(1,[\s\S]*?_appliedW\s*=\s*w\s*;\s*_appliedH\s*=\s*h\s*;/,
+        'applySize must set _appliedW = w; _appliedH = h after computing aspectScale',
+    );
+});
+
+// ── draw() re-frames on CSS-box drift ───────────────────────────────────────
+
+test('draw() reads the live canvas box once per frame', () => {
+    assert.match(
+        src,
+        /const\s+box\s*=\s*canvasSize\(\s*highwayCanvas\s*\)\s*;/,
+        'draw() must sample canvasSize(highwayCanvas) for the live box',
+    );
+});
+
+test('backing-store drift branch is preserved (splitscreen path)', () => {
+    // The original check that catches the splitscreen hw.resize override
+    // resizing the element without calling renderer.resize() must remain.
+    assert.match(
+        src,
+        /if\s*\(\s*highwayCanvas\.width\s*!==\s*_lastHwW\s*\|\|\s*highwayCanvas\.height\s*!==\s*_lastHwH\s*\)\s*\{\s*_lastHwW\s*=\s*highwayCanvas\.width\s*;\s*_lastHwH\s*=\s*highwayCanvas\.height\s*;\s*if\s*\(\s*box\.w\s*>\s*0\s*&&\s*box\.h\s*>\s*0\s*\)\s*applySize\(\s*box\.w\s*,\s*box\.h\s*\)\s*;/,
+        'the backing-store (canvas.width/height) drift branch must still re-apply',
+    );
+});
+
+test('draw() re-applies on CSS-box drift even without a backing-store change', () => {
+    // The else-if branch: backing store unchanged, but the flex box drifted
+    // from the last applied logical size by more than 1px → re-frame. This is
+    // the branch that fixes the open-song crop without a manual window resize.
+    assert.match(
+        src,
+        /else if\s*\(\s*box\.w\s*>\s*0\s*&&\s*box\.h\s*>\s*0\s*&&\s*\(\s*Math\.abs\(\s*box\.w\s*-\s*_appliedW\s*\)\s*>\s*1\s*\|\|\s*Math\.abs\(\s*box\.h\s*-\s*_appliedH\s*\)\s*>\s*1\s*\)\s*\)\s*\{\s*applySize\(\s*box\.w\s*,\s*box\.h\s*\)\s*;/,
+        'draw() must re-apply when the live box drifts >1px from _appliedW/_appliedH',
+    );
+});
+
+// ── Lifecycle reset ─────────────────────────────────────────────────────────
+
+test('destroy() resets the applied-size tracking', () => {
+    // Instances are reused across songs (destroy() → init()); stale applied
+    // dims would suppress the first reframe of the next song.
+    assert.match(
+        src,
+        /_appliedW\s*=\s*0\s*;\s*_appliedH\s*=\s*0\s*;/,
+        'destroy() must reset _appliedW / _appliedH to 0',
+    );
+});

--- a/tests/js/highway_3d_smooth_clock_pause.test.js
+++ b/tests/js/highway_3d_smooth_clock_pause.test.js
@@ -1,0 +1,82 @@
+// Source-level guards for the smoothNow() pause-drift fix.
+//
+// smoothNow() interpolates bundle.currentTime forward with performance.now()
+// between distinct audio samples. Before this fix it only stopped once the
+// interpolation cap (dt > 0.1 s) was crossed, so for the first ~100 ms of a
+// pause the 3D highway crept forward against a frozen audio clock and then
+// snapped back to raw — a visible twitch on every pause.
+//
+// The fix wires a host pause signal (slopsmith core's bundle.isPlaying) into
+// smoothNow: when the chart clock is not advancing, return raw immediately
+// and re-anchor. These tests lock in both halves of the contract by
+// inspecting source (the createHighway / renderer closures own WebGL + audio
+// lifecycle that's too heavy to execute in a vm sandbox — same approach as
+// the other highway source-guard tests in this dir).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const highwayJs = path.join(__dirname, '..', '..', 'static', 'highway.js');
+const highway3dJs = path.join(__dirname, '..', '..', 'plugins', 'highway_3d', 'screen.js');
+
+// Brace-balanced extraction (same helper shape as highway_note_state.test.js).
+function extractBlock(src, signature) {
+    const start = src.indexOf(signature);
+    assert.ok(start !== -1, `signature '${signature}' not found`);
+    const openBrace = src.indexOf('{', start);
+    assert.ok(openBrace !== -1, `opening brace after '${signature}' not found`);
+    let depth = 1;
+    let i = openBrace + 1;
+    while (i < src.length && depth > 0) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') depth--;
+        i++;
+    }
+    assert.ok(depth === 0, `unbalanced braces after '${signature}'`);
+    return src.slice(start, i);
+}
+
+test('core _makeBundle exposes isPlaying derived from the chart-clock anchor', () => {
+    const src = fs.readFileSync(highwayJs, 'utf8');
+    const fn = extractBlock(src, 'function _makeBundle()');
+    // Field present in the bundle.
+    assert.match(fn, /\bisPlaying\s*:/, 'bundle must expose isPlaying');
+    // It is computed from the same anchor/advance state getTime() uses, not a
+    // hardcoded literal — anchor must exist AND the clock must have advanced
+    // within the interp cap.
+    assert.match(
+        fn,
+        /isPlaying\s*:\s*!Number\.isNaN\(\s*_chartAnchorPerfNow\s*\)/,
+        'isPlaying must gate on a live anchor (_chartAnchorPerfNow not NaN)',
+    );
+    assert.match(
+        fn,
+        /_chartLastAdvanceAt\s*\)\s*<=\s*_CHART_MAX_INTERP_MS/,
+        'isPlaying must require the clock advanced within _CHART_MAX_INTERP_MS',
+    );
+});
+
+test('smoothNow returns raw and re-anchors when the host reports not playing', () => {
+    const src = fs.readFileSync(highway3dJs, 'utf8');
+    const fn = extractBlock(src, 'function smoothNow(bundle)');
+    // Strict === false so downlevel hosts (isPlaying undefined) fall through
+    // to the existing staleness-based interpolation cap.
+    const guardIdx = fn.search(/bundle\.isPlaying\s*===\s*false/);
+    assert.ok(guardIdx !== -1, 'smoothNow must check bundle.isPlaying === false');
+
+    // The pause branch re-anchors the clock state and returns the raw sample
+    // (no forward extrapolation).
+    const branch = fn.slice(guardIdx);
+    assert.match(branch, /_clkAudioT\s*=\s*raw/, 'pause branch must re-anchor _clkAudioT to raw');
+    assert.match(branch, /_clkPerf\s*=\s*p/, 'pause branch must re-anchor _clkPerf to now');
+    assert.match(branch, /return\s*\(\s*_frameNow\s*=\s*raw\s*\)/, 'pause branch must return raw');
+
+    // The pause gate must come before the new-sample re-anchor / interpolation
+    // path so a frozen clock never extrapolates forward.
+    const newSampleIdx = fn.search(/if\s*\(\s*raw\s*!==\s*_clkAudioT\s*\)/);
+    assert.ok(newSampleIdx !== -1, 'smoothNow new-sample branch not found');
+    assert.ok(guardIdx < newSampleIdx, 'isPlaying pause gate must precede the interpolation path');
+});

--- a/tests/js/highway_3d_sustain_bloom.test.js
+++ b/tests/js/highway_3d_sustain_bloom.test.js
@@ -37,13 +37,13 @@ test('the bloom rail material uses additive blending', () => {
     );
 });
 
-test('the bloom pool seeds meshes at renderOrder 14, behind the core rail (16)', () => {
-    // renderOrder 10 keeps the bloom behind the core sustain rail (11) so the
+test('the bloom pool seeds meshes at renderOrder 4, behind the core rail (5)', () => {
+    // renderOrder 4 keeps the bloom behind the core sustain rail (5) so the
     // glow reads as a trail rather than occluding the rail.
     const src = fs.readFileSync(SCREEN_JS, 'utf8');
     assert.match(
         src,
-        /pSusRailBloom\s*=\s*pool\([^)]*,\s*\(\)\s*=>\s*\{[\s\S]*?m\.renderOrder\s*=\s*10\s*;[\s\S]*?\}\s*\)/,
-        'pSusRailBloom pool must seed meshes with renderOrder = 10',
+        /pSusRailBloom\s*=\s*pool\([^)]*,\s*\(\)\s*=>\s*\{[\s\S]*?m\.renderOrder\s*=\s*4\s*;[\s\S]*?\}\s*\)/,
+        'pSusRailBloom pool must seed meshes with renderOrder = 4',
     );
 });

--- a/tests/js/highway_3d_sustain_rail.test.js
+++ b/tests/js/highway_3d_sustain_rail.test.js
@@ -35,14 +35,15 @@ test('sustain rails pick arpeggio color for arpeggio frames, teal otherwise', ()
     );
 });
 
-test('sustain-rail pool meshes keep renderOrder 16 so note gems (20/21) stay on top', () => {
-    // renderOrder 11 sits above the chord frame edges but below note
-    // outline/core. Bumping it past the notes would let the rails
-    // occlude flying gems.
+test('sustain-rail pool meshes keep renderOrder 5 so strings (7) stay on top', () => {
+    // renderOrder 5 sits below string-line glows (7) so strings render on top
+    // of the rail. Chord frame edges are Z-proportional [48,698] and note gems
+    // are Z-proportional [50,700], so the flat seed value does not conflict —
+    // emitSusStrip() assigns its own Z-proportional RO per segment at draw time.
     const src = fs.readFileSync(SCREEN_JS, 'utf8');
     assert.match(
         src,
-        /pSusRail\s*=\s*pool\([^)]*,\s*\(\)\s*=>\s*\{[\s\S]*?m\.renderOrder\s*=\s*11\s*;[\s\S]*?\}\s*\)/,
-        'pSusRail pool must seed meshes with renderOrder = 11',
+        /pSusRail\s*=\s*pool\([^)]*,\s*\(\)\s*=>\s*\{[\s\S]*?m\.renderOrder\s*=\s*5\s*;[\s\S]*?\}\s*\)/,
+        'pSusRail pool must seed meshes with renderOrder = 5',
     );
 });


### PR DESCRIPTION
## Summary

Reworks the 3D Highway renderer's depth/render-order pipeline and adds visual and performance improvements.

## 🎨 Visual changes

- **Per-string gradient gems** — each string now uses its own `BoxGeometry` with a per-vertex color attribute, sampled from the Rocksmith color PNGs (top highlight → deeper bottom). White material + `vertexColors:true` so the gradient shows pure.
- **Fret-wire anchor highlight** — fret wires inside the active anchor range turn gold (`0xD8A636`), aligned exactly to the dynamic lane edges via `laneBoundsFromAnchor()`; the rest stay gray (`0x666688`).
- **Per-note fret-number labels** — standalone notes and arpeggio/synth-chord notes show the fret number, with a lookahead scale ramp (2× at max lookahead → 1× at the hit line) and string-colored half-length drop lines.
- **Fret labels at the base of the highway** — one number per unique fretted position on non-repeated chords.

## ⚙️ Render-order overhaul (overdraw fix)

Replaces the old small-constant `renderOrder` scheme (7/10/11/17/18/19) with a **Z-depth-proportional** scheme, so distant notes/frames no longer overdraw nearer elements:

- Gems: `_noteRO = max(50, round(700 + noteZ/K))` → range `[50, 700]`
- Gem outline: `_noteRO`; gem core: `_noteRO + 1`; technique markers: `TECH_RO = _noteRO + 2`
- Chord frames: `chordBaseRO = max(48, round(700 + z/K) - 2)` → range `[48, 698]`, always below gems
- Sustain trails/ribbons: kept strictly below chord frames at the same Z
- String mesh: `703`; fret wires: `704`; technique/ghost-fret labels: `1000`
- **Fret inlay dots** — raised to `renderOrder = 3` (above the lane at `1` and its dividers at `2`, below strings/wires/notes) so the translucent dynamic lane no longer paints over and hides the inlays.

## 🚀 Performance

- **`InstancedMesh` batching for PM/FH-X markers and chord strum indicators** — replaces the `pPMXFill`/`pMuteXLines`/`pFHXFill`/`pFHXLines` pools and `pTechPlane` entries, collapsing O(visible-muted-notes) draw calls to ~2 per type (shared `ShaderMaterial`, `instanceColor`/`instanceAlpha`).
- **Low-overdraw sustain rendering (new default)** — on fill-bound dense palm-mute / fret-hand-mute passages the transparent sustain trails/rails stack many blended fragments. Profiling identified the additive **rail bloom halo** (wide gaussian planes + additive blending) as the dominant per-pixel cost, so the lean default drops **only the rail bloom**. The trail/ribbon white **outline** is kept — it's a thin, cheap layer that gives tails their border — along with all trail/rail cores, so sustains stay clearly visible with their outline intact. Net ~7.5→5.9 ms `ren.render()` p50 (~107→134 fps) in a pinned A/B loop. Opt back into the full look (re-enable the rail bloom) per browser: `localStorage.h3d_full_sus = '1'`.
- **Sub-frame clock smoothing (`smoothNow`)** — `bundle.currentTime` only updates every ~20–23 ms (coarser than a 60/144 Hz frame), causing scroll stutter. `smoothNow()` interpolates with `performance.now()` between distinct samples, tracks the observed playback rate (keeps the speed slider accurate), and falls back to the raw value on pause/seek/stall. Notes and camera share one clock.

## 🏷️ Fret-label dedup

- **Per-(time, fret) measure-skip visibility cache** — shows only the first note of a given fret in a measure, suppresses it for the following measure, then allows it again.
- **Per-frame dedup** (40 ms buckets) — multiple strings at the same onset/fret (arpeggios, synthetic chords) never stack duplicate labels.

## 🎥 Camera framing & lookahead

- **Zoom-dependent framing** — the camera's height (`h*`) and depth (`dist*`) multipliers are now interpolated by zoom distance instead of being fixed constants. Tight nut-position views sit lower and closer (`h*0.75`, `dist*0.575` at `dist≈93·K`); as the played fret span widens the camera rises and pulls back (`h*1.00`, `dist*0.60` at `dist≈141·K`, the fret 1↔20 midpoint), clamped at both ends. Keeps the whole-neck case in frame without flattening the close-up view. Driven by the new `CAM_FRAME_*` constants.
- **Measure-based lookahead window** — the lookahead window that drives camera X-pan and zoom targeting is now `CAM_LOOKAHEAD_MEASURES` (9) measures ahead, derived from the chart beats, instead of a fixed 3 seconds. Measure-start times (beats with `measure >= 0`; intra-measure `measure === -1` beats are skipped) are cached and rebuilt only when the beats array changes. Falls back to `CAM_LOOKAHEAD_SEC` seconds when no beats are available, and extrapolates past the last known measure using the average measure duration. Anticipation now scales with song tempo rather than wall-clock time.
- **Reduced lateral shoulder offset** — `20·K → 10·K` for a more head-on framing.
- **Fix: camera over-zoom on song change** — the measure-start cache backing the lookahead window is now invalidated on song switch (and teardown), so a `reconnect()`-based switch no longer sizes the window off the previous song's measure grid (which over-zoomed and stayed latched until an app restart).
- **Fix: strings cropped intermittently on song open** — when a song opens the player layout (controls / sections bar) may not have settled yet, so the `flex:1` highway canvas is briefly too tall and `applySize()` frames `cam.aspect` for the wrong height, cropping the near strings and the fret-number row. Once the layout settles the flex box shrinks to the correct size, but the backing store (`canvas.width/height`) is unchanged, so the splitscreen-oriented `_lastHwW/_lastHwH` check never fires — the framing stayed wrong until the user un/re-maximized the window (which fires a real `resize`). `draw()` now also compares the live canvas box (`canvasSize()`) against the last logical size handed to `applySize()` (`_appliedW/_appliedH`) and re-applies on >1px drift even when the backing store held, so the framing self-corrects as the layout settles. Steady state is one `getBoundingClientRect` + compare per frame (no reflow, no oscillation — `flex:1` ignores the style height `applySize` writes).
- **Test coverage** — `highway_3d_camera_framing.test.js` pins the `CAM_FRAME_*` constants + clamped zoom interpolation, the measure-based lookahead (`CAM_LOOKAHEAD_MEASURES = 9`, measure-start cache on `measure >= 0`, `lookaheadEndTime` with seconds fallback), and that the temporary debug hook stayed out. `highway_3d_resize_reframe.test.js` pins the reframe-on-layout-settle behaviour (applied-size tracking, the CSS-box drift branch independent of the backing store, and the lifecycle reset).

## ✅ Tests

- New: `highway_3d_render_order`, `highway_3d_fret_row_labels`, `highway_3d_fret_label_render_order`, `highway_3d_lean_sustain`, `highway_3d_camera_framing`, `highway_3d_resize_reframe`
- Updated: `highway_3d_sustain_bloom`, `highway_3d_sustain_rail` (new renderOrder scheme + low-overdraw default), `highway_3d_lefty` (10·K shoulder offset)
- **82/82 passing** (`node --test tests/js/highway_3d_*.test.js`)

Also bumps the plugin version to `3.22.0`.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Version bumped to 3.22.0

* **Bug Fixes**
  * More consistent render layering for frets, notes, strings and effects
  * Improved fret-label visibility, color and opacity logic
  * Stabilized sustain/trail visuals and bloom/rail layering
  * Adjusted camera framing/lookahead and lefty shoulder offset behavior
  * Added per-frame isPlaying flag for smoother pause behavior

* **Tests**
  * Added extensive rendering and visual-regression tests covering layering, labels, sustain, camera and resize behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->